### PR TITLE
chore(docs): fix image rendering on GitHub using details tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Comprehensive documentation, including installation and usage guides, is availab
 | `size`       | Analyzes image size and layer distribution for optimization.                           |
 | `versioning` | Ensures semantic versioning consistency and tag validation.                            |
 
-## License
-
-MIT
-
 ---
 
 ## Report Preview

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ MIT
 
 ---
 
-`regis-cli` generates high-quality, interactive HTML dashboards. Below is a preview of the different sections available in a standard report.
+## Report Preview
+
+`regis-cli` generates high-quality, interactive HTML dashboards.
+ Below is a preview of the different sections available in a standard report.
 
 **[Explore the interactive Alpine example report here](https://trivoallan.github.io/regis-cli/regis-cli/0.14.0/_attachments/examples/alpine/index.html)**
 

--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ Comprehensive documentation, including installation and usage guides, is availab
 <br>
 <img src=".github/assets/report-technical-details.png" alt="Technical Details" width="100%">
 </details>
+
+---
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -35,24 +35,48 @@ MIT
 
 ---
 
-## Report Preview
-
 `regis-cli` generates high-quality, interactive HTML dashboards. Below is a preview of the different sections available in a standard report.
 
 **[Explore the interactive Alpine example report here](https://trivoallan.github.io/regis-cli/regis-cli/0.14.0/_attachments/examples/alpine/index.html)**
 
-```carousel
-![Dashboard Overview](.github/assets/report-overview.png)
-<!-- slide -->
-![Compliance Analysis](.github/assets/report-compliance.png)
-<!-- slide -->
-![Vulnerability Security](.github/assets/report-security.png)
-<!-- slide -->
-![Supply Chain & Quality](.github/assets/report-supply-chain.png)
-<!-- slide -->
-![Best Practices](.github/assets/report-best-practices.png)
-<!-- slide -->
-![Insights & Lifecycle](.github/assets/report-insights.png)
-<!-- slide -->
-![Technical Details](.github/assets/report-technical-details.png)
-```
+<details>
+<summary>📈 Dashboard Overview</summary>
+<br>
+<img src=".github/assets/report-overview.png" alt="Dashboard Overview" width="100%">
+</details>
+
+<details>
+<summary>✅ Compliance Analysis</summary>
+<br>
+<img src=".github/assets/report-compliance.png" alt="Compliance Analysis" width="100%">
+</details>
+
+<details>
+<summary>🛡️ Vulnerability & Security</summary>
+<br>
+<img src=".github/assets/report-security.png" alt="Vulnerability Security" width="100%">
+</details>
+
+<details>
+<summary>🔗 Supply Chain & Quality</summary>
+<br>
+<img src=".github/assets/report-supply-chain.png" alt="Supply Chain & Quality" width="100%">
+</details>
+
+<details>
+<summary>✨ Best Practices</summary>
+<br>
+<img src=".github/assets/report-best-practices.png" alt="Best Practices" width="100%">
+</details>
+
+<details>
+<summary>💡 Insights & Lifecycle</summary>
+<br>
+<img src=".github/assets/report-insights.png" alt="Insights & Lifecycle" width="100%">
+</details>
+
+<details>
+<summary>⚙️ Technical Details</summary>
+<br>
+<img src=".github/assets/report-technical-details.png" alt="Technical Details" width="100%">
+</details>


### PR DESCRIPTION
The previous `carousel` syntax was not supported by GitHub's README renderer, resulting in raw markdown being shown. 

This PR replaces the `carousel` with a series of `<details>` tags for each report page. This maintains a clean, compact README while ensuring that the screenshots are correctly rendered and accessible to users on GitHub.

Key changes:
- Replaced `carousel` with `<details>`/`<img>` tags in `README.md`.
- Restored the "Report Preview" header.