### PR TITLE
docs(playbook): mention bootstrap playbook in playbook documentation

### DIFF
--- a/docs/modules/ROOT/pages/playbooks.adoc
+++ b/docs/modules/ROOT/pages/playbooks.adoc
@@ -189,6 +189,17 @@ integrations:
 
 During evaluation, templates whose condition passes are aggregated. The CLI then executes these templates with access to the full analysis context (e.g., `cookiecutter.regis.score`), and writes the generated files back to the current working directory so they can be committed to the MR branch.
 
+== Creating a Custom Playbook
+
+While you can write a playbook from scratch, the easiest way to start is by using the `bootstrap playbook` command. This creates a new directory with a pre-configured playbook template and all necessary files.
+
+[source,bash]
+----
+regis-cli bootstrap playbook my-custom-playbook
+----
+
+This command will prompt you for basic information (name, slug, etc.) and generate a skeleton playbook that you can then customize with your own rules and scorecards. For more information, see the xref:commands.adoc#bootstrap[Bootstrapping Reference].
+
 == Example Playbook
 
 The following example shows a simplified playbook definition:


### PR DESCRIPTION
Mention the `bootstrap playbook` command in the playbook documentation to guide users on how to start a new custom playbook.

This change adds a new section "Creating a Custom Playbook" to the `playbooks.adoc` file, providing an example command and linking to the bootstrapping reference.