### PR TITLE
feat(analyzer/versioning): digest-based reporting and release lines hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ regis-cli analyze nginx:latest -f html --cache
 ```
 
 ### Dynamic Output Paths
-By default, reports are written to `reports/{registry}/{repository}/{tag}/{format}`. You can override this using:
+By default, reports are written to `reports/{registry}/{repository}/{digest}/report.{format}`. You can override this using:
 ```bash
 regis-cli analyze nginx:latest -o "my-custom-report.{format}" -D "results/{repository}"
 ```

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/.regis-evidence/SECURITY_EVIDENCE.md
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/.regis-evidence/SECURITY_EVIDENCE.md
@@ -1,0 +1,28 @@
+# 🛡️ regis-cli Security Evidence
+
+> Generated automatically by `regis-cli`
+
+Analysis performed on **2026-03-05T14:33:50.790894+00:00**.
+
+## 📦 Target Details
+- **Registry**: `registry-1.docker.io`
+- **Repository**: `library/alpine`
+- **Tag**: `latest`
+
+## 📊 Playbook Results: RegiS Default Playbook
+- **Score**: `83%`
+- **Passed Scorecards**: `5/6`
+
+
+
+## 🐛 Vulnerability Summary (Trivy)
+- **Critical**: `0`
+- **High**: `0`
+- **Total**: `0`
+
+
+
+
+## 📅 Image Freshness
+- **Age in Days**: `36`
+

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/best-practices.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/best-practices.html
@@ -434,7 +434,41 @@ RUN CMD [&#34;/bin/sh&#34;]</code></pre>
 
                                 
 
-    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Dockle execution failed. Ensure dockle is installed and in PATH.&#39;}</p>
+<div class="grid">
+    <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+        <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">STATUS</strong><br>
+        
+            <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: var(--pico-ins-color);">PASSED</span>
+        
+    </div>
+    
+        
+            
+        
+            
+            <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+                <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">WARN</strong><br>
+                <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: var(--pico-del-color);">
+                    2
+                </span>
+            </div>
+            
+        
+            
+            <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+                <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">INFO</strong><br>
+                <span style="font-size: 2rem; font-weight: bold; line-height: 1; ">
+                    2
+                </span>
+            </div>
+            
+        
+            
+        
+            
+        
+    
+</div>
 
 
                                 
@@ -461,7 +495,100 @@ RUN CMD [&#34;/bin/sh&#34;]</code></pre>
 
 
 
-    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Dockle execution failed. Ensure dockle is installed and in PATH.&#39;}</p>
+    
+        <div class="overflow-auto">
+            <table class="striped">
+                <thead>
+                    <tr>
+                        <th>Level</th>
+                        <th>Code</th>
+                        <th>Title / Description</th>
+                        <th>Alerts</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    
+                    <tr>
+                        <td>
+                            
+                                <span class="badge warning">Warning</span>
+                            
+                        </td>
+                        <td><code>CIS-DI-0001</code></td>
+                        <td>Create a user for the container</td>
+                        <td>
+                            
+                                <ul style="margin: 0; padding-left: 1rem; font-size: 0.9em;">
+                                
+                                    <li style="margin-bottom: 0;">Last user should not be root</li>
+                                
+                                </ul>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            
+                                <span class="badge warning">Warning</span>
+                            
+                        </td>
+                        <td><code>DKL-DI-0006</code></td>
+                        <td>Avoid latest tag</td>
+                        <td>
+                            
+                                <ul style="margin: 0; padding-left: 1rem; font-size: 0.9em;">
+                                
+                                    <li style="margin-bottom: 0;">Avoid &#39;latest&#39; tag</li>
+                                
+                                </ul>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            
+                                <span class="badge info">Info</span>
+                            
+                        </td>
+                        <td><code>CIS-DI-0005</code></td>
+                        <td>Enable Content trust for Docker</td>
+                        <td>
+                            
+                                <ul style="margin: 0; padding-left: 1rem; font-size: 0.9em;">
+                                
+                                    <li style="margin-bottom: 0;">export DOCKER_CONTENT_TRUST=1 before docker pull/build</li>
+                                
+                                </ul>
+                            
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <td>
+                            
+                                <span class="badge info">Info</span>
+                            
+                        </td>
+                        <td><code>CIS-DI-0006</code></td>
+                        <td>Add HEALTHCHECK instruction to the container image</td>
+                        <td>
+                            
+                                <ul style="margin: 0; padding-left: 1rem; font-size: 0.9em;">
+                                
+                                    <li style="margin-bottom: 0;">not found HEALTHCHECK statement</li>
+                                
+                                </ul>
+                            
+                        </td>
+                    </tr>
+                    
+                </tbody>
+            </table>
+        </div>
+        
+    
 
 
                                 
@@ -511,15 +638,6 @@ RUN CMD [&#34;/bin/sh&#34;]</code></pre>
 
     
     
-        
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
         
     
         

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/compliance.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/compliance.html
@@ -289,7 +289,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Overall Compliance</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">67%</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">83%</span>
                                     </div>
                             
                         
@@ -305,7 +305,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Mandatory Requirements</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">75%</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">100%</span>
                                     </div>
                             
                         
@@ -371,9 +371,9 @@ header h2 {
                         <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
                             <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">security</strong><br>
                             <span style="font-size: 1.8rem; font-weight: bold; line-height: 1.2;">
-                                3<small style="font-size: 1rem; opacity: 0.5;">/4</small>
+                                4<small style="font-size: 1rem; opacity: 0.5;">/4</small>
                             </span>
-                            <div style="font-size: 0.8rem; margin-top: 0.2rem; opacity: 0.7;">75% pass</div>
+                            <div style="font-size: 0.8rem; margin-top: 0.2rem; opacity: 0.7;">100% pass</div>
                         </div>
                     
                 </div>
@@ -463,7 +463,7 @@ header h2 {
                             </tr>
                             
                             <tr>
-                                <td><span class="status-failed">❌</span></td>
+                                <td><span class="status-passed">✅</span></td>
                                 
                                 <td>
                                     <strong>No FATAL issues found by Dockle.</strong>
@@ -476,7 +476,7 @@ header h2 {
                                         
                                     </div>
                                     
-                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.dockle.issues_by_level.FATAL (MISSING) == 0</div>
+                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.dockle.issues_by_level.FATAL (0) == 0</div>
                                 </td>
                                 <td>
                                     
@@ -629,7 +629,7 @@ header h2 {
                                         
                                     </div>
                                     
-                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.freshness.age_days (35) &lt; 30</div>
+                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.freshness.age_days (36) &lt; 30</div>
                                 </td>
                                 <td>
                                     
@@ -673,15 +673,6 @@ header h2 {
 
     
     
-        
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
         
     
         

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/index.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/index.html
@@ -287,9 +287,9 @@ header h2 {
                                     <div class="grid" style="margin-bottom: calc(4 * var(--pico-spacing));">
                                     
                                 
-                                <div class="recommandation-nogo" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; ">
+                                <div class="recommandation-go" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Recommandation</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">NOGO</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">GO</span>
                                     </div>
                             
                         
@@ -345,7 +345,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; cursor: pointer;"><a href="compliance.html" style="text-decoration: none; color: inherit; display: block;">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Overall Compliance</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">67%</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">83%</span>
                                     </a></div>
                             
                         
@@ -361,7 +361,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: center; cursor: pointer;"><a href="compliance.html" style="text-decoration: none; color: inherit; display: block;">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Mandatory Requirements</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">3 / 4</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">4 / 4</span>
                                     </a></div>
                             
                         
@@ -433,9 +433,9 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Creation Time</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">2026-03-04</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">2026-03-05</span>
                                     
-                                    <br><small style="opacity: 0.8; font-size: 0.9rem;">19:17:27</small>
+                                    <br><small style="opacity: 0.8; font-size: 0.9rem;">14:33:50</small>
                                     </div>
                             
                         
@@ -530,6 +530,17 @@ header h2 {
             
             
             <tr>
+                <td><strong>digest</strong></td>
+                <td>
+                    
+                        sha256-25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+                    
+                </td>
+            </tr>
+            
+            
+            
+            <tr>
                 <td><strong>analyzers</strong></td>
                 <td>
                     
@@ -544,7 +555,7 @@ header h2 {
                 <td><strong>timestamp</strong></td>
                 <td>
                     
-                        2026-03-04 19:17:27
+                        2026-03-05 14:33:50
                     
                 </td>
             </tr>
@@ -692,15 +703,6 @@ header h2 {
 
     
     
-        
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
         
     
         

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/insights.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/insights.html
@@ -291,7 +291,7 @@ header h2 {
 <div class="grid">
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">AGE</strong><br>
-        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">35<small style="font-size: 1rem; opacity: 0.5;"> days</small></span>
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">36<small style="font-size: 1rem; opacity: 0.5;"> days</small></span>
     </div>
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">BEHIND LATEST</strong><br>
@@ -409,7 +409,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Pulls</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">{{ results.popularity.pull_count | format_number }}</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">11,698,239,956</span>
                                     </div>
                             
                         
@@ -425,7 +425,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Stars</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">{{ results.popularity.star_count | format_number }}</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">11,471</span>
                                     </div>
                             
                         
@@ -474,7 +474,7 @@ header h2 {
             </tr>
             <tr>
                 <td><strong>Pulls</strong></td>
-                <td>11,696,423,002</td>
+                <td>11,698,239,956</td>
             </tr>
             <tr>
                 <td><strong>Stars</strong></td>
@@ -645,15 +645,6 @@ header h2 {
 
     
     
-        
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
         
     
         

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/metadata.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/metadata.html
@@ -1010,9 +1010,21 @@ header h2 {
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">DOMINANT PATTERN</strong><br>
         <span style="font-size: 1.5rem; font-weight: bold; line-height: 1;">semver</span>
     </div>
+    
+    <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+        <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">RELEASE LINES</strong><br>
+        <span style="font-size: 1.1rem; font-weight: bold; line-height: 1.2; display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; margin-top: 4px;">
+            
+            <kbd style="font-size: 0.9rem; padding: 2px 6px;">20260127</kbd>
+            
+        </span>
+    </div>
+    
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">SEMVER COMPLIANCE</strong><br>
-        <span style="font-size: 2rem; font-weight: bold; line-height: 1; ">
+        
+        
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: inherit;">
             70.5%
         </span>
     </div>
@@ -1202,15 +1214,6 @@ header h2 {
 
     
     
-        
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
         
     
         

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/report.json
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/report.json
@@ -1,10 +1,11 @@
 {
-  "version": "0.8.0",
+  "version": "0.12.0",
   "request": {
     "url": "alpine:latest",
     "registry": "registry-1.docker.io",
     "repository": "library/alpine",
     "tag": "latest",
+    "digest": "sha256-25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659",
     "analyzers": [
       "dockle",
       "endoflife",
@@ -19,15 +20,56 @@
       "trivy",
       "versioning"
     ],
-    "timestamp": "2026-03-04T19:17:27.303476+00:00"
+    "timestamp": "2026-03-05T14:33:50.790894+00:00"
   },
   "results": {
     "dockle": {
       "analyzer": "dockle",
-      "error": {
-        "type": "validation",
-        "message": "Dockle execution failed. Ensure dockle is installed and in PATH."
-      }
+      "repository": "library/alpine",
+      "tag": "latest",
+      "passed": true,
+      "issues_count": 4,
+      "issues_by_level": {
+        "FATAL": 0,
+        "WARN": 2,
+        "INFO": 2,
+        "SKIP": 0,
+        "PASS": 0
+      },
+      "issues": [
+        {
+          "code": "CIS-DI-0001",
+          "level": "WARN",
+          "title": "Create a user for the container",
+          "alerts": [
+            "Last user should not be root"
+          ]
+        },
+        {
+          "code": "DKL-DI-0006",
+          "level": "WARN",
+          "title": "Avoid latest tag",
+          "alerts": [
+            "Avoid 'latest' tag"
+          ]
+        },
+        {
+          "code": "CIS-DI-0005",
+          "level": "INFO",
+          "title": "Enable Content trust for Docker",
+          "alerts": [
+            "export DOCKER_CONTENT_TRUST=1 before docker pull/build"
+          ]
+        },
+        {
+          "code": "CIS-DI-0006",
+          "level": "INFO",
+          "title": "Add HEALTHCHECK instruction to the container image",
+          "alerts": [
+            "not found HEALTHCHECK statement"
+          ]
+        }
+      ]
     },
     "endoflife": {
       "analyzer": "endoflife",
@@ -46,7 +88,7 @@
       "tag": "latest",
       "tag_created": "2026-01-28T01:18:04.977843834Z",
       "latest_created": null,
-      "age_days": 35,
+      "age_days": 36,
       "behind_latest_days": null,
       "is_latest": true
     },
@@ -76,7 +118,7 @@
       "analyzer": "popularity",
       "repository": "library/alpine",
       "available": true,
-      "pull_count": 11696423002,
+      "pull_count": 11698239956,
       "star_count": 11471,
       "description": "A minimal Docker image based on Alpine Linux with a complete package index and only 5 MB in size!",
       "last_updated": "2026-01-28T04:26:42.651499Z",
@@ -847,15 +889,18 @@
           ]
         }
       ],
-      "variants": []
+      "variants": [],
+      "release_lines": [
+        "20260127"
+      ]
     }
   },
   "playbooks": [
     {
       "playbook_name": "RegiS Default Playbook",
-      "score": 67,
+      "score": 83,
       "total_scorecards": 6,
-      "passed_scorecards": 4,
+      "passed_scorecards": 5,
       "pages": [
         {
           "title": "Overview",
@@ -875,20 +920,20 @@
               "widgets": [
                 {
                   "label": "Recommandation",
-                  "value": "{{ 'NOGO' }}",
+                  "value": "{{ 'GO' }}",
                   "options": {
-                    "class": "recommandation-nogo",
+                    "class": "recommandation-go",
                     "align": "center"
                   },
                   "condition": {
-                    "<": [
+                    ">=": [
                       {
                         "var": "playbooks.0.pages.compliance.sections.mandatory_requirements.score"
                       },
                       90
                     ]
                   },
-                  "resolved_value": "NOGO"
+                  "resolved_value": "GO"
                 }
               ],
               "render_order": [
@@ -911,7 +956,7 @@
                   "options": {
                     "align": "center"
                   },
-                  "resolved_value": "67%",
+                  "resolved_value": "83%",
                   "resolved_url": "compliance.html"
                 },
                 {
@@ -921,7 +966,7 @@
                   "options": {
                     "align": "center"
                   },
-                  "resolved_value": "3 / 4",
+                  "resolved_value": "4 / 4",
                   "resolved_url": "compliance.html"
                 },
                 {
@@ -954,8 +999,8 @@
                   "options": {
                     "subvalue": "{{ request.timestamp | format_time }}"
                   },
-                  "resolved_value": "2026-03-04",
-                  "resolved_subvalue": "19:17:27"
+                  "resolved_value": "2026-03-05",
+                  "resolved_subvalue": "14:33:50"
                 },
                 {
                   "label": "Triggered by",
@@ -1009,9 +1054,9 @@
         {
           "title": "Compliance",
           "slug": "compliance",
-          "score": 67,
+          "score": 83,
           "total_scorecards": 6,
-          "passed_scorecards": 4,
+          "passed_scorecards": 5,
           "sections": [
             {
               "name": " ",
@@ -1028,7 +1073,7 @@
                   "options": {
                     "align": "center"
                   },
-                  "resolved_value": "67%"
+                  "resolved_value": "83%"
                 },
                 {
                   "label": "Mandatory Requirements",
@@ -1036,7 +1081,7 @@
                   "options": {
                     "align": "center"
                   },
-                  "resolved_value": "75%"
+                  "resolved_value": "100%"
                 },
                 {
                   "label": "Recommended Requirements",
@@ -1053,15 +1098,15 @@
             },
             {
               "name": "Mandatory Requirements",
-              "score": 75,
+              "score": 100,
               "total_scorecards": 4,
-              "passed_scorecards": 3,
+              "passed_scorecards": 4,
               "levels_summary": {},
               "tags_summary": {
                 "security": {
                   "total": 4,
-                  "passed": 3,
-                  "percentage": 75
+                  "passed": 4,
+                  "percentage": 100
                 }
               },
               "scorecards": [
@@ -1105,10 +1150,10 @@
                   "analyzers": [
                     "dockle"
                   ],
-                  "passed": false,
-                  "status": "incomplete",
+                  "passed": true,
+                  "status": "passed",
                   "condition": "{\"==\": [{\"var\": \"results.dockle.issues_by_level.FATAL\"}, 0]}",
-                  "details": "results.dockle.issues_by_level.FATAL (MISSING) == 0"
+                  "details": "results.dockle.issues_by_level.FATAL (0) == 0"
                 },
                 {
                   "name": "trusted-domain",
@@ -1177,7 +1222,7 @@
                   "passed": false,
                   "status": "failed",
                   "condition": "{\"<\": [{\"var\": \"results.freshness.age_days\"}, 30]}",
-                  "details": "results.freshness.age_days (35) < 30"
+                  "details": "results.freshness.age_days (36) < 30"
                 }
               ],
               "render_order": [
@@ -1404,12 +1449,12 @@
                 {
                   "label": "Pulls",
                   "value": "{{ results.popularity.pull_count | format_number }}",
-                  "resolved_value": "{{ results.popularity.pull_count | format_number }}"
+                  "resolved_value": "11,698,239,956"
                 },
                 {
                   "label": "Stars",
                   "value": "{{ results.popularity.star_count | format_number }}",
-                  "resolved_value": "{{ results.popularity.star_count | format_number }}"
+                  "resolved_value": "11,471"
                 },
                 {
                   "template": "analyzers/popularity/table.html",
@@ -1532,19 +1577,44 @@
         }
       ],
       "slug": null,
+      "labels": [
+        "regis::warn"
+      ],
+      "mr_description_checklists": [
+        {
+          "title": "📝 Review Checklist",
+          "items": [
+            {
+              "label": "Revue de sécurité réalisée",
+              "checked": false
+            },
+            {
+              "label": "Aucune vulnérabilité CRITIQUE détectée",
+              "checked": true
+            },
+            {
+              "label": "Image issue d'un registre de confiance",
+              "checked": true
+            }
+          ]
+        }
+      ],
+      "mr_templates": [
+        {
+          "url": "https://github.com/trivoallan/regis-cli",
+          "directory": "cookiecutters/mr-evidence"
+        }
+      ],
       "_meta": {
         "source_name": "default"
-      },
-      "labels": [
-        "regis::fail"
-      ]
+      }
     }
   ],
   "playbook": {
     "playbook_name": "RegiS Default Playbook",
-    "score": 67,
+    "score": 83,
     "total_scorecards": 6,
-    "passed_scorecards": 4,
+    "passed_scorecards": 5,
     "pages": [
       {
         "title": "Overview",
@@ -1564,20 +1634,20 @@
             "widgets": [
               {
                 "label": "Recommandation",
-                "value": "{{ 'NOGO' }}",
+                "value": "{{ 'GO' }}",
                 "options": {
-                  "class": "recommandation-nogo",
+                  "class": "recommandation-go",
                   "align": "center"
                 },
                 "condition": {
-                  "<": [
+                  ">=": [
                     {
                       "var": "playbooks.0.pages.compliance.sections.mandatory_requirements.score"
                     },
                     90
                   ]
                 },
-                "resolved_value": "NOGO"
+                "resolved_value": "GO"
               }
             ],
             "render_order": [
@@ -1600,7 +1670,7 @@
                 "options": {
                   "align": "center"
                 },
-                "resolved_value": "67%",
+                "resolved_value": "83%",
                 "resolved_url": "compliance.html"
               },
               {
@@ -1610,7 +1680,7 @@
                 "options": {
                   "align": "center"
                 },
-                "resolved_value": "3 / 4",
+                "resolved_value": "4 / 4",
                 "resolved_url": "compliance.html"
               },
               {
@@ -1643,8 +1713,8 @@
                 "options": {
                   "subvalue": "{{ request.timestamp | format_time }}"
                 },
-                "resolved_value": "2026-03-04",
-                "resolved_subvalue": "19:17:27"
+                "resolved_value": "2026-03-05",
+                "resolved_subvalue": "14:33:50"
               },
               {
                 "label": "Triggered by",
@@ -1698,9 +1768,9 @@
       {
         "title": "Compliance",
         "slug": "compliance",
-        "score": 67,
+        "score": 83,
         "total_scorecards": 6,
-        "passed_scorecards": 4,
+        "passed_scorecards": 5,
         "sections": [
           {
             "name": " ",
@@ -1717,7 +1787,7 @@
                 "options": {
                   "align": "center"
                 },
-                "resolved_value": "67%"
+                "resolved_value": "83%"
               },
               {
                 "label": "Mandatory Requirements",
@@ -1725,7 +1795,7 @@
                 "options": {
                   "align": "center"
                 },
-                "resolved_value": "75%"
+                "resolved_value": "100%"
               },
               {
                 "label": "Recommended Requirements",
@@ -1742,15 +1812,15 @@
           },
           {
             "name": "Mandatory Requirements",
-            "score": 75,
+            "score": 100,
             "total_scorecards": 4,
-            "passed_scorecards": 3,
+            "passed_scorecards": 4,
             "levels_summary": {},
             "tags_summary": {
               "security": {
                 "total": 4,
-                "passed": 3,
-                "percentage": 75
+                "passed": 4,
+                "percentage": 100
               }
             },
             "scorecards": [
@@ -1794,10 +1864,10 @@
                 "analyzers": [
                   "dockle"
                 ],
-                "passed": false,
-                "status": "incomplete",
+                "passed": true,
+                "status": "passed",
                 "condition": "{\"==\": [{\"var\": \"results.dockle.issues_by_level.FATAL\"}, 0]}",
-                "details": "results.dockle.issues_by_level.FATAL (MISSING) == 0"
+                "details": "results.dockle.issues_by_level.FATAL (0) == 0"
               },
               {
                 "name": "trusted-domain",
@@ -1866,7 +1936,7 @@
                 "passed": false,
                 "status": "failed",
                 "condition": "{\"<\": [{\"var\": \"results.freshness.age_days\"}, 30]}",
-                "details": "results.freshness.age_days (35) < 30"
+                "details": "results.freshness.age_days (36) < 30"
               }
             ],
             "render_order": [
@@ -2093,12 +2163,12 @@
               {
                 "label": "Pulls",
                 "value": "{{ results.popularity.pull_count | format_number }}",
-                "resolved_value": "{{ results.popularity.pull_count | format_number }}"
+                "resolved_value": "11,698,239,956"
               },
               {
                 "label": "Stars",
                 "value": "{{ results.popularity.star_count | format_number }}",
-                "resolved_value": "{{ results.popularity.star_count | format_number }}"
+                "resolved_value": "11,471"
               },
               {
                 "template": "analyzers/popularity/table.html",
@@ -2221,11 +2291,36 @@
       }
     ],
     "slug": null,
+    "labels": [
+      "regis::warn"
+    ],
+    "mr_description_checklists": [
+      {
+        "title": "📝 Review Checklist",
+        "items": [
+          {
+            "label": "Revue de sécurité réalisée",
+            "checked": false
+          },
+          {
+            "label": "Aucune vulnérabilité CRITIQUE détectée",
+            "checked": true
+          },
+          {
+            "label": "Image issue d'un registre de confiance",
+            "checked": true
+          }
+        ]
+      }
+    ],
+    "mr_templates": [
+      {
+        "url": "https://github.com/trivoallan/regis-cli",
+        "directory": "cookiecutters/mr-evidence"
+      }
+    ],
     "_meta": {
       "source_name": "default"
-    },
-    "labels": [
-      "regis::fail"
-    ]
+    }
   }
 }

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/security.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/security.html
@@ -500,15 +500,6 @@ header h2 {
     
     
         
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
-        
     
         
     

--- a/docs/modules/ROOT/assets/attachments/examples/alpine/supply-chain.html
+++ b/docs/modules/ROOT/assets/attachments/examples/alpine/supply-chain.html
@@ -656,15 +656,6 @@ header h2 {
     
     
         
-            
-<article style="border-left: 5px solid #ef4444;">
-    <header>
-        <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
-    </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
-</article>
-
-        
     
         
     

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/.regis-evidence/SECURITY_EVIDENCE.md
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/.regis-evidence/SECURITY_EVIDENCE.md
@@ -1,0 +1,28 @@
+# 🛡️ regis-cli Security Evidence
+
+> Generated automatically by `regis-cli`
+
+Analysis performed on **2026-03-05T14:35:29.071050+00:00**.
+
+## 📦 Target Details
+- **Registry**: `ghcr.io`
+- **Repository**: `trivoallan/regis-cli`
+- **Tag**: `latest`
+
+## 📊 Playbook Results: RegiS Default Playbook
+- **Score**: `50%`
+- **Passed Scorecards**: `3/6`
+
+
+
+## 🐛 Vulnerability Summary (Trivy)
+- **Critical**: `1`
+- **High**: `18`
+- **Total**: `204`
+
+
+
+
+## 📅 Image Freshness
+- **Age in Days**: `0`
+

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/best-practices.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/best-practices.html
@@ -748,7 +748,7 @@ RUN CMD [&#34;--help&#34;]</code></pre>
 
                                 
 
-    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Dockle execution failed. Ensure dockle is installed and in PATH.&#39;}</p>
+    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Failed to parse dockle output: 2026-03-05T15:34:06.942+0100\t\x1b[31mFATAL\x1b[0m\tunable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;\n&#39;}</p>
 
 
                                 
@@ -775,7 +775,7 @@ RUN CMD [&#34;--help&#34;]</code></pre>
 
 
 
-    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Dockle execution failed. Ensure dockle is installed and in PATH.&#39;}</p>
+    <p>⚠️ Dockle Error: {&#39;type&#39;: &#39;validation&#39;, &#39;message&#39;: &#39;Failed to parse dockle output: 2026-03-05T15:34:06.942+0100\t\x1b[31mFATAL\x1b[0m\tunable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;\n&#39;}</p>
 
 
                                 
@@ -831,7 +831,8 @@ RUN CMD [&#34;--help&#34;]</code></pre>
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/compliance.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/compliance.html
@@ -604,7 +604,7 @@ header h2 {
                                         
                                     </div>
                                     
-                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.trivy.high_count (17) == 0</div>
+                                    <div style="font-size: 0.8rem; opacity: 0.7; margin-top: 0.3rem;">results.trivy.high_count (18) == 0</div>
                                 </td>
                                 <td>
                                     
@@ -679,7 +679,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/index.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/index.html
@@ -433,9 +433,9 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Creation Time</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">2026-03-04</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">2026-03-05</span>
                                     
-                                    <br><small style="opacity: 0.8; font-size: 0.9rem;">19:22:52</small>
+                                    <br><small style="opacity: 0.8; font-size: 0.9rem;">14:35:29</small>
                                     </div>
                             
                         
@@ -530,6 +530,17 @@ header h2 {
             
             
             <tr>
+                <td><strong>digest</strong></td>
+                <td>
+                    
+                        sha256-a1b4f6ba7c5d08f23e089a2fdb4c9d465bdfa3808fc1d3b40d0ad43d8ca2c5cf
+                    
+                </td>
+            </tr>
+            
+            
+            
+            <tr>
                 <td><strong>analyzers</strong></td>
                 <td>
                     
@@ -544,7 +555,7 @@ header h2 {
                 <td><strong>timestamp</strong></td>
                 <td>
                     
-                        2026-03-04 19:22:52
+                        2026-03-05 14:35:29
                     
                 </td>
             </tr>
@@ -698,7 +709,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/insights.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/insights.html
@@ -342,7 +342,7 @@ header h2 {
             </tr>
             <tr>
                 <td><strong>Created</strong></td>
-                <td>2026-03-04T19:14:32.663169564Z</td>
+                <td>2026-03-05T10:51:49.930566144Z</td>
             </tr>
             
             <tr>
@@ -409,7 +409,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Pulls</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">{{ results.popularity.pull_count | format_number }}</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">None</span>
                                     </div>
                             
                         
@@ -425,7 +425,7 @@ header h2 {
                                 
                                 <div class="" style="padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow); text-align: left; ">
                                     <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">Stars</strong><br>
-                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">{{ results.popularity.star_count | format_number }}</span>
+                                    <span style="font-size: 2rem; font-weight: bold; line-height: 1;">None</span>
                                     </div>
                             
                         
@@ -583,7 +583,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/metadata.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/metadata.html
@@ -423,7 +423,7 @@ header h2 {
     </div>
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">TAGS</strong><br>
-        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">62</span>
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">85</span>
     </div>
     
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
@@ -476,7 +476,7 @@ header h2 {
                 </td>
                 <td>
                     
-                        <code title="sha256:7f24b3ff0ba02a6de28983ceaf319f2acff83764ab6683121121107c19eaa8d3">sha256:7f24b...</code>
+                        <code title="sha256:b2a530321971a3a41ab5ba17a4234e2d0876c7f61cc747feabb325f29f1528f8">sha256:b2a53...</code>
                     
                 </td>
                 <td>
@@ -484,7 +484,7 @@ header h2 {
                         <code>regis</code>
                     
                 </td>
-                <td><small>2026-03-04T19:14:32.663169564Z</small></td>
+                <td><small>2026-03-05T10:51:49.930566144Z</small></td>
                 <td>14</td>
                 <td>
                     
@@ -500,7 +500,7 @@ header h2 {
                 </td>
                 <td>
                     
-                        <code title="sha256:885ad41ec3cfa40d322b7870bfafecd298a888a87774d7822ca5c05098404921">sha256:885ad...</code>
+                        <code title="sha256:aac8055ee1819c6fe5e1e751c930cef414d5f139a08308ae593e729c5a233854">sha256:aac80...</code>
                     
                 </td>
                 <td>
@@ -590,15 +590,29 @@ header h2 {
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">DOMINANT PATTERN</strong><br>
         <span style="font-size: 1.5rem; font-weight: bold; line-height: 1;">named</span>
     </div>
+    
+    <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+        <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">RELEASE LINES</strong><br>
+        <span style="font-size: 1.1rem; font-weight: bold; line-height: 1.2; display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; margin-top: 4px;">
+            
+            <kbd style="font-size: 0.9rem; padding: 2px 6px;">0.12</kbd>
+            
+            <kbd style="font-size: 0.9rem; padding: 2px 6px;">0.12.0</kbd>
+            
+        </span>
+    </div>
+    
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">SEMVER COMPLIANCE</strong><br>
+        
+        
         <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: var(--pico-del-color);">
-            9.7%
+            11.8%
         </span>
     </div>
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">TOTAL TAGS</strong><br>
-        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">62</span>
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1;">85</span>
     </div>
 </div>
 
@@ -642,13 +656,17 @@ header h2 {
                     
                     <tr>
                         <td><strong>named</strong></td>
-                        <td>50</td>
-                        <td>80.6%</td>
+                        <td>65</td>
+                        <td>76.5%</td>
                         <td>
                             
                             <code>latest</code>, 
                             
                             <code>main</code>, 
+                            
+                            <code>sha-08211a2</code>, 
+                            
+                            <code>sha-1664655</code>, 
                             
                             <code>sha-194d574</code>, 
                             
@@ -660,20 +678,22 @@ header h2 {
                             
                             <code>sha-2bffefd</code>, 
                             
-                            <code>sha-342d0b8</code>, 
-                            
-                            <code>sha-376c16e</code>, 
-                            
-                            <code>sha-391d74f</code>
+                            <code>sha-340f44d</code>
                             
                         </td>
                     </tr>
                     
                     <tr>
                         <td><strong>numeric</strong></td>
-                        <td>6</td>
-                        <td>9.7%</td>
+                        <td>10</td>
+                        <td>11.8%</td>
                         <td>
+                            
+                            <code>0.10</code>, 
+                            
+                            <code>0.11</code>, 
+                            
+                            <code>0.12</code>, 
                             
                             <code>0.2</code>, 
                             
@@ -685,16 +705,24 @@ header h2 {
                             
                             <code>0.7</code>, 
                             
-                            <code>0.8</code>
+                            <code>0.8</code>, 
+                            
+                            <code>0.9</code>
                             
                         </td>
                     </tr>
                     
                     <tr>
                         <td><strong>semver</strong></td>
-                        <td>6</td>
-                        <td>9.7%</td>
+                        <td>10</td>
+                        <td>11.8%</td>
                         <td>
+                            
+                            <code>0.10.0</code>, 
+                            
+                            <code>0.11.0</code>, 
+                            
+                            <code>0.12.0</code>, 
                             
                             <code>0.2.2</code>, 
                             
@@ -706,7 +734,9 @@ header h2 {
                             
                             <code>0.7.0</code>, 
                             
-                            <code>0.8.0</code>
+                            <code>0.8.0</code>, 
+                            
+                            <code>0.9.0</code>
                             
                         </td>
                     </tr>
@@ -775,7 +805,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/report.json
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/report.json
@@ -1,10 +1,11 @@
 {
-  "version": "0.8.0",
+  "version": "0.12.0",
   "request": {
     "url": "ghcr.io/trivoallan/regis-cli:latest",
     "registry": "ghcr.io",
     "repository": "trivoallan/regis-cli",
     "tag": "latest",
+    "digest": "sha256-a1b4f6ba7c5d08f23e089a2fdb4c9d465bdfa3808fc1d3b40d0ad43d8ca2c5cf",
     "analyzers": [
       "dockle",
       "endoflife",
@@ -19,14 +20,14 @@
       "trivy",
       "versioning"
     ],
-    "timestamp": "2026-03-04T19:22:52.619886+00:00"
+    "timestamp": "2026-03-05T14:35:29.071050+00:00"
   },
   "results": {
     "dockle": {
       "analyzer": "dockle",
       "error": {
         "type": "validation",
-        "message": "Dockle execution failed. Ensure dockle is installed and in PATH."
+        "message": "Failed to parse dockle output: 2026-03-05T15:34:06.942+0100\t\u001b[31mFATAL\u001b[0m\tunable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture \"arm64\", variant \"v8\", OS \"linux\"\n"
       }
     },
     "endoflife": {
@@ -44,7 +45,7 @@
       "analyzer": "freshness",
       "repository": "trivoallan/regis-cli",
       "tag": "latest",
-      "tag_created": "2026-03-04T19:14:32.663169564Z",
+      "tag_created": "2026-03-05T10:51:49.930566144Z",
       "latest_created": null,
       "age_days": 0,
       "behind_latest_days": null,
@@ -250,12 +251,12 @@
         {
           "type": "oci-annotation",
           "key": "org.opencontainers.image.revision",
-          "value": "fd24eb99c7ca6646c3fd7b72294cb49d006df298"
+          "value": "42459a3b2e7b9858704ae7c6759d76db8e209274"
         },
         {
           "type": "oci-annotation",
           "key": "org.opencontainers.image.created",
-          "value": "2026-03-04T19:14:02.753Z"
+          "value": "2026-03-05T10:51:28.093Z"
         }
       ]
     },
@@ -269,8 +270,8 @@
       "total_components": 686,
       "component_types": {
         "library": 683,
-        "operating-system": 1,
-        "application": 2
+        "application": 2,
+        "operating-system": 1
       },
       "total_dependencies": 687,
       "licenses": [
@@ -453,10 +454,10 @@
       ],
       "components": [
         {
-          "name": "github.com/moby/docker-image-spec",
-          "version": "v1.3.1",
+          "name": "github.com/docker/distribution",
+          "version": "v2.8.3+incompatible",
           "type": "library",
-          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
+          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
           "licenses": []
         },
         {
@@ -467,24 +468,31 @@
           "licenses": []
         },
         {
+          "name": "github.com/go-logr/stdr",
+          "version": "v1.2.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/docker/go-units",
+          "version": "v0.5.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/docker/go-units@v0.5.0",
+          "licenses": []
+        },
+        {
+          "name": "github.com/felixge/httpsnoop",
+          "version": "v1.0.4",
+          "type": "library",
+          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+          "licenses": []
+        },
+        {
           "name": "github.com/hashicorp/errwrap",
           "version": "v1.1.0",
           "type": "library",
           "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/toqueteos/webbrowser",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/toqueteos/webbrowser@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/objx",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
           "licenses": []
         },
         {
@@ -495,6 +503,41 @@
           "licenses": []
         },
         {
+          "name": "github.com/pkg/errors",
+          "version": "v0.9.1",
+          "type": "library",
+          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+          "licenses": []
+        },
+        {
+          "name": "gopkg.in/yaml.v3",
+          "version": "v3.0.1",
+          "type": "library",
+          "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/gogo/protobuf",
+          "version": "v1.3.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/hashicorp/go-multierror",
+          "version": "v1.1.1",
+          "type": "library",
+          "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/davecgh/go-spew",
+          "version": "v1.1.2-0.20180830191138-d8f796af33cc",
+          "type": "library",
+          "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
+          "licenses": []
+        },
+        {
           "name": "github.com/opencontainers/go-digest",
           "version": "v1.0.0",
           "type": "library",
@@ -502,38 +545,10 @@
           "licenses": []
         },
         {
-          "name": "github.com/google/uuid",
-          "version": "v1.6.0",
+          "name": "github.com/modern-go/concurrent",
+          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
           "type": "library",
-          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pmezard/go-difflib",
-          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/russross/blackfriday/v2",
-          "version": "v2.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-          "licenses": []
-        },
-        {
-          "name": "debian",
-          "version": "13.3",
-          "type": "operating-system",
-          "purl": null,
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/objx",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
+          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
           "licenses": []
         },
         {
@@ -544,40 +559,47 @@
           "licenses": []
         },
         {
-          "name": "github.com/pkg/errors",
-          "version": "v0.9.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+          "name": "usr/local/bin/trivy",
+          "version": null,
+          "type": "application",
+          "purl": null,
           "licenses": []
         },
         {
-          "name": "github.com/knqyf263/nested",
-          "version": "v0.0.1",
+          "name": "github.com/moby/docker-image-spec",
+          "version": "v1.3.1",
           "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/nested@v0.0.1",
+          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
           "licenses": []
         },
         {
-          "name": "github.com/go-logr/stdr",
-          "version": "v1.2.2",
+          "name": "github.com/json-iterator/go",
+          "version": "v1.1.12",
           "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
           "licenses": []
         },
         {
           "name": "regis-cli",
-          "version": "0.8.0",
+          "version": "0.12.0",
           "type": "library",
-          "purl": "pkg:pypi/regis-cli@0.8.0",
+          "purl": "pkg:pypi/regis-cli@0.12.0",
           "licenses": [
             "MIT"
           ]
         },
         {
-          "name": "github.com/pkg/errors",
-          "version": "v0.9.1",
+          "name": "github.com/russross/blackfriday/v2",
+          "version": "v2.1.0",
           "type": "library",
-          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
+          "licenses": []
+        },
+        {
+          "name": "github.com/russross/blackfriday/v2",
+          "version": "v2.1.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
           "licenses": []
         },
         {
@@ -585,41 +607,6 @@
           "version": "v0.0.1",
           "type": "library",
           "purl": "pkg:golang/github.com/knqyf263/nested@v0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gogo/protobuf",
-          "version": "v1.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/distribution",
-          "version": "v2.8.3+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/distribution/reference",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/distribution/reference@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-multierror",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gogo/protobuf",
-          "version": "v1.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
           "licenses": []
         },
         {
@@ -637,145 +624,10 @@
           "licenses": []
         },
         {
-          "name": "github.com/hashicorp/errwrap",
-          "version": "v1.1.0",
+          "name": "github.com/toqueteos/webbrowser",
+          "version": "v1.2.0",
           "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/docker-image-spec",
-          "version": "v1.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/yaml.v3",
-          "version": "v3.0.1",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/distribution",
-          "version": "v2.8.3+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/go-units",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/go-units@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/json-iterator/go",
-          "version": "v1.1.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/concurrent",
-          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/felixge/httpsnoop",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/json-iterator/go",
-          "version": "v1.1.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-logr/stdr",
-          "version": "v1.2.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/go-digest",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pmezard/go-difflib",
-          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/felixge/httpsnoop",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/mountinfo",
-          "version": "v0.7.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/mountinfo@v0.7.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/davecgh/go-spew",
-          "version": "v1.1.2-0.20180830191138-d8f796af33cc",
-          "type": "library",
-          "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
-          "licenses": []
-        },
-        {
-          "name": "regis-cli",
-          "version": "0.8.0",
-          "type": "library",
-          "purl": "pkg:pypi/regis-cli@0.8.0",
-          "licenses": [
-            "MIT"
-          ]
-        },
-        {
-          "name": "github.com/russross/blackfriday/v2",
-          "version": "v2.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-          "licenses": []
-        },
-        {
-          "name": "usr/local/bin/trivy",
-          "version": null,
-          "type": "application",
-          "purl": null,
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/concurrent",
-          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/uuid",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+          "purl": "pkg:golang/github.com/toqueteos/webbrowser@v1.2.0",
           "licenses": []
         },
         {
@@ -793,10 +645,159 @@
           "licenses": []
         },
         {
+          "name": "github.com/knqyf263/nested",
+          "version": "v0.0.1",
+          "type": "library",
+          "purl": "pkg:golang/github.com/knqyf263/nested@v0.0.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/google/uuid",
+          "version": "v1.6.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+          "licenses": []
+        },
+        {
+          "name": "github.com/moby/sys/mountinfo",
+          "version": "v0.7.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/moby/sys/mountinfo@v0.7.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/moby/docker-image-spec",
+          "version": "v1.3.1",
+          "type": "library",
+          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/opencontainers/go-digest",
+          "version": "v1.0.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
+          "licenses": []
+        },
+        {
+          "name": "debian",
+          "version": "13.3",
+          "type": "operating-system",
+          "purl": null,
+          "licenses": []
+        },
+        {
+          "name": "github.com/gogo/protobuf",
+          "version": "v1.3.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/felixge/httpsnoop",
+          "version": "v1.0.4",
+          "type": "library",
+          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
+          "licenses": []
+        },
+        {
+          "name": "github.com/modern-go/concurrent",
+          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+          "type": "library",
+          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+          "licenses": []
+        },
+        {
           "name": "gopkg.in/yaml.v3",
           "version": "v3.0.1",
           "type": "library",
           "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/hashicorp/errwrap",
+          "version": "v1.1.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
+          "licenses": []
+        },
+        {
+          "name": "github.com/docker/distribution",
+          "version": "v2.8.3+incompatible",
+          "type": "library",
+          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
+          "licenses": []
+        },
+        {
+          "name": "github.com/google/uuid",
+          "version": "v1.6.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+          "licenses": []
+        },
+        {
+          "name": "regis-cli",
+          "version": "0.12.0",
+          "type": "library",
+          "purl": "pkg:pypi/regis-cli@0.12.0",
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "name": "github.com/go-logr/stdr",
+          "version": "v1.2.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/pmezard/go-difflib",
+          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/stretchr/objx",
+          "version": "v0.5.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/pkg/errors",
+          "version": "v0.9.1",
+          "type": "library",
+          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+          "licenses": []
+        },
+        {
+          "name": "github.com/stretchr/objx",
+          "version": "v0.5.2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
+          "licenses": []
+        },
+        {
+          "name": "github.com/json-iterator/go",
+          "version": "v1.1.12",
+          "type": "library",
+          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+          "licenses": []
+        },
+        {
+          "name": "github.com/distribution/reference",
+          "version": "v0.6.0",
+          "type": "library",
+          "purl": "pkg:golang/github.com/distribution/reference@v0.6.0",
+          "licenses": []
+        },
+        {
+          "name": "github.com/pmezard/go-difflib",
+          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
+          "type": "library",
+          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
           "licenses": []
         },
         {
@@ -6371,9 +6372,9 @@
         },
         {
           "name": "chardet",
-          "version": "7.0.0",
+          "version": "7.0.1",
           "type": "library",
-          "purl": "pkg:pypi/chardet@7.0.0",
+          "purl": "pkg:pypi/chardet@7.0.1",
           "licenses": [
             "MIT"
           ]
@@ -6523,9 +6524,9 @@
         },
         {
           "name": "referencing",
-          "version": "0.37.0",
+          "version": "0.36.2",
           "type": "library",
-          "purl": "pkg:pypi/referencing@0.37.0",
+          "purl": "pkg:pypi/referencing@0.36.2",
           "licenses": [
             "MIT"
           ]
@@ -6628,7 +6629,7 @@
       "repository": "trivoallan/regis-cli",
       "tag": "latest",
       "multi_arch": true,
-      "total_compressed_bytes": 214624391,
+      "total_compressed_bytes": 214681173,
       "total_compressed_human": "204.7 MB",
       "layer_count": 14,
       "config_size_bytes": 0,
@@ -6636,13 +6637,13 @@
       "platforms": [
         {
           "platform": "linux/amd64",
-          "compressed_bytes": 214624391,
+          "compressed_bytes": 214681173,
           "compressed_human": "204.7 MB",
           "layer_count": 14
         },
         {
           "platform": "unknown/unknown",
-          "compressed_bytes": 39342,
+          "compressed_bytes": 39276,
           "compressed_human": "38.4 KB",
           "layer_count": 1
         }
@@ -6657,17 +6658,17 @@
         {
           "architecture": "amd64",
           "os": "linux",
-          "digest": "sha256:7f24b3ff0ba02a6de28983ceaf319f2acff83764ab6683121121107c19eaa8d3",
-          "created": "2026-03-04T19:14:32.663169564Z",
+          "digest": "sha256:b2a530321971a3a41ab5ba17a4234e2d0876c7f61cc747feabb325f29f1528f8",
+          "created": "2026-03-05T10:51:49.930566144Z",
           "labels": {
-            "org.opencontainers.image.created": "2026-03-04T19:14:02.753Z",
-            "org.opencontainers.image.description": "",
+            "org.opencontainers.image.created": "2026-03-05T10:51:28.093Z",
+            "org.opencontainers.image.description": "regis-cli is a command-line tool designed to analyze container image registries, evaluate security playbooks, and generate comprehensive reports. It provides deep visibility into container image metadata and security posture, enabling automated policy enforcement in CI/CD environments.",
             "org.opencontainers.image.licenses": "",
-            "org.opencontainers.image.revision": "fd24eb99c7ca6646c3fd7b72294cb49d006df298",
+            "org.opencontainers.image.revision": "42459a3b2e7b9858704ae7c6759d76db8e209274",
             "org.opencontainers.image.source": "https://github.com/trivoallan/regis-cli",
             "org.opencontainers.image.title": "regis-cli",
             "org.opencontainers.image.url": "https://github.com/trivoallan/regis-cli",
-            "org.opencontainers.image.version": "0.8.0"
+            "org.opencontainers.image.version": "0.12.0"
           },
           "layers_count": 14,
           "variant": null,
@@ -6676,7 +6677,7 @@
         {
           "architecture": "unknown",
           "os": "unknown",
-          "digest": "sha256:885ad41ec3cfa40d322b7870bfafecd298a888a87774d7822ca5c05098404921",
+          "digest": "sha256:aac8055ee1819c6fe5e1e751c930cef414d5f139a08308ae593e729c5a233854",
           "created": null,
           "labels": {},
           "layers_count": 1,
@@ -6746,7 +6747,30 @@
         "sha-e5b0e77",
         "0.8.0",
         "0.8",
-        "sha-fd24eb9"
+        "sha-fd24eb9",
+        "0.9.0",
+        "0.9",
+        "sha-57f48a3",
+        "sha-08211a2",
+        "sha-9393b48",
+        "sha-a48b4b2",
+        "sha-abd95d2",
+        "0.10.0",
+        "0.10",
+        "sha-f04d633",
+        "sha-340f44d",
+        "sha-f18e91b",
+        "sha-ef81c05",
+        "sha-1664655",
+        "sha-9898bd8",
+        "0.11.0",
+        "0.11",
+        "sha-9aaef15",
+        "sha-f865cb0",
+        "sha-9a7914f",
+        "0.12.0",
+        "0.12",
+        "sha-42459a3"
       ]
     },
     "trivy": {
@@ -6754,12 +6778,12 @@
       "repository": "trivoallan/regis-cli",
       "tag": "latest",
       "trivy_version": "2",
-      "vulnerability_count": 202,
+      "vulnerability_count": 204,
       "critical_count": 1,
-      "high_count": 17,
+      "high_count": 18,
       "medium_count": 51,
       "low_count": 133,
-      "unknown_count": 0,
+      "unknown_count": 1,
       "targets": [
         {
           "Target": "ghcr.io/trivoallan/regis-cli:latest (debian 13.3)",
@@ -6916,6 +6940,15 @@
               "Severity": "LOW",
               "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
               "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
+            },
+            {
+              "VulnerabilityID": "CVE-2026-2219",
+              "PkgName": "dpkg",
+              "InstalledVersion": "1.22.21",
+              "FixedVersion": "",
+              "Severity": "UNKNOWN",
+              "Title": "[dpkg-deb: Persistent hang on malformed .deb archives (DoS)]",
+              "Description": ""
             },
             {
               "VulnerabilityID": "CVE-2018-1000021",
@@ -8596,62 +8629,84 @@
         },
         {
           "Target": "usr/local/bin/trivy",
-          "Vulnerabilities": null
+          "Vulnerabilities": [
+            {
+              "VulnerabilityID": "CVE-2025-15558",
+              "PkgName": "github.com/docker/cli",
+              "InstalledVersion": "v29.1.1+incompatible",
+              "FixedVersion": "29.2.0",
+              "Severity": "HIGH",
+              "Title": "Docker CLI Plugins: Uncontrolled Search Path Element Leads to Local Privilege Escalation on Windows",
+              "Description": "Docker CLI for Windows searches for plugin binaries in C:\\ProgramData\\Docker\\cli-plugins, a directory that does not exist by default. A low-privileged attacker can create this directory and place malicious CLI plugin binaries (docker-compose.exe, docker-buildx.exe, etc.) that are executed when a victim user opens Docker Desktop or invokes Docker CLI plugin features, and allow privilege-escalation if the docker CLI is executed as a privileged user.\n\nThis issue affects Docker CLI: through 29.1.5 and Windows binaries acting as a CLI-plugin manager using the  github.com/docker/cli/cli-plugins/manager https://pkg.go.dev/github.com/docker/cli@v29.1.5+incompatible/cli-plugins/manager  package, such as Docker Compose.\n\nThis issue does not impact non-Windows binaries, and projects not using the plugin-manager code."
+            }
+          ]
         }
       ]
     },
     "versioning": {
       "analyzer": "versioning",
       "repository": "trivoallan/regis-cli",
-      "total_tags": 62,
+      "total_tags": 85,
       "dominant_pattern": "named",
-      "semver_compliant_percentage": 9.7,
+      "semver_compliant_percentage": 11.8,
       "patterns": [
         {
           "pattern": "named",
-          "count": 50,
-          "percentage": 80.6,
+          "count": 65,
+          "percentage": 76.5,
           "examples": [
             "latest",
             "main",
+            "sha-08211a2",
+            "sha-1664655",
             "sha-194d574",
             "sha-21b7549",
             "sha-2823f64",
             "sha-295db88",
             "sha-2bffefd",
-            "sha-342d0b8",
-            "sha-376c16e",
-            "sha-391d74f"
+            "sha-340f44d"
           ]
         },
         {
           "pattern": "numeric",
-          "count": 6,
-          "percentage": 9.7,
+          "count": 10,
+          "percentage": 11.8,
           "examples": [
+            "0.10",
+            "0.11",
+            "0.12",
             "0.2",
             "0.3",
             "0.4",
             "0.5",
             "0.7",
-            "0.8"
+            "0.8",
+            "0.9"
           ]
         },
         {
           "pattern": "semver",
-          "count": 6,
-          "percentage": 9.7,
+          "count": 10,
+          "percentage": 11.8,
           "examples": [
+            "0.10.0",
+            "0.11.0",
+            "0.12.0",
             "0.2.2",
             "0.3.0",
             "0.4.0",
             "0.5.0",
             "0.7.0",
-            "0.8.0"
+            "0.8.0",
+            "0.9.0"
           ]
         }
       ],
-      "variants": []
+      "variants": [],
+      "release_lines": [
+        "0.12",
+        "0.12.0"
+      ]
     }
   },
   "playbooks": [
@@ -8758,8 +8813,8 @@
                   "options": {
                     "subvalue": "{{ request.timestamp | format_time }}"
                   },
-                  "resolved_value": "2026-03-04",
-                  "resolved_subvalue": "19:22:52"
+                  "resolved_value": "2026-03-05",
+                  "resolved_subvalue": "14:35:29"
                 },
                 {
                   "label": "Triggered by",
@@ -8966,7 +9021,7 @@
                   "passed": false,
                   "status": "failed",
                   "condition": "{\"==\": [{\"var\": \"results.trivy.high_count\"}, 0]}",
-                  "details": "results.trivy.high_count (17) == 0"
+                  "details": "results.trivy.high_count (18) == 0"
                 },
                 {
                   "name": "age",
@@ -9208,12 +9263,12 @@
                 {
                   "label": "Pulls",
                   "value": "{{ results.popularity.pull_count | format_number }}",
-                  "resolved_value": "{{ results.popularity.pull_count | format_number }}"
+                  "resolved_value": "None"
                 },
                 {
                   "label": "Stars",
                   "value": "{{ results.popularity.star_count | format_number }}",
-                  "resolved_value": "{{ results.popularity.star_count | format_number }}"
+                  "resolved_value": "None"
                 },
                 {
                   "template": "analyzers/popularity/table.html",
@@ -9336,13 +9391,34 @@
         }
       ],
       "slug": null,
+      "labels": [
+        "security::critical",
+        "regis::fail"
+      ],
+      "mr_description_checklists": [
+        {
+          "title": "📝 Review Checklist",
+          "items": [
+            {
+              "label": "Revue de sécurité réalisée",
+              "checked": false
+            },
+            {
+              "label": "Image issue d'un registre de confiance",
+              "checked": true
+            }
+          ]
+        }
+      ],
+      "mr_templates": [
+        {
+          "url": "https://github.com/trivoallan/regis-cli",
+          "directory": "cookiecutters/mr-evidence"
+        }
+      ],
       "_meta": {
         "source_name": "default"
-      },
-      "labels": [
-        "regis::fail",
-        "security::critical"
-      ]
+      }
     }
   ],
   "playbook": {
@@ -9448,8 +9524,8 @@
                 "options": {
                   "subvalue": "{{ request.timestamp | format_time }}"
                 },
-                "resolved_value": "2026-03-04",
-                "resolved_subvalue": "19:22:52"
+                "resolved_value": "2026-03-05",
+                "resolved_subvalue": "14:35:29"
               },
               {
                 "label": "Triggered by",
@@ -9656,7 +9732,7 @@
                 "passed": false,
                 "status": "failed",
                 "condition": "{\"==\": [{\"var\": \"results.trivy.high_count\"}, 0]}",
-                "details": "results.trivy.high_count (17) == 0"
+                "details": "results.trivy.high_count (18) == 0"
               },
               {
                 "name": "age",
@@ -9898,12 +9974,12 @@
               {
                 "label": "Pulls",
                 "value": "{{ results.popularity.pull_count | format_number }}",
-                "resolved_value": "{{ results.popularity.pull_count | format_number }}"
+                "resolved_value": "None"
               },
               {
                 "label": "Stars",
                 "value": "{{ results.popularity.star_count | format_number }}",
-                "resolved_value": "{{ results.popularity.star_count | format_number }}"
+                "resolved_value": "None"
               },
               {
                 "template": "analyzers/popularity/table.html",
@@ -10026,12 +10102,33 @@
       }
     ],
     "slug": null,
+    "labels": [
+      "security::critical",
+      "regis::fail"
+    ],
+    "mr_description_checklists": [
+      {
+        "title": "📝 Review Checklist",
+        "items": [
+          {
+            "label": "Revue de sécurité réalisée",
+            "checked": false
+          },
+          {
+            "label": "Image issue d'un registre de confiance",
+            "checked": true
+          }
+        ]
+      }
+    ],
+    "mr_templates": [
+      {
+        "url": "https://github.com/trivoallan/regis-cli",
+        "directory": "cookiecutters/mr-evidence"
+      }
+    ],
     "_meta": {
       "source_name": "default"
-    },
-    "labels": [
-      "regis::fail",
-      "security::critical"
-    ]
+    }
   }
 }

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/security.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/security.html
@@ -310,7 +310,7 @@ header h2 {
             <strong style="font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">HIGH</strong><br>
             <!-- prettier-ignore-start -->
             <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: var(--pico-del-color);">
-                17
+                18
             </span>
             <!-- prettier-ignore-end -->
         </div>
@@ -681,6 +681,47 @@ header h2 {
         
     
         
+            
+
+            
+                
+                
+                <div style="margin-top: 1rem; margin-bottom: 1rem;">
+                    <h5 style="margin-bottom: 0.5rem; color: var(--pico-secondary);">usr/local/bin/trivy</h5>
+                    <div class="overflow-auto">
+                        <table class="striped">
+                            <thead>
+                                <tr>
+                                    <th>Severity</th>
+                                    <th>ID</th>
+                                    <th>Package</th>
+                                    <th>Fixed In</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                
+                                <tr>
+                                    <td>
+                                        
+                                        <span class="badge ">
+    HIGH
+</span>
+                                    </td>
+                                    <td><code>CVE-2025-15558</code></td>
+                                    <td>
+                                        <strong>github.com/docker/cli</strong><br>
+                                        <small>v29.1.1+incompatible</small>
+                                    </td>
+                                    <td>29.2.0</td>
+                                </tr>
+                                
+                            </tbody>
+                        </table>
+                    </div>
+                    
+                </div>
+            
+        
     
     
 
@@ -805,7 +846,7 @@ header h2 {
                 <td><code>org.opencontainers.image.revision</code></td>
                 <td>
                     
-                        fd24eb99c7ca6646c3fd7b72294cb49d006df298
+                        42459a3b2e7b9858704ae7c6759d76db8e209274
                     
                 </td>
             </tr>
@@ -815,7 +856,7 @@ header h2 {
                 <td><code>org.opencontainers.image.created</code></td>
                 <td>
                     
-                        2026-03-04T19:14:02.753Z
+                        2026-03-05T10:51:28.093Z
                     
                 </td>
             </tr>
@@ -878,7 +919,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/assets/attachments/examples/regis-cli/supply-chain.html
+++ b/docs/modules/ROOT/assets/attachments/examples/regis-cli/supply-chain.html
@@ -1078,8 +1078,8 @@ header h2 {
             <tbody>
                 
                 <tr>
-                    <td><code>github.com/moby/docker-image-spec</code></td>
-                    <td>v1.3.1</td>
+                    <td><code>github.com/docker/distribution</code></td>
+                    <td>v2.8.3+incompatible</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1092,22 +1092,29 @@ header h2 {
                 </tr>
                 
                 <tr>
+                    <td><code>github.com/go-logr/stdr</code></td>
+                    <td>v1.2.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/docker/go-units</code></td>
+                    <td>v0.5.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/felixge/httpsnoop</code></td>
+                    <td>v1.0.4</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
                     <td><code>github.com/hashicorp/errwrap</code></td>
                     <td>v1.1.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/toqueteos/webbrowser</code></td>
-                    <td>v1.2.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/stretchr/objx</code></td>
-                    <td>v0.5.2</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1120,6 +1127,41 @@ header h2 {
                 </tr>
                 
                 <tr>
+                    <td><code>github.com/pkg/errors</code></td>
+                    <td>v0.9.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>gopkg.in/yaml.v3</code></td>
+                    <td>v3.0.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/gogo/protobuf</code></td>
+                    <td>v1.3.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/hashicorp/go-multierror</code></td>
+                    <td>v1.1.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/davecgh/go-spew</code></td>
+                    <td>v1.1.2-0.20180830191138-d8f796af33cc</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
                     <td><code>github.com/opencontainers/go-digest</code></td>
                     <td>v1.0.0</td>
                     <td><small>library</small></td>
@@ -1127,36 +1169,8 @@ header h2 {
                 </tr>
                 
                 <tr>
-                    <td><code>github.com/google/uuid</code></td>
-                    <td>v1.6.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/pmezard/go-difflib</code></td>
-                    <td>v1.0.1-0.20181226105442-5d4384ee4fb2</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/russross/blackfriday/v2</code></td>
-                    <td>v2.1.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>debian</code></td>
-                    <td>13.3</td>
-                    <td><small>operating-system</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/stretchr/objx</code></td>
-                    <td>v0.5.2</td>
+                    <td><code>github.com/modern-go/concurrent</code></td>
+                    <td>v0.0.0-20180306012644-bacd9c7ef1dd</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1169,36 +1183,43 @@ header h2 {
                 </tr>
                 
                 <tr>
-                    <td><code>github.com/pkg/errors</code></td>
-                    <td>v0.9.1</td>
+                    <td><code>usr/local/bin/trivy</code></td>
+                    <td>None</td>
+                    <td><small>application</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/moby/docker-image-spec</code></td>
+                    <td>v1.3.1</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
                 
                 <tr>
-                    <td><code>github.com/knqyf263/nested</code></td>
-                    <td>v0.0.1</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/go-logr/stdr</code></td>
-                    <td>v1.2.2</td>
+                    <td><code>github.com/json-iterator/go</code></td>
+                    <td>v1.1.12</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
                 
                 <tr>
                     <td><code>regis-cli</code></td>
-                    <td>0.8.0</td>
+                    <td>0.12.0</td>
                     <td><small>library</small></td>
                     <td>MIT</td>
                 </tr>
                 
                 <tr>
-                    <td><code>github.com/pkg/errors</code></td>
-                    <td>v0.9.1</td>
+                    <td><code>github.com/russross/blackfriday/v2</code></td>
+                    <td>v2.1.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/russross/blackfriday/v2</code></td>
+                    <td>v2.1.0</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1206,41 +1227,6 @@ header h2 {
                 <tr>
                     <td><code>github.com/knqyf263/nested</code></td>
                     <td>v0.0.1</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/gogo/protobuf</code></td>
-                    <td>v1.3.2</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/docker/distribution</code></td>
-                    <td>v2.8.3+incompatible</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/distribution/reference</code></td>
-                    <td>v0.6.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/hashicorp/go-multierror</code></td>
-                    <td>v1.1.1</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/gogo/protobuf</code></td>
-                    <td>v1.3.2</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1260,141 +1246,8 @@ header h2 {
                 </tr>
                 
                 <tr>
-                    <td><code>github.com/hashicorp/errwrap</code></td>
-                    <td>v1.1.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/moby/docker-image-spec</code></td>
-                    <td>v1.3.1</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>gopkg.in/yaml.v3</code></td>
-                    <td>v3.0.1</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/docker/distribution</code></td>
-                    <td>v2.8.3+incompatible</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/docker/go-units</code></td>
-                    <td>v0.5.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/json-iterator/go</code></td>
-                    <td>v1.1.12</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/modern-go/concurrent</code></td>
-                    <td>v0.0.0-20180306012644-bacd9c7ef1dd</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/felixge/httpsnoop</code></td>
-                    <td>v1.0.4</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/json-iterator/go</code></td>
-                    <td>v1.1.12</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/go-logr/stdr</code></td>
-                    <td>v1.2.2</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/opencontainers/go-digest</code></td>
-                    <td>v1.0.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/pmezard/go-difflib</code></td>
-                    <td>v1.0.1-0.20181226105442-5d4384ee4fb2</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/felixge/httpsnoop</code></td>
-                    <td>v1.0.4</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/moby/sys/mountinfo</code></td>
-                    <td>v0.7.2</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/davecgh/go-spew</code></td>
-                    <td>v1.1.2-0.20180830191138-d8f796af33cc</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>regis-cli</code></td>
-                    <td>0.8.0</td>
-                    <td><small>library</small></td>
-                    <td>MIT</td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/russross/blackfriday/v2</code></td>
-                    <td>v2.1.0</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>usr/local/bin/trivy</code></td>
-                    <td>None</td>
-                    <td><small>application</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/modern-go/concurrent</code></td>
-                    <td>v0.0.0-20180306012644-bacd9c7ef1dd</td>
-                    <td><small>library</small></td>
-                    <td></td>
-                </tr>
-                
-                <tr>
-                    <td><code>github.com/google/uuid</code></td>
-                    <td>v1.6.0</td>
+                    <td><code>github.com/toqueteos/webbrowser</code></td>
+                    <td>v1.2.0</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1414,8 +1267,155 @@ header h2 {
                 </tr>
                 
                 <tr>
+                    <td><code>github.com/knqyf263/nested</code></td>
+                    <td>v0.0.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/google/uuid</code></td>
+                    <td>v1.6.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/moby/sys/mountinfo</code></td>
+                    <td>v0.7.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/moby/docker-image-spec</code></td>
+                    <td>v1.3.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/opencontainers/go-digest</code></td>
+                    <td>v1.0.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>debian</code></td>
+                    <td>13.3</td>
+                    <td><small>operating-system</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/gogo/protobuf</code></td>
+                    <td>v1.3.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/felixge/httpsnoop</code></td>
+                    <td>v1.0.4</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/modern-go/concurrent</code></td>
+                    <td>v0.0.0-20180306012644-bacd9c7ef1dd</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
                     <td><code>gopkg.in/yaml.v3</code></td>
                     <td>v3.0.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/hashicorp/errwrap</code></td>
+                    <td>v1.1.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/docker/distribution</code></td>
+                    <td>v2.8.3+incompatible</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/google/uuid</code></td>
+                    <td>v1.6.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>regis-cli</code></td>
+                    <td>0.12.0</td>
+                    <td><small>library</small></td>
+                    <td>MIT</td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/go-logr/stdr</code></td>
+                    <td>v1.2.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/pmezard/go-difflib</code></td>
+                    <td>v1.0.1-0.20181226105442-5d4384ee4fb2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/stretchr/objx</code></td>
+                    <td>v0.5.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/pkg/errors</code></td>
+                    <td>v0.9.1</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/stretchr/objx</code></td>
+                    <td>v0.5.2</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/json-iterator/go</code></td>
+                    <td>v1.1.12</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/distribution/reference</code></td>
+                    <td>v0.6.0</td>
+                    <td><small>library</small></td>
+                    <td></td>
+                </tr>
+                
+                <tr>
+                    <td><code>github.com/pmezard/go-difflib</code></td>
+                    <td>v1.0.1-0.20181226105442-5d4384ee4fb2</td>
                     <td><small>library</small></td>
                     <td></td>
                 </tr>
@@ -1572,7 +1572,8 @@ header h2 {
     <header>
         <h3 style="color: #ef4444; margin: 0;">⚠️ dockle Analyzer Error</h3>
     </header>
-    <p><strong>validation:</strong> Dockle execution failed. Ensure dockle is installed and in PATH.</p>
+    <p><strong>validation:</strong> Failed to parse dockle output: 2026-03-05T15:34:06.942+0100	[31mFATAL[0m	unable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture &#34;arm64&#34;, variant &#34;v8&#34;, OS &#34;linux&#34;
+</p>
 </article>
 
         

--- a/docs/modules/ROOT/pages/schemas/report.adoc
+++ b/docs/modules/ROOT/pages/schemas/report.adoc
@@ -12,6 +12,7 @@
 ** [[properties_request_properties_registry]]**`registry`** *(string, required)*: Resolved registry hostname (e.g. registry-1.docker.io).
 ** [[properties_request_properties_repository]]**`repository`** *(string, required)*: Full repository path (e.g. library/nginx).
 ** [[properties_request_properties_tag]]**`tag`** *(string, required)*: Image tag that was analyzed.
+** [[properties_request_properties_digest]]**`digest`** *(string)*: Resolved image manifest digest (e.g. sha256-xxx), if available.
 ** [[properties_request_properties_analyzers]]**`analyzers`** *(array, required)*: List of analyzer names that were executed.
 *** [[properties_request_properties_analyzers_items]]**Items** *(string)*
 ** [[properties_request_properties_timestamp]]**`timestamp`** *(string, format: date-time, required)*: ISO 8601 UTC timestamp of the analysis.

--- a/docs/modules/ROOT/pages/schemas/versioning.adoc
+++ b/docs/modules/ROOT/pages/schemas/versioning.adoc
@@ -5,6 +5,8 @@
 * [[properties_repository]]**`repository`** *(string, required)*
 * [[properties_total_tags]]**`total_tags`** *(integer, required)*: Minimum: `0`.
 * [[properties_dominant_pattern]]**`dominant_pattern`** *(string, required)*: Must be one of: "semver", "semver-prerelease", "semver-variant", "calver", "numeric", "hash", "named", or "unknown".
+* [[properties_release_lines]]**`release_lines`** *(array)*
+** [[properties_release_lines_items]]**Items** *(string)*
 * [[properties_semver_compliant_percentage]]**`semver_compliant_percentage`** *(number, required)*: Minimum: `0`. Maximum: `100`.
 * [[properties_patterns]]**`patterns`** *(array, required)*
 ** [[properties_patterns_items]]**Items** *(object)*: Cannot contain additional properties.

--- a/regis_cli/analyzers/versioning.py
+++ b/regis_cli/analyzers/versioning.py
@@ -237,7 +237,92 @@ class VersioningAnalyzer(BaseAnalyzer):
         )
         semver_compliant = round(semver_count / len(tags) * 100, 1) if tags else 0
 
-        return {
+        # Determine release lines if the current tag is an alias
+        current_pattern = _classify_tag(tag)
+        release_lines = []
+        if current_pattern not in ("semver", "semver-prerelease", "semver-variant"):
+            inspect_target = f"docker://{registry}/{repository}:{tag}"
+
+            inspect_cmd = ["skopeo", "inspect", inspect_target]
+            if platform:
+                try:
+                    os_str, arch = platform.split("/", 1)
+                    inspect_cmd.extend(
+                        ["--override-os", os_str, "--override-arch", arch]
+                    )
+                except ValueError:
+                    logger.debug(
+                        "Invalid platform format %s, ignoring for inspect", platform
+                    )
+            else:
+                # Default to linux/amd64 to avoid host architecture mismatch for multi-arch images
+                inspect_cmd.extend(
+                    ["--override-os", "linux", "--override-arch", "amd64"]
+                )
+
+            if client.username and client.password:
+                inspect_cmd.extend(["--creds", f"{client.username}:{client.password}"])
+
+            try:
+                res_inspect = subprocess.run(
+                    inspect_cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                inspect_data = json.loads(res_inspect.stdout)
+                repo_tags = inspect_data.get("RepoTags", [])
+
+                # Filter to numeric release tags (semver-like)
+                # We want 3, 3.14, 3.14.3 etc.
+                numeric_tags = []
+                for t in repo_tags:
+                    p = _classify_tag(t)
+                    if p in ("semver", "numeric"):
+                        # Ensure it's not a variant or prerelease (handled by _classify_tag)
+                        numeric_tags.append(t)
+
+                if numeric_tags:
+                    # Sort to find the most specific one
+                    # (3 < 3.14 < 3.14.3)
+                    numeric_tags.sort(
+                        key=lambda x: [
+                            int(c)
+                            for c in x.lstrip("v").split(".")
+                            if x.lstrip("v").replace(".", "").isdigit()
+                        ]
+                    )
+
+                    most_specific = numeric_tags[-1]
+                    # Identify hierarchy: if most specific is 3.14.3, we want [3, 3.14, 3.14.3]
+                    # But only if those tags actually exist in numeric_tags
+                    parts = most_specific.lstrip("v").split(".")
+                    hierarchy = []
+                    for i in range(1, len(parts) + 1):
+                        prefix = ".".join(parts[:i])
+                        # Handle "v" prefix if present
+                        if f"v{prefix}" in numeric_tags:
+                            hierarchy.append(f"v{prefix}")
+                        elif prefix in numeric_tags:
+                            hierarchy.append(prefix)
+
+                    release_lines = hierarchy
+
+                # Also fallback if no numeric hierarchy found
+                if not release_lines:
+                    semver_tags = [
+                        t
+                        for t in repo_tags
+                        if _classify_tag(t) in ("semver", "calver", "semver-variant")
+                    ]
+                    if semver_tags:
+                        semver_tags.sort(key=len, reverse=True)
+                        release_lines = [semver_tags[0]]
+
+            except Exception as e:
+                logger.debug("Failed to inspect %s to find release lines: %s", tag, e)
+
+        report = {
             "analyzer": self.name,
             "repository": repository,
             "total_tags": len(tags),
@@ -255,4 +340,7 @@ class VersioningAnalyzer(BaseAnalyzer):
                     variant_counts.items(), key=lambda x: x[1], reverse=True
                 )
             ],
+            "release_lines": release_lines,
         }
+
+        return report

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -56,6 +56,7 @@ def _format_output_path(template: str, report: dict[str, Any], fmt: str) -> Path
     context = {
         "repository": repo,
         "tag": req.get("tag", "latest"),
+        "digest": req.get("digest", req.get("tag", "latest")),
         "registry": req.get("registry", "unknown"),
         "timestamp": timestamp,
         "format": fmt,
@@ -185,7 +186,7 @@ main.add_command(gitlab_cmd, name="gitlab")
     "--output-dir",
     "output_dir_template",
     help="Base directory template for output files (e.g. 'reports/{repository}').",
-    default="reports/{registry}/{repository}/{tag}",
+    default="reports/{registry}/{repository}/{digest}",
 )
 @click.option(
     "--pretty/--no-pretty",
@@ -259,13 +260,32 @@ def analyze(
         err=True,
     )
 
+    from regis_cli.registry.auth import resolve_credentials
+
+    # Create the registry client early to fetch the digest.
+    username, password = resolve_credentials(ref.registry, list(auth) if auth else None)
+    client = RegistryClient(
+        registry=ref.registry,
+        repository=ref.repository,
+        username=username,
+        password=password,
+    )
+
+    try:
+        raw_digest = client.get_digest(ref.tag)
+        # Sanitize the digest for filesystem safety
+        digest = raw_digest.replace(":", "-") if raw_digest else ref.tag
+    except Exception as exc:
+        logger.debug("Failed to fetch digest: %s", exc)
+        digest = ref.tag
+
     # Select output formats.
     # JSON is always generated. HTML if --site is active.
     formats = ["json"]
     if site:
         formats.append("html")
 
-    dir_tmpl = output_dir_template or "reports/{registry}/{repository}/{tag}"
+    dir_tmpl = output_dir_template or "reports/{registry}/{repository}/{digest}"
     file_tmpl = output_template or "report.{format}"
 
     # 1. Check for cache if requested.
@@ -278,6 +298,7 @@ def analyze(
                 "registry": ref.registry,
                 "repository": ref.repository,
                 "tag": ref.tag,
+                "digest": digest,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         }
@@ -317,19 +338,6 @@ def analyze(
                 selected[name] = all_analyzers[name]
         else:
             selected = all_analyzers
-
-        from regis_cli.registry.auth import resolve_credentials
-
-        # Create the registry client.
-        username, password = resolve_credentials(
-            ref.registry, list(auth) if auth else None
-        )
-        client = RegistryClient(
-            registry=ref.registry,
-            repository=ref.repository,
-            username=username,
-            password=password,
-        )
 
         # Run each analyzer.
         reports: dict[str, Any] = {}
@@ -380,6 +388,7 @@ def analyze(
                 "registry": ref.registry,
                 "repository": ref.repository,
                 "tag": ref.tag,
+                "digest": digest,
                 "analyzers": sorted(reports.keys()),
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             },

--- a/regis_cli/registry/client.py
+++ b/regis_cli/registry/client.py
@@ -95,6 +95,38 @@ class RegistryClient:
         """
         return self._get(f"/{self.repository}/blobs/{digest}")
 
+    def get_digest(self, tag: str) -> str | None:
+        """Fetch the Docker-Content-Digest for a given tag using a HEAD request.
+
+        Args:
+            tag: The image tag.
+
+        Returns:
+            The digest string (e.g. ``sha256:abc...``), or None if not returned by the registry.
+
+        Raises:
+            RegistryError: If the API call fails.
+        """
+        accept = (
+            "application/vnd.oci.image.index.v1+json, "
+            "application/vnd.docker.distribution.manifest.list.v2+json, "
+            "application/vnd.oci.image.manifest.v1+json, "
+            "application/vnd.docker.distribution.manifest.v2+json"
+        )
+        url = self._base_url + f"/{self.repository}/manifests/{tag}"
+        headers = {"Accept": accept}
+
+        # Try without auth first, then authenticate on 401.
+        resp = self._request(url, headers, method="HEAD")
+        if resp.status_code == 401:
+            self._authenticate(resp)
+            resp = self._request(url, headers, method="HEAD")
+
+        if resp.status_code != 200:
+            raise RegistryError(f"Registry returned {resp.status_code} for HEAD {url}")
+
+        return resp.headers.get("Docker-Content-Digest")
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
@@ -129,14 +161,17 @@ class RegistryClient:
         self,
         url: str,
         headers: dict[str, str],
+        method: str = "GET",
     ) -> requests.Response:
-        """Execute a single GET request, attaching the bearer token if available."""
+        """Execute a single HTTP request, attaching the bearer token if available."""
         req_headers = {**headers}
         if self._token:
             req_headers["Authorization"] = f"Bearer {self._token}"
 
-        logger.debug("GET %s", url)
-        return self._session.get(url, headers=req_headers, timeout=self.timeout)
+        logger.debug("%s %s", method, url)
+        return self._session.request(
+            method, url, headers=req_headers, timeout=self.timeout
+        )
 
     def _authenticate(self, response: requests.Response) -> None:
         """Parse a ``WWW-Authenticate`` header and obtain a bearer token."""

--- a/regis_cli/schemas/report.schema.json
+++ b/regis_cli/schemas/report.schema.json
@@ -48,6 +48,10 @@
           "type": "string",
           "description": "Image tag that was analyzed."
         },
+        "digest": {
+          "type": "string",
+          "description": "Resolved image manifest digest (e.g. sha256-xxx), if available."
+        },
         "analyzers": {
           "type": "array",
           "items": { "type": "string" },

--- a/regis_cli/schemas/versioning.schema.json
+++ b/regis_cli/schemas/versioning.schema.json
@@ -21,6 +21,10 @@
       "type": "string",
       "enum": ["semver", "semver-prerelease", "semver-variant", "calver", "numeric", "hash", "named", "unknown"]
     },
+    "release_lines": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "semver_compliant_percentage": {
       "type": "number",
       "minimum": 0,

--- a/regis_cli/templates/default/analyzers/versioning/cards.html
+++ b/regis_cli/templates/default/analyzers/versioning/cards.html
@@ -5,9 +5,22 @@
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">DOMINANT PATTERN</strong><br>
         <span style="font-size: 1.5rem; font-weight: bold; line-height: 1;">{{ data.dominant_pattern | default('N/A') | e }}</span>
     </div>
+    {% if data.release_lines %}
+    <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
+        <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">RELEASE LINES</strong><br>
+        <span style="font-size: 1.1rem; font-weight: bold; line-height: 1.2; display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; margin-top: 4px;">
+            {% for line in data.release_lines %}
+            <kbd style="font-size: 0.9rem; padding: 2px 6px;">{{ line | e }}</kbd>
+            {% endfor %}
+        </span>
+    </div>
+    {% endif %}
     <div style="text-align: center; padding: var(--pico-spacing); background: var(--pico-card-background-color); border-radius: var(--pico-border-radius); box-shadow: var(--pico-card-box-shadow);">
         <strong style="font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.8;">SEMVER COMPLIANCE</strong><br>
-        <span style="font-size: 2rem; font-weight: bold; line-height: 1; {% if data.semver_compliant_percentage >= 80 %}color: var(--pico-ins-color);{% elif data.semver_compliant_percentage < 50 %}color: var(--pico-del-color);{% endif %}">
+        {% set color = 'inherit' %}
+        {% if data.semver_compliant_percentage >= 80 %}{% set color = 'var(--pico-ins-color)' %}
+        {% elif data.semver_compliant_percentage < 50 %}{% set color = 'var(--pico-del-color)' %}{% endif %}
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1; color: {{ color }};">
             {{ data.semver_compliant_percentage }}%
         </span>
     </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,7 +71,8 @@ class TestRegistryAuth:
         # 1. Initial request -> 401
         # 2. Token request -> 200
         # 3. Retried request -> 200
-        mock_session.get.side_effect = [resp_401, token_resp, resp_200]
+        mock_session.request.side_effect = [resp_401, resp_200]
+        mock_session.get.return_value = token_resp
 
         client = RegistryClient(
             "registry.example.com",
@@ -84,10 +85,11 @@ class TestRegistryAuth:
         client.list_tags()
 
         # Verify calls
-        assert mock_session.get.call_count == 3
+        assert mock_session.request.call_count == 2
+        assert mock_session.get.call_count == 1
 
-        # Check the token request (2nd call)
-        token_call = mock_session.get.call_args_list[1]
+        # Check the token request (only 1 call to get)
+        token_call = mock_session.get.call_args_list[0]
         args, kwargs = token_call
 
         assert args[0] == "https://auth.docker.io/token"
@@ -107,6 +109,7 @@ class TestRegistryAuth:
         mock_analyzer_instance = mock_analyzer_cls.return_value
         mock_analyzer_instance.analyze.return_value = {"some": "data"}
         mock_discover.return_value = {"test_analyzer": mock_analyzer_cls}
+        mock_client_cls.return_value.get_digest.return_value = None
 
         env = {
             "REGIS_USERNAME": "env_user",
@@ -197,6 +200,7 @@ class TestRegistryAuth:
         mock_analyzer_instance = mock_analyzer_cls.return_value
         mock_analyzer_instance.analyze.return_value = {"some": "data"}
         mock_discover.return_value = {"test_analyzer": mock_analyzer_cls}
+        mock_client_cls.return_value.get_digest.return_value = None
 
         result = runner.invoke(
             main,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,7 @@ class TestCliBasics:
                 pass
 
         mock_discover.return_value = {"dummy": DummyAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
 
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -105,6 +106,7 @@ class TestCliBasics:
                 pass
 
         mock_discover.return_value = {"dummy": DummyAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
 
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -148,6 +150,7 @@ class TestCliBasics:
                 pass
 
         mock_discover.return_value = {"dummy": DummyAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
 
         runner = CliRunner()
         with runner.isolated_filesystem():

--- a/tests/test_gh_env.py
+++ b/tests/test_gh_env.py
@@ -49,6 +49,7 @@ class TestGithubEnvironment:
                 pass
 
         mock_discover.return_value = {"dummy": DummyAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
 
         runner = CliRunner()
         with runner.isolated_filesystem():

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -256,3 +256,29 @@ class TestVersioningAnalyzer:
         assert v_map["micro"] == 1
         assert v_map["init"] == 1
         assert v_map["rhel"] == 1
+
+    @patch("regis_cli.analyzers.versioning.subprocess.run")
+    def test_release_line_detection_for_alias(self, mock_run):
+        """Test detection of release_line for alias tags."""
+        # mock_run will be called twice:
+        # 1. skopeo list-tags
+        # 2. skopeo inspect
+        mock_list_tags = MagicMock()
+        mock_list_tags.stdout = json.dumps({"Tags": ["1", "1.10", "1.10.4", "latest"]})
+
+        mock_inspect = MagicMock()
+        mock_inspect.stdout = json.dumps(
+            {"RepoTags": ["1", "1.10", "1.10.4", "latest"]}
+        )
+
+        mock_run.side_effect = [mock_list_tags, mock_inspect]
+
+        client = MockRegistryClient()
+        analyzer = VersioningAnalyzer()
+        report = analyzer.analyze(client, "library/test", "1")
+        analyzer.validate(report)
+
+        assert "release_lines" in report
+        assert report["release_lines"] == ["1", "1.10", "1.10.4"]
+        assert "release_line" not in report
+        assert mock_run.call_count == 2


### PR DESCRIPTION
This PR implements the following features:
- **Digest-based reporting**: Reports are now stored in repositories named after the image digest (e.g., `sha256-abcd...`) instead of the mutable tag. This ensures reports are uniquely associated with a specific image version.
- **Release Lines Hierarchy**: The `versioning` analyzer now identifies and reports the full hierarchy of numeric release lines sharing the same digest (e.g., `["3", "3.14", "3.14.3"]`).
- **HTML Reporting**: Added a new card in the versioning report to display the identified release lines as badges.
- **Schema & Documentation**: Updated the JSON schemas (`versioning.schema.json`, `report.schema.json`) and regenerated the documentation.
- **Tests**: Updated the test suite to validate the new digest fetching logic and versioning hierarchy.