### PR TITLE
docs: modernize getting started and project generation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ regis-cli analyze nginx:latest
 
 ### Advanced Reporting
 ```bash
-# Generate both JSON and HTML reports in a dedicated directory
-regis-cli analyze nginx:latest -f json -f html -s examples/all-reports.yaml
+# Generate both JSON and HTML reports
+regis-cli analyze nginx:latest --site
 ```
 
 ### Report Caching
 ```bash
 # Faster HTML generation by reusing previous analysis
-regis-cli analyze nginx:latest -f html --cache
+regis-cli analyze nginx:latest --site --cache
 ```
 
 ### Dynamic Output Paths

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -69,7 +69,7 @@ Reports are written to the `reports/` directory by default (e.g., `reports/docke
 
 [IMPORTANT]
 ====
-Our **GitLab integration** is currently the most feature-rich, offering automated Merge Request comments, status updates, and deep CI/CD pipeline integration.
+Our **xref:integrations/gitlab.adoc[GitLab integration]** is currently the most feature-rich, offering automated Merge Request comments, status updates, and deep CI/CD pipeline integration.
 ====
 
 == Next steps

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -1,65 +1,79 @@
 = Get Started
 
-This guide helps you install `regis-cli` and run your first container image analysis.
+`regis-cli` is a powerful Docker registry analysis tool designed to inspect container images, evaluate security policies via playbooks, and generate comprehensive reports.
 
 == Prerequisites
 
-Before you install `regis-cli`, ensure that your environment meets the following requirements:
+The requirements depend on whether you use the Docker image or install the tool locally.
 
-* **Python**: Version 3.10 or later.
-* **Pipenv**: For managing dependencies and virtual environments.
-* **External Tools**:
-** **Skopeo**: Used for multi-architecture registry inspection.
-** **Trivy** (Optional): Required for SBOM and vulnerability analysis.
-** **Hadolint** (Optional): Required for Dockerfile linting.
-** **Dockle** (Optional): Required for container image security linting.
+* **Core Requirement**:
+** **Skopeo**: Essential for multi-architecture registry inspection and metadata extraction.
+* **Optional Analyzers**:
+** **Trivy**: Required for vulnerability scanning and SBOM generation.
+** **Hadolint**: Required for Dockerfile linting.
+** **Dockle**: Required for container image security linting.
 
 == Installation
 
-To install `regis-cli` in your project, follow these steps:
+=== Docker (Recommended)
 
-1. Clone the repository or navigate to your project directory.
-2. Install the dependencies using Pipenv:
+The easiest way to use `regis-cli` without managing local dependencies is to use the official Docker image. It comes pre-packaged with Skopeo, Trivy, Hadolint, and Dockle.
 
 [source,bash]
 ----
-pipenv install
+docker run --rm trivoallan/regis-cli --help
 ----
 
-This command creates a virtual environment and installs all required packages as defined in the `Pipfile`.
+=== Local Installation
+
+If you prefer a local installation, ensure you have **Python 3.14 or later** and **Skopeo** installed in your system.
+
+[source,bash]
+----
+pip install regis-cli
+----
+
+[TIP]
+====
+For developers wanting to contribute to the project, use **Pipenv**:
+`pipenv install --dev`
+====
 
 == Run your first analysis
 
-You can analyze any public container image without additional configuration. To analyze the latest `nginx` image and view the results in your terminal as JSON, run the following command:
+You can analyze any public container image. By default, `regis-cli` produces a JSON report on `stdout`.
 
 [source,bash]
 ----
-pipenv run regis-cli analyze nginx:latest
+regis-cli analyze nginx:latest
 ----
 
-== Generate a report site
+=== Generating a Web Report
 
-To generate a rich HTML report instead of JSON output, use the `--site` (or `-s`) flag:
+To generate a rich HTML dashboard alongside the JSON report, use the `-f` (format) and `-s` (site) options:
 
 [source,bash]
 ----
-pipenv run regis-cli analyze nginx:latest --site
+regis-cli analyze nginx:latest -f json -f html --site
 ----
 
-By default, the tool writes reports to the `reports/` directory. You can find the HTML report at `reports/docker.io/library/nginx/latest/index.html`.
+Reports are written to the `reports/` directory by default (e.g., `reports/docker.io/library/nginx/latest/index.html`).
 
-== Use the security playbook
+== Advanced Tools
 
-To get the most out of `regis-cli`, you should evaluate your images against a security playbook. We recommend starting with our default playbook, which includes rules for vulnerability counts and image freshness:
+`regis-cli` includes specialized subcommands for advanced workflows:
 
-[source,bash]
-----
-pipenv run regis-cli analyze nginx:latest --site \
-  -p https://raw.githubusercontent.com/trivoallan/regis-cli/refs/heads/main/regis_cli/playbooks/default.yaml
-----
+* `generate`: Infrastructure as Code (IaC) for your analysis. Bootstrap a new Git repository with pre-configured CI/CD.
+* `evaluate`: Test playbooks against existing analysis reports without re-fetching image data.
+* `gitlab` / `github`: Seamless integration with CI/CD platforms.
+
+[IMPORTANT]
+====
+Our **GitLab integration** is currently the most feature-rich, offering automated Merge Request comments, status updates, and deep CI/CD pipeline integration.
+====
 
 == Next steps
 
-* **Registry Authentication**: Learn how to analyze private images by providing credentials.
-* **Custom Playbooks**: Define your own security and compliance rules in the xref:playbooks.adoc[Understand Playbooks] guide.
+* **Custom Playbooks**: Define your own security rules in the xref:playbooks.adoc[Understand Playbooks] guide.
+* **Project Bootstrapping**: Learn how to use `regis-cli generate` in the xref:integrations/cookiecutter.adoc[Quickstart with Cookiecutter] guide.
 * **CI/CD Integration**: See our guides for xref:integrations/github.adoc[GitHub Workflows] and xref:integrations/gitlab.adoc[GitLab CI].

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -57,7 +57,7 @@ To generate a rich HTML report alongside the JSON report, use the `--site` (or `
 regis-cli analyze nginx:latest --site
 ----
 
-Reports are written to the `reports/` directory by default (e.g., `reports/docker.io/library/nginx/latest/index.html`).
+Reports are written to the `reports/` directory by default (e.g., `reports/docker.io/library/nginx/sha256-.../index.html`).
 
 == Advanced Tools
 

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -50,11 +50,11 @@ regis-cli analyze nginx:latest
 
 === Generating a Web Report
 
-To generate a rich HTML dashboard alongside the JSON report, use the `-f` (format) and `-s` (site) options:
+To generate a rich HTML report alongside the JSON report, use the `--site` (or `-s`) flag:
 
 [source,bash]
 ----
-regis-cli analyze nginx:latest -f json -f html --site
+regis-cli analyze nginx:latest --site
 ----
 
 Reports are written to the `reports/` directory by default (e.g., `reports/docker.io/library/nginx/latest/index.html`).

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -65,7 +65,7 @@ Reports are written to the `reports/` directory by default (e.g., `reports/docke
 
 * `generate`: Infrastructure as Code (IaC) for your analysis. Bootstrap a new Git repository with pre-configured CI/CD.
 * `evaluate`: Test playbooks against existing analysis reports without re-fetching image data.
-* `gitlab` / `github`: Seamless integration with CI/CD platforms.
+* `gitlab`: Seamless integration with GitLab CI/CD for automated reporting and MR updates.
 
 [IMPORTANT]
 ====

--- a/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
+++ b/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
@@ -1,11 +1,11 @@
 = Quickstart with Cookiecutter
 
-The `regis-cli` Cookiecutter template allows you to bootstrap a new Git repository dedicated to container image analysis and security scoring.
+The `regis-cli` project generation feature allows you to bootstrap a new Git repository dedicated to container image analysis and security scoring. It uses a Cookiecutter template internally to set up everything you need.
 
 == Prerequisites
 
-* Install Cookiecutter: `pip install cookiecutter` or `brew install cookiecutter`
-* Access to the `regis-cli` repository (local or remote)
+* Access to the `regis-cli` repository (local or remote).
+* The `regis-cli` tool installed in your environment.
 
 == Creating a New Repository
 
@@ -13,11 +13,11 @@ Follow these steps to create your analysis project:
 
 === 1. Generate the Project
 
-Run Cookiecutter pointing to the `cookiecutter/` directory in this repository:
+Use the `regis-cli generate` command pointing to the `cookiecutter/` directory in this repository:
 
 [source,bash]
 ----
-pipenv run cookiecutter cookiecutter/
+regis-cli generate cookiecutter/
 ----
 
 [NOTE]
@@ -66,30 +66,27 @@ git commit -m "feat: initial bootstrap"
 
 == Post-Generation Setup
 
-To enable the fully automated reporting workflow, you must perform the following steps in your GitHub repository:
+To enable the fully automated reporting workflow, you must perform the following steps in your chosen platform:
 
-=== 1. Enable GitHub Pages
+=== For GitLab (Recommended)
 
-The generated workflow is designed to publish reports to GitHub Pages.
+The GitLab integration is highly automated. Simply push your code to a GitLab repository, and the pipelines will be ready. See xref:gitlab.adoc[GitLab CI] for details on report publishing.
+
+=== For GitHub
 
 . Go to your repository **Settings**.
 . Navigate to **Pages** in the sidebar.
 . Under **Build and deployment**, set the **Source** to **GitHub Actions**.
 
-=== 2. Configure Secrets (Optional)
-
-If you are analyzing private images, ensure your GitHub Actions environment has the necessary credentials (e.g., `GH_TOKEN` or registry logins) as described in the xref:github.adoc[GitHub Workflow guide].
-
 == Running Your First Analysis
 
-Once pushed to GitHub, you can trigger a manual analysis:
+Once pushed to your platform, you can trigger a manual analysis:
 
-. Go to the **Actions** tab in your repository.
-. Select the **Image Analysis** workflow.
-. Click **Run workflow**.
+. Locate the **Image Analysis** workflow/pipeline.
+. Run the job manually.
 . Enter the URL of the image you want to analyze (e.g., `ghcr.io/my-org/my-app:latest`).
 
-The workflow will run the analysis, commit the reports to your repository, and deploy the updated site to GitHub Pages.
+The workflow will run the analysis, commit the reports to your repository, and deploy the updated site.
 
 == Manual Usage
 
@@ -97,5 +94,5 @@ You can also run the analysis locally using the `--site` flag to generate the HT
 
 [source,bash]
 ----
-pipenv run regis-cli analyze my-image:latest --site
+regis-cli analyze my-image:latest -f html --site
 ----

--- a/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
+++ b/docs/modules/ROOT/pages/integrations/cookiecutter.adoc
@@ -94,5 +94,5 @@ You can also run the analysis locally using the `--site` flag to generate the HT
 
 [source,bash]
 ----
-regis-cli analyze my-image:latest -f html --site
+regis-cli analyze my-image:latest --site
 ----

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -93,7 +93,7 @@ It uses `Jinja2` templates to produce rich, themeable HTML reports for human rev
 
 The project uses the following technologies:
 
-* **Language**: Python 3.10+
+* **Language**: Python 3.14+
 * **Dependency Management**: Pipenv
 * **CLI Framework**: Click
 * **Templating**: Jinja2


### PR DESCRIPTION
This PR updates the "Get Started" and "Quickstart with Cookiecutter" documentation to reflect the current state of the project.

Key changes:
- Updated requirements (Python 3.14+, Core vs Optional tools).
- Added Docker as recommended installation method.
- Replaced manual `cookiecutter` instructions with `regis-cli generate`.
- Removed obsolete `-f`/`--format` flag from usage examples (JSON is now always generated, HTML is enabled via `--site`).
- Corrected the default output path example to use the image **digest (SHA)** instead of the tag.
- Removed the non-existent `github` subcommand (only `gitlab` is currently supported as a direct CLI command).
- Emphasized and linked to the **GitLab integration** documentation.