### PR TITLE
feat(ci): implement gitlab subcommand for CI workflow

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -7,10 +7,11 @@
 - [x] Mécanisme configurable pour ajouter du contenu à la MR (via cookiecutter ?)
 - [ ] Recommandation de configuration d'import (regex)
 - [ ] Démo intégration avec PowerBI (idées)
-- [ ] Refactor engine.py
+- [x] Refactor engine.py
 - [ ] ajouter sous-commande pour la ci gitlab
 - [x] groupes pour les checklists
 - [ ] docs : search
 - [ ] Revoir l'organisation des rapports (stocker par digest)
 - [ ] image build : signature
 - [ ] image build : provenance
+- [ ] image build : sbom

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ jinja2 = "*"
 regis-cli = {file = ".", editable = true}
 cookiecutter = "*"
 referencing = "<0.37.0"
+python-gitlab = ">=4.4.0"
 
 [dev-packages]
 pytest = ">=7.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "21290aa3ad2038b43ce9bc7e4135ec37ae772a83cd586b35be83944274deecfd"
+            "sha256": "4a67767b2c159fc0156023d8365a7d19f5eab478c93576e60cd7ad21a51e096d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,36 +49,36 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:11bb4541efc6b82ca7809d8044fed19ee3c8d0a0e2632dfe9f9e0828bda48883",
-                "sha256:1c174e06e0be69c84bcec4fb21c416cc6c9858f47c814b8c632d55c7a8739263",
-                "sha256:23a7c9aa3674f62721d6c34a3666d8c28aff0ec5908790f3985a73b10b355be4",
-                "sha256:23ceffa098b95da7ffa88aaf62c45e316438f2c7ea9e0c63cf42a5c0361fa505",
-                "sha256:25682c2655978e247b45dcc9eccce497599886745aaee1205a23d43cb5aa93f3",
-                "sha256:4108c8dde681107d73f2b2e3fb74c3a521eed97024547ce4b7b191da5fd6b2ac",
-                "sha256:432c4c063ca184eeb3da7d2803b7f3681a7ae352b538d8c6ef86d15eab1448a1",
-                "sha256:49966634d83fc7ebc305a31cf931fc398118805d838b3c123b2ddb78d5ace9f3",
-                "sha256:5272ea14c48cb5f38e87e698c641a7ea2a8b1db6c42ea729527fbe8bd621f39c",
-                "sha256:6751ef77c6826b464615a25adff8887a64a061a9a4c61fb61c2d1bb4d90a5630",
-                "sha256:6e74e95c1284c374e05aa061f5629ba3f13cb82e3040395447b4de9659b155ff",
-                "sha256:79f8a53a25596c21a1f6df75cc948ab83bf443978cdad64de4595484a426716b",
-                "sha256:7d8bf5429bbba5d3c3709af873753e00d03352389177e65b2d00732ef0a28619",
-                "sha256:8102637cb2695535f35f2f6a1df3edd5c0a3b63f3572d52a88a83f3d4a50e556",
-                "sha256:8657ef6a394b64e7dc36c7a5bfcdc653cb99909a0292a83707db0e0da84b34a3",
-                "sha256:884cbd66256e7d82b885d1c3ed4d8c7b0285ea329f41a475f4d13d17b6047f44",
-                "sha256:8883e3fd31f8125952c3c4d8b3a0245f5095268706a43794f4431c74744e3cb8",
-                "sha256:89889ec2f64e49956d70e35c57e4d52bb7680616de8577beefef081edf9f7216",
-                "sha256:8aeb797bd40a75f620feb6f4ed3aaa48ea969b8f5ff537b23043a08efbf135fe",
-                "sha256:8bfe685e10855f7e8a89a18830088db4988768df5935f5febd8dedf933b3fbd4",
-                "sha256:ada0fada6199007f9c46e7a43f8563e0c843d98e8a491f15e0209198d1912f85",
-                "sha256:cc175fa09a813297a2db957ea71e7a5b708cf2cff4b8e2e7580e3ffd1940f1ad",
-                "sha256:d5a8f8edda42b016352de4cdb36e1145e19a66ddd5ac42a1b2bbb6592f4d070c",
-                "sha256:daef86877738cb7d310bc8d74ca73e98c543d07c5d2e0b957779591d38796651",
-                "sha256:ebf9d2af092f2660b43a25b4043ab5d72f0714106edc580b41ea5a3d03b0760c",
-                "sha256:f71dcd89e24f77439cdaf1398b79adcb21b7e8f42b3e92b359dfba4271212c39",
-                "sha256:f81d9b6caa13e0c9db313f6f6bcce00a6f6cbfa786abfbdbf222924ebe4d13f1"
+                "sha256:11f51985946b49739968b6dc2fa70e7d8f490bb15574377c5ee114f33d19ef7e",
+                "sha256:1566d0f91990b8f33b53836391d557f779584bd48beabf90efbf7a6efa89179e",
+                "sha256:169951fa88d449e72e0c6194cec1c5e405fd36a6cfbe74c7dab5494cc35f1700",
+                "sha256:26186f0ea03c4c1f9be20c088b127c71b0e9d487676930fab77625ddec2a4ef2",
+                "sha256:265cb3b5dafc0411c0949800a0692f07e986fb663b6ae1ecfba32ad193a55a03",
+                "sha256:302798e1e62008ca34a216dd04ecc5e240993b2090628e2a35d4c0754313ea9a",
+                "sha256:3355a3c8453d673e7c1664fdd24a0c6ef39964c3d41befc4849250f7eb1de3b5",
+                "sha256:33f4132f9781302beff34713fe6c990badd009aa8ea730611aef0931b27f1541",
+                "sha256:44011e3b4fd4a8a15bc94736717414b7ec82880066fb22d9f476c68a4ded2647",
+                "sha256:4af34cf0652a9da44720540c97f11e30781a77900c89547b311984a7272b33f7",
+                "sha256:5333f9967863ea7d8642df0e00cf4d33e8ed7e99fe7b6464b40ba969a2808544",
+                "sha256:54e448fab0c11b27bb908ea0218e2094578c583d05faa5f65b91fa6ccfa45570",
+                "sha256:63bc210ce73f8a1b87430b949f84d086cb326d67eb259305862e7c8861b73374",
+                "sha256:67fe3f453416ed9343057dcf06583b36aae6d8bdb013370b3ff46bc37b7e30ac",
+                "sha256:69708a504a43464b60ea16d031250b58206969c9bbd6851266e2f39afef53168",
+                "sha256:6f907962b18df78d5ca87a7484e4034354408d2c97cec6f53634b0ea0424c594",
+                "sha256:6fce895c12c5495bb598e59ae3cd89306969b4464ec7b6dd609b9c86e3397fe3",
+                "sha256:8714f0013c208452a98e23595d99cef53c5364565454425f431446eb586e2591",
+                "sha256:88793aeebb28a5296eea9bdd9b5e74ee4e3582766a6a2cb7f39e4761a96fdd55",
+                "sha256:8a8d87853c7f191029933307094a8896b087c2c436703281cb289a22aa4ae8bd",
+                "sha256:9e827211249d8e3cacc1adf6950a7a8cf56920e5e303e56dcab827b71c03df33",
+                "sha256:c12abc65830068ad05bd257fb953aaaf63a551446688e03e145522086be5738c",
+                "sha256:c3f59dc3e148b54813ec5c7b4b2e025d37f5dc221ee28a06d1a62f169cfaedf5",
+                "sha256:dd6db7505556ae8f9e2a3bf6d689c2b86aa6b459cf39552645d2c4d3fdbf489c",
+                "sha256:e51e1ff2c51b2d622d97c9737bd5ee9d9b9038f05b7dd8f9ea10b9e2d9674c24",
+                "sha256:f661edbfa77b8683a503043ddc9b9fe9036cf28af13064200e11fa1844ded79c",
+                "sha256:fb14755377d8de845c69378bbaedc0e35109c21a43824450524fd9c3178792d5"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "charset-normalizer": {
             "hashes": [
@@ -385,6 +385,15 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
+        "python-gitlab": {
+            "hashes": [
+                "sha256:660f15e3f889ec430797d260322bc61d90f8d90accfc10ba37593b11aed371bd",
+                "sha256:b1a59e81e5e0363185b446a707dc92c27ee8bf1fc14ce75ed8eafa58cbdce63a"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.10.0'",
+            "version": "==8.1.0"
+        },
         "python-slugify": {
             "hashes": [
                 "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8",
@@ -494,6 +503,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.32.5"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+                "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.0.0"
         },
         "rich": {
             "hashes": [

--- a/cookiecutters/consumer/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/cookiecutters/consumer/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -40,7 +40,7 @@ request_analysis:
       BRANCH_NAME="regis/analyze/${SAFE_URL:0:30}-$CI_PIPELINE_IID"
 
       echo "Creating analysis request for $IMAGE_URL (requested by $GITLAB_USER_LOGIN)"
-      echo "aW1wb3J0IGpzb24sIHN5cwpwcmludChqc29uLmR1bXBzKHsKICAnaW1hZ2VfdXJsJzogc3lzLmFyZ3ZbMV0sCiAgJ3BsYXlib29rX3VybCc6IHN5cy5hcmd2WzJdLAogICdyZXF1ZXN0ZXJfaWQnOiBpbnQoc3lzLmFyZ3ZbM10pLAogICdyZXF1ZXN0ZXJfbG9naW4nOiBzeXMuYXJndls0XSwKfSkpCg==" | base64 -d | python3 - "$IMAGE_URL" "$[[ inputs.playbook_url ]]" "$GITLAB_USER_ID" "$GITLAB_USER_LOGIN" > analysis-request.json
+      regis-cli gitlab create-request "$IMAGE_URL" "$[[ inputs.playbook_url ]]" "$GITLAB_USER_ID" "$GITLAB_USER_LOGIN" > analysis-request.json
 
       git config --global user.name "GitLab CI"
       git config --global user.email "gitlab-ci@example.com"
@@ -140,18 +140,12 @@ push_results:
         REPORT_INDEX="reports/${ANALYZE_JOB_ID}/index.html"
         if [ -f "$REPORT_INDEX" ]; then
           REPORT_URL="${CI_PROJECT_URL}/-/jobs/${ANALYZE_JOB_ID}/artifacts/external_file/${REPORT_INDEX}"
-          echo "Posting MR comment with link to report..."
-          curl --fail --request POST --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "{\"body\": \"🚀 **regis-cli Analysis Complete!**\n\nThe full HTML security report is ready: [View Analysis Report]($REPORT_URL)\"}" \
-            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes"
-
-          echo "Updating MR description with report link..."
-          echo "aW1wb3J0IGpzb24sIHN5cywgdXJsbGliLnJlcXVlc3QKCnJlcG9ydF91cmwsIGFwaV91cmwsIHRva2VuID0gc3lzLmFyZ3ZbMV0sIHN5cy5hcmd2WzJdLCBzeXMuYXJndlszXQoKcmVxID0gdXJsbGliLnJlcXVlc3QuUmVxdWVzdChhcGlfdXJsLCBoZWFkZXJzPXsiUFJJVkFURS1UT0tFTiI6IHRva2VufSkKd2l0aCB1cmxsaWIucmVxdWVzdC51cmxvcGVuKHJlcSkgYXMgcjoKICAgIG1yID0ganNvbi5sb2FkcyhyLnJlYWQoKSkKCmN1cnJlbnRfZGVzYyA9IG1yLmdldCgiZGVzY3JpcHRpb24iKSBvciAiIgpyZXBvcnRfbGluayA9IGYi8J+TiiAqKltWaWV3IEFuYWx5c2lzIFJlcG9ydF0oe3JlcG9ydF91cmx9KSoqIgpuZXdfZGVzYyA9IGYie3JlcG9ydF9saW5rfVxuXG57Y3VycmVudF9kZXNjfSIgaWYgY3VycmVudF9kZXNjIGVsc2UgcmVwb3J0X2xpbmsKCnBheWxvYWQgPSBqc29uLmR1bXBzKHsiZGVzY3JpcHRpb24iOiBuZXdfZGVzY30pLmVuY29kZSgpCnB1dF9yZXEgPSB1cmxsaWIucmVxdWVzdC5SZXF1ZXN0KAogICAgYXBpX3VybCwKICAgIGRhdGE9cGF5bG9hZCwKICAgIGhlYWRlcnM9eyJQUklWQVRFLVRPS0VOIjogdG9rZW4sICJDb250ZW50LVR5cGUiOiAiYXBwbGljYXRpb24vanNvbiJ9LAogICAgbWV0aG9kPSJQVVQiLAopCndpdGggdXJsbGliLnJlcXVlc3QudXJsb3BlbihwdXRfcmVxKSBhcyByOgogICAgcHJpbnQoIk1SIGRlc2NyaXB0aW9uIHVwZGF0ZWQsIHN0YXR1czoiLCByLnN0YXR1cykK" | base64 -d > /tmp/update_desc.py
-          python3 /tmp/update_desc.py \
-            "$REPORT_URL" \
-            "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}" \
-            "${GITLAB_TOKEN}"
+          echo "Updating MR with regis-cli gitlab update-mr..."
+          regis-cli gitlab update-mr \
+            --report reports/report.json \
+            --report-url "$REPORT_URL" \
+            --mr-url "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}" \
+            --token "${GITLAB_TOKEN}"
         fi
       fi
   rules:
@@ -159,85 +153,6 @@ push_results:
       when: never
     - if: $CI_MERGE_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
-# Phase 3: Apply labels from report.json to the MR
-set_labels:
-  stage: report
-  image: alpine:latest
-  needs:
-    - push_results
-  before_script:
-    - apk add --no-cache curl python3
-  script:
-    - |
-      if [ -z "$GITLAB_TOKEN" ] || [ -z "$CI_MERGE_REQUEST_IID" ]; then
-        echo "No token or no MR context, skipping labels."
-        exit 0
-      fi
-
-      REPORT_JSON=$(find reports -name report.json -print -quit)
-      if [ -z "$REPORT_JSON" ]; then
-        echo "No report.json found, skipping labels."
-        exit 0
-      fi
-
-      LABELS=$(python3 -c "import json; print(','.join(json.load(open('$REPORT_JSON')).get('playbook', {}).get('labels', [])))")
-      if [ -n "$LABELS" ]; then
-        echo "Applying labels to MR: $LABELS"
-        curl --fail --request PUT --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-          --data "add_labels=${LABELS}" \
-          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}"
-      else
-        echo "No labels to apply."
-      fi
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web" && "$[[ inputs.image_url ]]" != ""
-      when: never
-    - if: $CI_MERGE_REQUEST_IID
-
-# Phase 3: Append review checklist to MR description
-set_checklist:
-  stage: report
-  image: alpine:latest
-  needs:
-    - push_results
-  before_script:
-    - apk add --no-cache curl python3
-  script:
-    - |
-      if [ -z "$GITLAB_TOKEN" ] || [ -z "$CI_MERGE_REQUEST_IID" ]; then
-        echo "No token or no MR context, skipping checklist."
-        exit 0
-      fi
-
-      REPORT_JSON=$(find reports -name report.json -print -quit)
-      if [ -z "$REPORT_JSON" ]; then
-        echo "No report.json found, skipping checklist."
-        exit 0
-      fi
-
-      echo "aW1wb3J0IGpzb24sIHN5cwpkYXRhID0ganNvbi5sb2FkKG9wZW4oc3lzLmFyZ3ZbMV0pKQpjaGVja2xpc3RzID0gZGF0YS5nZXQoInBsYXlib29rIiwge30pLmdldCgibXJfZGVzY3JpcHRpb25fY2hlY2tsaXN0cyIsIFtdKQppZiBjaGVja2xpc3RzOgogICAgbGluZXMgPSBbXQogICAgZm9yIGNsaXN0IGluIGNoZWNrbGlzdHM6CiAgICAgICAgbGluZXMuYXBwZW5kKGYiXG5cbi0tLVxuXG4jIyB7Y2xpc3QuZ2V0KCd0aXRsZScpfVxuIikKICAgICAgICBmb3IgaXRlbSBpbiBjbGlzdC5nZXQoIml0ZW1zIiwgW10pOgogICAgICAgICAgICBpZiBpc2luc3RhbmNlKGl0ZW0sIGRpY3QpOgogICAgICAgICAgICAgICAgY2hlY2sgPSAieCIgaWYgaXRlbS5nZXQoImNoZWNrZWQiKSBlbHNlICIgIgogICAgICAgICAgICAgICAgbGFiZWwgPSBpdGVtWyJsYWJlbCJdCiAgICAgICAgICAgICAgICBsaW5lcy5hcHBlbmQoZiItIFt7Y2hlY2t9XSB7bGFiZWx9IikKICAgICAgICAgICAgZWxzZToKICAgICAgICAgICAgICAgIGxpbmVzLmFwcGVuZChmIi0gWyBdIHtpdGVtfSIpCiAgICBwcmludCgiXG4iLmpvaW4obGluZXMpKQo=" | base64 -d > /tmp/checklist_script.py
-      CHECKLIST=$(python3 /tmp/checklist_script.py "$REPORT_JSON")
-      if [ -n "$CHECKLIST" ]; then
-        echo "Appending checklist to MR description..."
-        curl --silent --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}" \
-          > /tmp/mr_current.json
-        CURRENT_DESC=$(python3 -c "import json; print(json.load(open('/tmp/mr_current.json')).get('description','') or '')")
-        printf '%s%s' "$CURRENT_DESC" "$CHECKLIST" > /tmp/mr_desc_combined.txt
-        python3 -c "import json; d=open('/tmp/mr_desc_combined.txt').read(); print(json.dumps({'description':d}))" > /tmp/mr_payload.json
-        curl --fail --request PUT \
-          --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
-          --header "Content-Type: application/json" \
-          --data "@/tmp/mr_payload.json" \
-          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}"
-      else
-        echo "No checklist items to apply."
-      fi
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web" && "$[[ inputs.image_url ]]" != ""
-      when: never
-    - if: $CI_MERGE_REQUEST_IID
 
 # Phase 3: Deploy to GitLab Pages (Default branch only)
 pages:

--- a/docs/modules/ROOT/pages/gitlab-workflow.adoc
+++ b/docs/modules/ROOT/pages/gitlab-workflow.adoc
@@ -129,12 +129,7 @@ sequenceDiagram
     GL->>User: Merge Request opened
     GL->>CI: Job: analyze_image (MR context)
     CI->>Reg: Analyze image
-    CI->>GL: Job: push_results — commit report & post MR comment with report link
-    par Parallel reporting jobs
-        CI->>GL: Job: set_labels — apply scoped labels via API
-    and
-        CI->>GL: Job: set_checklist — append review checklist to MR description
-    end
+    CI->>GL: Job: push_results — commit report, update MR description, apply labels & checklists
 ....
 
 === 1. Trigger the Request
@@ -145,11 +140,9 @@ The pipeline automatically creates a new branch and a Merge Request.
 The MR description contains instructions to find the **Analysis Report** within the committed \`reports/\` directory or the exposed artifacts.
 
 === 3. Report Inspection
-Once the analysis job completes, the pipeline runs three parallel reporting jobs:
+Once the analysis job completes, the pipeline runs the `push_results` reporting job:
 
-*   **`push_results`**: Commits the `reports/` directory back to the branch, prepends a direct **[View Analysis Report]** link to the MR description, and posts an MR comment with the same link.
-*   **`set_labels`**: Applies scoped GitLab labels to the MR based on your playbook configuration (e.g., `regis::fail`, `security::critical`).
-*   **`set_checklist`**: Appends Markdown review checklists to the MR description. Checklist items defined with `check_if` conditions may render pre-checked when those conditions pass, and items can be conditionally included via `show_if` conditions.
+*   **`push_results`**: Commits the `reports/` directory back to the branch, posts an MR comment with a direct report link, updates the MR description to include the link and any review checklists, and applies scoped GitLab labels based on your playbook configuration. Checklist items defined with `check_if` conditions may render pre-checked when those conditions pass, and items can be conditionally included via `show_if` conditions.
 
 === 4. Governance
 Security teams can review the MR, check the compliance score via the direct HTML report link, and decide whether to merge the analysis request into the main registry branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "jinja2>=3.1",
   "cookiecutter>=2.5",
   "referencing<0.37.0",
+  "python-gitlab>=4.4.0",
 ]
 
 [project.scripts]

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -15,6 +15,7 @@ import click
 import jsonschema
 
 from regis_cli.analyzers.base import AnalyzerError, BaseAnalyzer
+from regis_cli.gitlab_cli import gitlab_cmd
 from regis_cli.registry.client import RegistryClient, RegistryError
 from regis_cli.registry.parser import parse_image_url
 
@@ -151,6 +152,10 @@ def main(verbose: bool) -> None:
         format="%(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
+
+
+# Register subcommands
+main.add_command(gitlab_cmd, name="gitlab")
 
 
 @main.command()

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -399,7 +399,7 @@ def analyze(
             default_pb = (
                 importlib.resources.files("regis_cli") / "playbooks" / "default.yaml"
             )
-            if default_pb.exists():
+            if default_pb.is_file():
                 playbook_paths = (str(default_pb),)
 
         if playbook_paths:

--- a/regis_cli/gitlab_cli.py
+++ b/regis_cli/gitlab_cli.py
@@ -1,0 +1,191 @@
+"""GitLab CLI commands for regis-cli."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import click
+import gitlab
+
+# We will need standard types like Path
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.group()
+def gitlab_cmd() -> None:
+    """GitLab CI integration commands."""
+    pass
+
+
+@gitlab_cmd.command(name="create-request")
+@click.argument("image_url")
+@click.argument("playbook_url")
+@click.argument("requester_id")
+@click.argument("requester_login")
+def create_request(
+    image_url: str, playbook_url: str, requester_id: str, requester_login: str
+) -> None:
+    """Create a JSON request for analysis.
+
+    This replaces the base64-encoded python snippet that outputs analysis-request.json.
+    """
+    try:
+        req_id = int(requester_id)
+    except ValueError as exc:
+        raise click.ClickException(
+            f"Invalid requester_id '{requester_id}', must be an integer."
+        ) from exc
+
+    request_data = {
+        "image_url": image_url,
+        "playbook_url": playbook_url,
+        "requester_id": req_id,
+        "requester_login": requester_login,
+    }
+
+    click.echo(json.dumps(request_data, indent=2))
+
+
+@gitlab_cmd.command(name="update-mr")
+@click.option(
+    "--report",
+    "report_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to report.json",
+)
+@click.option(
+    "--report-url", "report_url", required=True, help="URL to the generated HTML report"
+)
+@click.option(
+    "--mr-url",
+    "mr_url",
+    required=True,
+    help="GitLab API URL for the MR (e.g. https://gitlab.com/api/v4/projects/1/merge_requests/2)",
+)
+@click.option("--token", "token", required=True, help="GitLab PRIVATE-TOKEN")
+def update_mr(report_path: str, report_url: str, mr_url: str, token: str) -> None:
+    """Update a Merge Request with analysis results.
+
+    This command reads the report.json, posts a comment with a link to the HTML report,
+    updates the MR description to include the link and any checklists, and applies labels.
+    """
+    try:
+        from urllib.parse import urlparse
+
+        parsed_url = urlparse(mr_url)
+        # e.g. mr_url = "https://gitlab.example.com/api/v4/projects/123/merge_requests/456"
+        host = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+        path_parts = parsed_url.path.strip("/").split("/")
+        # Find 'projects' index and extract project ID and MR IID
+        try:
+            proj_idx = path_parts.index("projects")
+            project_id = int(path_parts[proj_idx + 1])
+            mr_iid = int(path_parts[proj_idx + 3])
+        except (ValueError, IndexError):
+            raise click.ClickException(
+                f"Invalid MR URL format: {mr_url}. Expected format containing /projects/<id>/merge_requests/<iid>"
+            )
+
+    except Exception as exc:
+        if isinstance(exc, click.ClickException):
+            raise
+        raise click.ClickException(f"Failed to parse MR URL: {exc}")
+
+    # Read the JSON report
+    try:
+        with open(report_path, "r", encoding="utf-8") as f:
+            report_data = json.load(f)
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to read report file {report_path}: {exc}"
+        ) from exc
+
+    # Initialize GitLab client
+    gl = gitlab.Gitlab(host, private_token=token)
+
+    try:
+        project = gl.projects.get(project_id)
+        mr = project.mergerequests.get(mr_iid)
+    except gitlab.GitlabGetError as exc:
+        raise click.ClickException(f"Failed to fetch MR from GitLab: {exc}") from exc
+
+    # 1. Post a comment with the report link
+    comment_body = (
+        "🚀 **regis-cli Analysis Complete!**\n\n"
+        f"The full HTML security report is ready: [View Analysis Report]({report_url})"
+    )
+    try:
+        mr.notes.create({"body": comment_body})
+        click.echo("Posted MR comment with report link.", err=True)
+    except gitlab.GitlabCreateError as exc:
+        click.echo(f"Warning: Failed to post MR comment: {exc}", err=True)
+
+    # 2. Extract labels and checklists from the playbook in the report
+    playbook_data = report_data.get("playbook", {})
+    labels = playbook_data.get("labels", [])
+    checklists = playbook_data.get("mr_description_checklists", [])
+
+    # 3. Build new MR description
+    current_desc = mr.description or ""
+    report_link_md = f"📝 **[View Analysis Report]({report_url})**"
+
+    # Prepend report link to description if changing it wasn't already done
+    if "View Analysis Report" not in current_desc:
+        new_desc = f"{report_link_md}\n\n{current_desc}"
+    else:
+        new_desc = current_desc
+
+    # Setup checklist strings
+    checklist_lines = []
+    if checklists:
+        for clist in checklists:
+            title = clist.get("title")
+            if title:
+                checklist_lines.append(f"\n\n---\n\n## {title}\n")
+            items = clist.get("items", [])
+            for item in items:
+                if isinstance(item, dict):
+                    checked = "x" if item.get("checked") else " "
+                    label = item["label"]
+                    checklist_lines.append(f"- [{checked}] {label}")
+                else:
+                    checklist_lines.append(f"- [ ] {item}")
+
+    # Append checklist to description
+    if checklist_lines:
+        checklist_md = "\n".join(checklist_lines)
+        if checklist_md not in new_desc:
+            new_desc = f"{new_desc}{checklist_md}"
+
+    update_kwargs = {}
+    if new_desc != current_desc:
+        update_kwargs["description"] = new_desc
+
+    if labels:
+        # Get existing labels to append new ones
+        ext_labels = list(mr.labels)
+        for label in labels:
+            if label not in ext_labels:
+                ext_labels.append(label)
+        update_kwargs["labels"] = ext_labels
+
+    if update_kwargs:
+        try:
+            for k, v in update_kwargs.items():
+                setattr(mr, k, v)
+            mr.save()
+            msg = []
+            if "description" in update_kwargs:
+                msg.append("description")
+            if "labels" in update_kwargs:
+                msg.append(f"labels ({','.join(labels)})")
+            click.echo(f"Updated MR: {' and '.join(msg)}.", err=True)
+        except gitlab.GitlabUpdateError as exc:
+            click.echo(f"Warning: Failed to update MR: {exc}", err=True)
+    else:
+        click.echo("No description or label updates required.", err=True)

--- a/regis_cli/gitlab_cli.py
+++ b/regis_cli/gitlab_cli.py
@@ -162,7 +162,9 @@ def update_mr(report_path: str, report_url: str, mr_url: str, token: str) -> Non
         if checklist_md not in new_desc:
             new_desc = f"{new_desc}{checklist_md}"
 
-    update_kwargs = {}
+    from typing import Any
+
+    update_kwargs: dict[str, Any] = {}
     if new_desc != current_desc:
         update_kwargs["description"] = new_desc
 

--- a/regis_cli/playbook/evaluator.py
+++ b/regis_cli/playbook/evaluator.py
@@ -140,14 +140,18 @@ def _resolve_links(
 
         try:
             if "{{" in url_tmpl or "{%" in url_tmpl:
-                url = _resolve_template(url_tmpl, full_context, nested_context=full_context)
+                url = _resolve_template(
+                    url_tmpl, full_context, nested_context=full_context
+                )
             else:
                 url = url_tmpl.format(**report)
 
             if url:
                 resolved_links.append({"label": link_def.get("label", ""), "url": url})
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Could not resolve link '%s': %s", link_def.get("label"), exc)
+            logger.warning(
+                "Could not resolve link '%s': %s", link_def.get("label"), exc
+            )
 
     if resolved_links:
         result["links"] = resolved_links

--- a/tests/test_gitlab_cli.py
+++ b/tests/test_gitlab_cli.py
@@ -1,0 +1,147 @@
+"""Tests for the gitlab CLI subcommands in regis-cli."""
+
+import json
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from regis_cli.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_create_request_success(runner):
+    """Test the create-request command generates expected output."""
+    result = runner.invoke(
+        main,
+        [
+            "gitlab",
+            "create-request",
+            "ghcr.io/myname/myimage:latest",
+            "https://example.com/playbook.yml",
+            "123",
+            "testuser",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["image_url"] == "ghcr.io/myname/myimage:latest"
+    assert data["playbook_url"] == "https://example.com/playbook.yml"
+    assert data["requester_id"] == 123
+    assert data["requester_login"] == "testuser"
+
+
+def test_create_request_invalid_id(runner):
+    """Test create-request command with invalid requester ID."""
+    result = runner.invoke(
+        main,
+        [
+            "gitlab",
+            "create-request",
+            "image:latest",
+            "url",
+            "not_an_int",
+            "user",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid requester_id 'not_an_int'" in result.output
+
+
+def test_update_mr_success(runner, tmp_path):
+    """Test update-mr success using mock gitlab."""
+    # Create fake report.json
+    report_file = tmp_path / "report.json"
+    report_data = {
+        "playbook": {
+            "labels": ["security"],
+            "mr_description_checklists": [
+                {
+                    "title": "Security Check",
+                    "items": [
+                        "Review report",
+                        {"label": "Approve", "checked": True},
+                        {"label": "Dismiss", "checked": False},
+                    ],
+                }
+            ],
+        }
+    }
+    report_file.write_text(json.dumps(report_data))
+
+    # Mock python-gitlab execution
+    with mock.patch("regis_cli.gitlab_cli.gitlab.Gitlab") as mock_gl:
+        mock_instance = mock_gl.return_value
+        mock_project = mock_instance.projects.get.return_value
+        mock_mr = mock_project.mergerequests.get.return_value
+        
+        # Setup existing MR properties
+        mock_mr.description = "Original Description"
+        mock_mr.labels = []
+
+        result = runner.invoke(
+            main,
+            [
+                "gitlab",
+                "update-mr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--mr-url",
+                "https://gitlab.com/api/v4/projects/1/merge_requests/2",
+                "--token",
+                "test-token",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Posted MR comment with report link." in result.output
+        assert "Updated MR: description and labels (security)." in result.output
+
+        # Verify Comment Creation
+        mock_mr.notes.create.assert_called_once()
+        create_args = mock_mr.notes.create.call_args[0][0]
+        assert "https://example.com/report.html" in create_args["body"]
+
+        # Verify Description Changes
+        assert "https://example.com/report.html" in mock_mr.description
+        assert "Original Description" in mock_mr.description
+        assert "Security Check" in mock_mr.description
+        assert "- [ ] Review report" in mock_mr.description
+        assert "- [x] Approve" in mock_mr.description
+        assert "- [ ] Dismiss" in mock_mr.description
+
+        # Verify Label Changes
+        assert mock_mr.labels == ["security"]
+        
+        # Save must be called to update MR on gitlab
+        mock_mr.save.assert_called_once()
+
+
+def test_update_mr_invalid_url(runner, tmp_path):
+    """Test update-mr with invalid mr-url format."""
+    report_file = tmp_path / "report.json"
+    report_file.write_text("{}")
+    
+    result = runner.invoke(
+        main,
+        [
+            "gitlab",
+            "update-mr",
+            "--report",
+            str(report_file),
+            "--report-url",
+            "http://url",
+            "--mr-url",
+            "https://gitlab.com/invalid/format",
+            "--token",
+            "token",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid MR URL format" in result.output

--- a/tests/test_gitlab_cli.py
+++ b/tests/test_gitlab_cli.py
@@ -78,7 +78,7 @@ def test_update_mr_success(runner, tmp_path):
         mock_instance = mock_gl.return_value
         mock_project = mock_instance.projects.get.return_value
         mock_mr = mock_project.mergerequests.get.return_value
-        
+
         # Setup existing MR properties
         mock_mr.description = "Original Description"
         mock_mr.labels = []
@@ -118,7 +118,7 @@ def test_update_mr_success(runner, tmp_path):
 
         # Verify Label Changes
         assert mock_mr.labels == ["security"]
-        
+
         # Save must be called to update MR on gitlab
         mock_mr.save.assert_called_once()
 
@@ -127,7 +127,7 @@ def test_update_mr_invalid_url(runner, tmp_path):
     """Test update-mr with invalid mr-url format."""
     report_file = tmp_path / "report.json"
     report_file.write_text("{}")
-    
+
     result = runner.invoke(
         main,
         [


### PR DESCRIPTION
This PR introduces the `regis-cli gitlab` command group to simplify testing and logic execution inside the `.gitlab-ci.yml` template. 
It replaces raw Python and `curl` scripts with unified, testable Python code using `python-gitlab`.

- Adds `python-gitlab` dependency
- Replaces Phase 1 script with `regis-cli gitlab create-request`
- Replaces Phase 3 scripts (`push_results`, `set_labels`, and `set_checklists`) with a unified `regis-cli gitlab update-mr`
- Adds unit tests and updates the Antora documentation for GitLab CI workflows.