### PR TITLE
docs(integrations): restructure integration sub-chapter and add cookiecutter tips

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -20,6 +20,10 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 - Updated `playbook.schema.json`, `engine.py`, `default.yaml`, and `test_playbook_engine.py` (27 tests pass).
 - Updated `docs/modules/ROOT/pages/playbooks.adoc` — checklist section documents `show_if`/`check_if`.
 - Updated `docs/modules/ROOT/pages/integrations/gitlab.adoc` — pipeline diagram and job descriptions reflect refactored pipeline.
+- Moved `cookiecutter.adoc` to `docs/modules/ROOT/pages/integrations/cookiecutter.adoc`.
+- Updated navigation to place Quickstart with Cookiecutter under Integrations.
+- Added utility tips for Cookiecutter template in both `github.adoc` and `gitlab.adoc`.
+
 
 ## Next Steps
 

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -11,7 +11,7 @@
 - Automated Antora documentation publishing to GitHub Pages.
 
 ## In Progress
-- Improving documentation for CI/CD integration.
+- Improving documentation for CI/CD integration (moved Cookiecutter, added tips).
 
 ## Future Roadmap
 - Additional analyzers (e.g., custom compliance checks).

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -6,7 +6,7 @@
 * Integrations
 ** xref:integrations/github.adoc[GitHub]
 ** xref:integrations/gitlab.adoc[GitLab]
-* xref:cookiecutter.adoc[Quickstart with Cookiecutter]
+** xref:integrations/cookiecutter.adoc[Quickstart with Cookiecutter]
 * Schemas
 ** xref:schemas/skopeo.adoc[Skopeo]
 ** xref:schemas/dockle.adoc[Dockle]

--- a/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
+++ b/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
@@ -78,7 +78,7 @@ The generated workflow is designed to publish reports to GitHub Pages.
 
 === 2. Configure Secrets (Optional)
 
-If you are analyzing private images, ensure your GitHub Actions environment has the necessary credentials (e.g., `GH_TOKEN` or registry logins) as described in the xref:integrations/github.adoc[GitHub Workflow guide].
+If you are analyzing private images, ensure your GitHub Actions environment has the necessary credentials (e.g., `GH_TOKEN` or registry logins) as described in the xref:github.adoc[GitHub Workflow guide].
 
 == Running Your First Analysis
 

--- a/docs/modules/ROOT/pages/integrations/github.adoc
+++ b/docs/modules/ROOT/pages/integrations/github.adoc
@@ -6,6 +6,12 @@ Integrating `regis-cli` into your GitHub Actions workflows allows you to automat
 
 To follow this guide, you should have a GitHub repository with a `Dockerfile` and a basic understanding of GitHub Actions.
 
+[TIP]
+====
+To quickly bootstrap a new GitHub repository pre-configured with `regis-cli` and GitHub Actions, you can use our xref:cookiecutter.adoc[Cookiecutter template].
+====
+
+
 == Workflow Setup
 
 A robust integration typically involves building your image, pushing it to a registry (like GitHub Container Registry), and then running `regis-cli` to analyze the results.

--- a/docs/modules/ROOT/pages/integrations/gitlab.adoc
+++ b/docs/modules/ROOT/pages/integrations/gitlab.adoc
@@ -9,19 +9,12 @@ This guide explains how to integrate `regis-cli` into your GitLab CI/CD pipeline
 * GitLab Runner with Docker executor.
 * (Optional) `glab` CLI installed locally.
 
-== Bootstrapping a New Project
 
-You can use `cookiecutter` to quickly create a new GitLab repository pre-configured for `regis-cli`.
+[TIP]
+====
+To quickly bootstrap a new GitLab repository pre-configured with `regis-cli` and GitLab CI, you can use our xref:cookiecutter.adoc[Cookiecutter template].
+====
 
-[source,bash]
-----
-# Generate the project from the unified template (choose 'gitlab')
-pipenv run cookiecutter cookiecutter/
-
-# Create the repository on GitLab and push
-cd <your-project-slug>
-glab repo create --public
-----
 
 == GitLab CI Configuration
 


### PR DESCRIPTION
This PR moves the Cookiecutter guide into the Integrations chapter and adds utility tips to the GitHub and GitLab integration guides to improve project bootstrapping discoverability.

Changes:
- Moved `docs/modules/ROOT/pages/cookiecutter.adoc` to `docs/modules/ROOT/pages/integrations/cookiecutter.adoc`
- Updated `docs/modules/ROOT/nav.adoc`
- Added utility tips to `docs/modules/ROOT/pages/integrations/github.adoc` and `docs/modules/ROOT/pages/integrations/gitlab.adoc`
- Updated memory bank (`activeContext.md` and `progress.md`)