### PR TITLE
feat(ci): migrate linting to trunk and add mypy/hadolint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Super-Linter
+name: Trunk Check
 
 on:
   push:
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Lint Code Base
+  trunk:
+    name: Trunk Check
     runs-on: ubuntu-latest
 
     permissions:
@@ -20,17 +20,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
-          fetch-depth: 0
 
-      - name: Lint Code Base
-        uses: github/super-linter@v5
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Python specific
-          VALIDATE_PYTHON_RUFF: true
-          VALIDATE_PYTHON_MYPY: true
-          VALIDATE_DOCKERFILE_HADOLINT: true
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
       packages: read
       statuses: write
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout Code

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.hadolint.yaml
+++ b/.trunk/configs/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Following source doesn't work in most setups
+ignored:
+  - SC1090
+  - SC1091

--- a/.trunk/configs/.isort.cfg
+++ b/.trunk/configs/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends: markdownlint/style/prettier

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,5 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,40 @@
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version: 0.1
+cli:
+  version: 1.25.0
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.7.5
+      uri: https://github.com/trunk-io/plugins
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+runtimes:
+  enabled:
+    - node@22.16.0
+    - python@3.10.8
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+lint:
+  enabled:
+    - hadolint@2.14.0
+    - mypy@1.19.1
+    - bandit@1.9.4
+    - black@26.1.0
+    - checkov@3.2.507
+    - git-diff-check
+    - isort@8.0.1
+    - markdownlint@0.48.0
+    - osv-scanner@2.3.3
+    - prettier@3.8.1
+    - ruff@0.15.4
+    - taplo@0.10.0
+    - trufflehog@3.93.7
+    - yamllint@1.38.0
+actions:
+  disabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+  enabled:
+    - trunk-upgrade-available

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,7 @@
+---
 # This file controls the behavior of Trunk: https://docs.trunk.io/cli
-# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+# To learn more about the format of this file, see
+# https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
   version: 1.25.0
@@ -9,12 +11,14 @@ plugins:
     - id: trunk
       ref: v1.7.5
       uri: https://github.com/trunk-io/plugins
-# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+# Many linters and tools depend on runtimes - configure them here.
+# (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
     - node@22.16.0
     - python@3.10.8
-# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+# This is the section where you manage your linters.
+# (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
     - hadolint@2.14.0

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -21,6 +21,7 @@ runtimes:
 # (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - actionlint@1.7.8
     - hadolint@2.14.0
     - mypy@1.19.1
     - bandit@1.9.4
@@ -31,7 +32,7 @@ lint:
     - markdownlint@0.48.0
     - osv-scanner@2.3.3
     - prettier@3.8.1
-    - ruff@0.15.4
+    - ruff@0.15.5
     - taplo@0.10.0
     - trufflehog@3.93.7
     - yamllint@1.38.0

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,9 @@ pytest-cov = ">=4.1"
 responses = ">=0.24"
 ruff = "*"
 jsonschema2md = "*"
+types-PyYAML = "*"
+types-requests = "*"
+types-jsonschema = "*"
 
 [requires]
 python_version = "3.14"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4a67767b2c159fc0156023d8365a7d19f5eab478c93576e60cd7ad21a51e096d"
+            "sha256": "805ca278b0e413a6960fb736539e83bfd2d2507afc3a85f5b0784c5c8d57b801"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -683,6 +683,14 @@
         }
     },
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11",
+                "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==25.4.0"
+        },
         "babel": {
             "hashes": [
                 "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d",
@@ -1088,6 +1096,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.0.3"
         },
+        "referencing": {
+            "hashes": [
+                "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa",
+                "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.36.2"
+        },
         "requests": {
             "hashes": [
                 "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
@@ -1106,30 +1123,178 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.26.0"
         },
+        "rpds-py": {
+            "hashes": [
+                "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f",
+                "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136",
+                "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3",
+                "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7",
+                "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65",
+                "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4",
+                "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169",
+                "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf",
+                "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4",
+                "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2",
+                "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c",
+                "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4",
+                "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3",
+                "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6",
+                "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7",
+                "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89",
+                "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85",
+                "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6",
+                "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa",
+                "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb",
+                "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6",
+                "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87",
+                "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856",
+                "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4",
+                "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f",
+                "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53",
+                "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229",
+                "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad",
+                "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23",
+                "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db",
+                "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038",
+                "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27",
+                "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00",
+                "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18",
+                "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083",
+                "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c",
+                "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738",
+                "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898",
+                "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e",
+                "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7",
+                "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08",
+                "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6",
+                "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551",
+                "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e",
+                "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288",
+                "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df",
+                "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0",
+                "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2",
+                "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05",
+                "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0",
+                "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464",
+                "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5",
+                "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404",
+                "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7",
+                "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139",
+                "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394",
+                "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb",
+                "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15",
+                "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff",
+                "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed",
+                "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6",
+                "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e",
+                "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95",
+                "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d",
+                "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950",
+                "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3",
+                "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5",
+                "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97",
+                "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e",
+                "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e",
+                "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b",
+                "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd",
+                "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad",
+                "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8",
+                "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425",
+                "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221",
+                "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d",
+                "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825",
+                "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51",
+                "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e",
+                "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f",
+                "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8",
+                "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f",
+                "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d",
+                "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07",
+                "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877",
+                "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31",
+                "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58",
+                "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94",
+                "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28",
+                "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000",
+                "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1",
+                "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1",
+                "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7",
+                "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7",
+                "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40",
+                "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d",
+                "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0",
+                "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84",
+                "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f",
+                "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a",
+                "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7",
+                "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419",
+                "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8",
+                "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a",
+                "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9",
+                "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be",
+                "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed",
+                "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a",
+                "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d",
+                "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324",
+                "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f",
+                "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2",
+                "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f",
+                "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.30.0"
+        },
         "ruff": {
             "hashes": [
-                "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f",
-                "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68",
-                "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1",
-                "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac",
-                "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3",
-                "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec",
-                "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992",
-                "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453",
-                "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22",
-                "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a",
-                "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338",
-                "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0",
-                "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba",
-                "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f",
-                "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75",
-                "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85",
-                "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc",
-                "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db"
+                "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752",
+                "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681",
+                "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204",
+                "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c",
+                "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd",
+                "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080",
+                "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74",
+                "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2",
+                "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe",
+                "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010",
+                "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8",
+                "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca",
+                "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2",
+                "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b",
+                "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65",
+                "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a",
+                "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d",
+                "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.15.4"
+            "version": "==0.15.5"
+        },
+        "types-jsonschema": {
+            "hashes": [
+                "sha256:29831baa4308865a9aec547a61797a06fc152b0dac8dddd531e002f32265cb07",
+                "sha256:41c95343abc4de9264e333a55e95dfb4d401e463856d0164eec9cb182e8746da"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.26.0.20260202"
+        },
+        "types-pyyaml": {
+            "hashes": [
+                "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3",
+                "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.0.12.20250915"
+        },
+        "types-requests": {
+            "hashes": [
+                "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f",
+                "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.4.20260107"
         },
         "urllib3": {
             "hashes": [

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -20,10 +20,8 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 - Updated `playbook.schema.json`, `engine.py`, `default.yaml`, and `test_playbook_engine.py` (27 tests pass).
 - Updated `docs/modules/ROOT/pages/playbooks.adoc` — checklist section documents `show_if`/`check_if`.
 - Updated `docs/modules/ROOT/pages/integrations/gitlab.adoc` — pipeline diagram and job descriptions reflect refactored pipeline.
-- Moved `cookiecutter.adoc` to `docs/modules/ROOT/pages/integrations/cookiecutter.adoc`.
-- Updated navigation to place Quickstart with Cookiecutter under Integrations.
-- Added utility tips for Cookiecutter template in both `github.adoc` and `gitlab.adoc`.
-- Added C4 Context and Container diagrams to `docs/modules/ROOT/pages/overview.adoc`.
+- Improved documentation for CI/CD integration (moved Cookiecutter, added tips, added C4 diagrams).
+- Unified linting experience by migrating to Trunk.
 - Refactored `generate` command into a `bootstrap` command group:
   - `bootstrap repository` — recreates the project repository from renamed `cookiecutters/repository` template.
   - `bootstrap playbook` — creates a new custom playbook from the newly added `cookiecutters/playbook` template.
@@ -35,10 +33,14 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 - Consolidated bootstrapping documentation:
   - Removed obsolete `docs/modules/ROOT/pages/integrations/cookiecutter.adoc`.
   - Added `#bootstrap` anchor to `commands.adoc`.
-  - Updated links in `index.adoc`, `get-started.adoc`, `github.adoc`, and `gitlab.adoc` to point to the new anchor.
-  - Removed `cookiecutter.adoc` from `nav.adoc`.
+- Updated links in `index.adoc`, `get-started.adoc`, `github.adoc`, and `gitlab.adoc` to point to the new anchor.
+- Removed `cookiecutter.adoc` from `nav.adoc`.
+- Migrated CI linting from Super-Linter to Trunk:
+  - Enabled `mypy` and `hadolint` in Trunk.
+  - Added necessary type stubs for `PyYAML`, `requests`, and `jsonschema`.
+  - Replaced `github/super-linter` with `trunk-io/trunk-action` in GitHub Actions.
 
 
 ## Next Steps
 
-- Commit and open a PR with conventional commit message covering these changes.
+- Push the `feat/trunk-linting` branch and open a PR.

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -40,7 +40,6 @@ Documentation update following the pipeline refactoring and checklist enhancemen
   - Added necessary type stubs for `PyYAML`, `requests`, and `jsonschema`.
   - Replaced `github/super-linter` with `trunk-io/trunk-action` in GitHub Actions.
 
-
 ## Next Steps
 
 - Push the `feat/trunk-linting` branch and open a PR.

--- a/docs/memory-bank/decisionLog.md
+++ b/docs/memory-bank/decisionLog.md
@@ -16,3 +16,4 @@
 - **Decision**: Update `evaluate` in `engine.py` to add type checking and safety guards for playbook links.
 - **Decision**: Integrate GitHub Actions metadata into the template workflow using `regis-cli --meta`.
 - **Rationale**: Prevent `AttributeError` crashes when link URLs are null or missing in playbook definitions. Improved metadata integration ensures better traceability in CI/CD.
+- 2026-03-05: Migrated CI linting from Super-Linter to Trunk to unify local and CI linting experience and improve performance.

--- a/docs/memory-bank/decisionLog.md
+++ b/docs/memory-bank/decisionLog.md
@@ -1,18 +1,22 @@
 # Decision Log
 
 ## 2026-02-20: Handle Skopeo Architecture Mismatch
+
 - **Decision**: Avoid high-level `skopeo inspect` on image indexes when the local architecture doesn't match the remote index.
 - **Rationale**: Prevent "no image found" errors (exit status 1) when analyzing multi-arch images on local dev machines (e.g., Apple Silicon).
 
 ## 2026-02-20: Automated Docs Publishing
+
 - **Decision**: Implement GitHub Actions workflow to build and publish Antora site to GitLab Pages.
 - **Rationale**: Automate documentation deployment to ensure it stays up-to-date with the code.
 
 ## 2026-02-20: Cookiecutter Template for Consumer Repos
+
 - **Decision**: Create a Cookiecutter template to bootstrap new repositories for `regis-cli` users.
 - **Rationale**: Facilitate adoption and standardize the setup for image analysis projects, including CI/CD and security policies.
 
 ## 2026-02-20: Fix Missing Playbook Values
+
 - **Decision**: Update `evaluate` in `engine.py` to add type checking and safety guards for playbook links.
 - **Decision**: Integrate GitHub Actions metadata into the template workflow using `regis-cli --meta`.
 - **Rationale**: Prevent `AttributeError` crashes when link URLs are null or missing in playbook definitions. Improved metadata integration ensures better traceability in CI/CD.

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -11,7 +11,8 @@
 - Automated Antora documentation publishing to GitHub Pages.
 
 ## In Progress
-- Improving documentation for CI/CD integration (moved Cookiecutter, added tips, added C4 diagrams).
+- Improved documentation for CI/CD integration (moved Cookiecutter, added tips, added C4 diagrams).
+- Unified linting experience by migrating to Trunk.
 
 ## Future Roadmap
 - Additional analyzers (e.g., custom compliance checks).

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -1,6 +1,7 @@
 # Progress
 
 ## Completed
+
 - Core CLI functionality.
 - Key analyzers (Skopeo, Trivy, Hadolint, etc.).
 - Playbook evaluation with JSON logic.
@@ -11,10 +12,12 @@
 - Automated Antora documentation publishing to GitHub Pages.
 
 ## In Progress
+
 - Improved documentation for CI/CD integration (moved Cookiecutter, added tips, added C4 diagrams).
 - Unified linting experience by migrating to Trunk.
 
 ## Future Roadmap
+
 - Additional analyzers (e.g., custom compliance checks).
 - More HTML themes.
 - Enhanced reporting features.


### PR DESCRIPTION
This PR migrates the CI linting workflow from **Super-Linter** to **Trunk Check**.

### Changes:
- **Unified Linting**: Enabled `mypy` and `hadolint` in `.trunk/trunk.yaml` to match CI checks.
- **CI Migration**: Replaced `github/super-linter` with `trunk-io/trunk-action` in `.github/workflows/lint.yml`.
- **Dependency Updates**: Added missing `mypy` type stubs (`types-PyYAML`, `types-requests`, `types-jsonschema`) to `Pipfile`.
- **Memory Bank Updated**: Documented the transition in `activeContext.md`, `decisionLog.md`, and `progress.md`.

### Verification:
- Ran `trunk check --all` locally.
- Verified that `mypy` correctly identifies type issues in `regis_cli/cli.py`.
- User verified `trunk install` locally.