### PR TITLE
feat(ci): add OCI image labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Use an official Python slim image as base
 FROM python:3.12-slim
 
+# OCI Labels
+LABEL org.opencontainers.image.source="https://github.com/trivoallan/regis-cli" \
+      org.opencontainers.image.description="Container Security & Policy-as-Code Orchestration. Unified analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD." \
+      org.opencontainers.image.licenses="MIT"
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -44,6 +44,7 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 - Corrected the Alpine example report URL in `README.md` to point to the versioned documentation path.
 - Added `README.md` to `release-please-config.json` `extra-files` to ensure consistent versioning and updates.
 - Redesign of `README.md` now properly redirects all technical documentation to the official Antora site.
+- Added OCI-compliant labels to `Dockerfile` for better GitHub Packages integration (`source`, `description`, `licenses`).
 
 ## Next Steps
 

--- a/docs/memory-bank/decisionLog.md
+++ b/docs/memory-bank/decisionLog.md
@@ -21,3 +21,8 @@
 - **Decision**: Integrate GitHub Actions metadata into the template workflow using `regis-cli --meta`.
 - **Rationale**: Prevent `AttributeError` crashes when link URLs are null or missing in playbook definitions. Improved metadata integration ensures better traceability in CI/CD.
 - 2026-03-05: Migrated CI linting from Super-Linter to Trunk to unify local and CI linting experience and improve performance.
+
+## 2026-03-05: Adopt OCI Image Labels
+
+- **Decision**: Add standard OCI labels (`org.opencontainers.image.*`) to the project's `Dockerfile`.
+- **Rationale**: Improve discoverability and integration with GitHub Packages registry, ensuring the image description and source repository are automatically linked on the package page.


### PR DESCRIPTION
Add OCI-compliant labels to the project's `Dockerfile` to ensure that GitHub Packages correctly displays the image description, source repository, and license information.

### Changes
- Updated `Dockerfile` with standard OCI labels (`org.opencontainers.image.*`).
- Updated Memory Bank (`activeContext.md` and `decisionLog.md`) to reflect these changes.

Following suggestions from [GitHub documentation](https://docs.github.com/fr/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images).