### PR TITLE
feat(ci): allow Docker authentication to prevent rate limits

### DIFF
--- a/cookiecutters/repository/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/cookiecutters/repository/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -10,6 +10,9 @@ spec:
 variables:
   # Default image — override with a CI/CD project variable named REGIS_CLI_IMAGE
   REGIS_CLI_IMAGE: "{{ cookiecutter.regis_cli_image_base }}:{{ cookiecutter.version }}"
+  # To avoid Docker Hub rate limits, you can set DOCKER_AUTH_CONFIG,
+  # REGIS_AUTH_DOCKER_IO_USERNAME/PASSWORD, or DOCKER_HUB_USERNAME/PASSWORD
+  # as CI/CD variables in your project settings.
 stages:
   - request
   - analyze

--- a/docs/modules/ROOT/pages/integrations/gitlab.adoc
+++ b/docs/modules/ROOT/pages/integrations/gitlab.adoc
@@ -206,5 +206,36 @@ pages:
         PAGES_PREFIX: ""
 ----
 
-This configuration generates a unique URL for each Merge Request (e.g., `\https://<namespace>.gitlab.io/<project>/review-123/`).
+This configuration generates a unique URL for each Merge Request (e.g., `https://<namespace>.gitlab.io/<project>/review-123/`).
 
+== Registry Authentication
+
+To avoid rate limits on public registries (like Docker Hub) or to analyze images from private registries, you can configure authentication using several methods.
+
+The following environment variables can be set in **Settings > CI/CD > Variables**:
+
+=== 1. Docker Config (Recommended)
+Set `DOCKER_AUTH_CONFIG` to a JSON string matching the content of a standard `~/.docker/config.json`. This is the standard GitLab method for runner authentication.
+
+[source,json]
+----
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "base64(username:password)"
+    }
+  }
+}
+----
+
+=== 2. regis-cli Specific Variables
+You can set domain-specific or global variables:
+
+* `REGIS_AUTH_<DOMAIN>_USERNAME` & `REGIS_AUTH_<DOMAIN>_PASSWORD`: (e.g., `REGIS_AUTH_DOCKER_IO_USERNAME`).
+* `REGIS_USERNAME` & `REGIS_PASSWORD`: Global fallback for all registries.
+
+=== 3. Standard Environment Variables
+`regis-cli` also supports standard Docker Cloud/Hub environment variables for `docker.io` registry:
+
+* `DOCKER_HUB_USERNAME` & `DOCKER_HUB_PASSWORD`
+* `DOCKER_USERNAME` & `DOCKER_PASSWORD`

--- a/regis_cli/registry/auth.py
+++ b/regis_cli/registry/auth.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -48,58 +49,87 @@ def resolve_credentials(
     # 2. Check domain-specific environment variables
     for alias in sorted(aliases):
         env_domain = alias.upper().replace(".", "_").replace(":", "_").replace("-", "_")
-        domain_user = os.environ.get(f"REGIS_AUTH_{env_domain}_USERNAME")
-        domain_pass = os.environ.get(f"REGIS_AUTH_{env_domain}_PASSWORD")
+        domain_user: str | None = os.environ.get(f"REGIS_AUTH_{env_domain}_USERNAME")
+        domain_pass: str | None = os.environ.get(f"REGIS_AUTH_{env_domain}_PASSWORD")
         if domain_user and domain_pass:
             logger.debug(
                 "Using domain-specific env vars for %s (via alias %s)", registry, alias
             )
             return domain_user, domain_pass
 
-    # 3. Check global environment variables
-    global_user = os.environ.get("REGIS_USERNAME")
-    global_pass = os.environ.get("REGIS_PASSWORD")
+    # 3. Check DOCKER_AUTH_CONFIG environment variable (JSON string)
+    docker_auth_config = os.environ.get("DOCKER_AUTH_CONFIG")
+    if docker_auth_config:
+        try:
+            config = json.loads(docker_auth_config)
+            docker_auth_user, docker_auth_pwd = _extract_from_docker_config(
+                registry, config, aliases
+            )
+            if docker_auth_user and docker_auth_pwd:
+                logger.debug("Using DOCKER_AUTH_CONFIG env var for %s", registry)
+                return docker_auth_user, docker_auth_pwd
+        except Exception as e:
+            logger.debug("Failed to parse DOCKER_AUTH_CONFIG: %s", e)
+
+    # 4. Check registry-specific fallbacks (e.g. Docker Hub)
+    if registry in ("registry-1.docker.io", "docker.io", "index.docker.io"):
+        for prefix in ("DOCKER_HUB", "DOCKER"):
+            prefix_user: str | None = os.environ.get(f"{prefix}_USERNAME")
+            prefix_pwd: str | None = os.environ.get(f"{prefix}_PASSWORD")
+            if prefix_user and prefix_pwd:
+                logger.debug("Using %s_* env vars for %s", prefix, registry)
+                return prefix_user, prefix_pwd
+
+    # 5. Check global environment variables
+    global_user: str | None = os.environ.get("REGIS_USERNAME")
+    global_pass: str | None = os.environ.get("REGIS_PASSWORD")
     if global_user and global_pass:
         logger.debug("Using global env vars for %s", registry)
         return global_user, global_pass
 
-    # 4. Check Docker config.json
+    # 6. Check Docker config.json
     try:
         docker_config_path = Path.home() / ".docker" / "config.json"
         if docker_config_path.exists():
             with open(docker_config_path, "r", encoding="utf-8") as f:
                 config = json.load(f)
-            auths = config.get("auths", {})
-
-            candidates = [
-                registry,
-                f"https://{registry}",
-                f"https://{registry}/v1/",
-                f"https://{registry}/v2/",
-                (
-                    "https://index.docker.io/v1/"
-                    if registry in ("docker.io", "registry-1.docker.io")
-                    else registry
-                ),
-            ]
-            for candidate in candidates:
-                if candidate in auths and "auth" in auths[candidate]:
-                    auth_b64 = auths[candidate]["auth"]
-                    try:
-                        auth_str = base64.b64decode(auth_b64).decode("utf-8")
-                        if ":" in auth_str:
-                            user, pwd = auth_str.split(":", 1)
-                            logger.debug(
-                                "Using Docker config.json credentials for %s", registry
-                            )
-                            return user, pwd
-                    except Exception as e:
-                        logger.debug(
-                            "Failed to decode auth from config.json for %s: %s",
-                            candidate,
-                            e,
-                        )
+            user_config, pwd_config = _extract_from_docker_config(
+                registry, config, aliases
+            )
+            if user_config and pwd_config:
+                logger.debug("Using Docker config.json credentials for %s", registry)
+                return user_config, pwd_config
     except Exception as e:
         logger.debug("Failed to read ~/.docker/config.json: %s", e)
 
+    return None, None
+
+
+def _extract_from_docker_config(
+    registry: str, config: dict[str, Any], aliases: set[str]
+) -> tuple[str | None, str | None]:
+    """Extract credentials from a Docker config-style dictionary."""
+    auths = config.get("auths", {})
+    candidates = [
+        registry,
+        f"https://{registry}",
+        f"https://{registry}/v1/",
+        f"https://{registry}/v2/",
+    ]
+    if registry in ("docker.io", "registry-1.docker.io", "index.docker.io"):
+        candidates.append("https://index.docker.io/v1/")
+
+    for candidate in candidates:
+        if candidate in auths and "auth" in auths[candidate]:
+            auth_b64 = auths[candidate]["auth"]
+            try:
+                auth_str = base64.b64decode(auth_b64).decode("utf-8")
+                if ":" in auth_str:
+                    return tuple(auth_str.split(":", 1))  # type: ignore[return-value]
+            except Exception as e:
+                logger.debug(
+                    "Failed to decode auth from config for %s: %s",
+                    candidate,
+                    e,
+                )
     return None, None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# trunk-ignore-all(bandit/B101)

--- a/tests/test_analyzer_dockle.py
+++ b/tests/test_analyzer_dockle.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_freshness.py
+++ b/tests/test_analyzer_freshness.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_hadolint.py
+++ b/tests/test_analyzer_hadolint.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_popularity.py
+++ b/tests/test_analyzer_popularity.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import pytest
 import requests
 import responses

--- a/tests/test_analyzer_provenance.py
+++ b/tests/test_analyzer_provenance.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_analyzer_scorecard.py
+++ b/tests/test_analyzer_scorecard.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzer_size.py
+++ b/tests/test_analyzer_size.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_skopeo.py
+++ b/tests/test_analyzer_skopeo.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_trivy.py
+++ b/tests/test_analyzer_trivy.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import pytest
 
 from regis_cli.analyzers.base import AnalyzerError

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -222,3 +223,50 @@ class TestRegistryAuth:
 
         assert kwargs["username"] == "override_user"
         assert kwargs["password"] == "override_pass"
+
+    def test_resolve_credentials_from_docker_auth_config_env(self):
+        """Test resolve_credentials from DOCKER_AUTH_CONFIG env var."""
+        from regis_cli.registry.auth import resolve_credentials
+
+        auth_config = {
+            "auths": {
+                "registry.example.com": {
+                    "auth": "ZW52X2NvbmZpZ191c2VyOmVudl9jb25maWdfcGFzcw=="  # env_config_user:env_config_pass
+                }
+            }
+        }
+        env = {"DOCKER_AUTH_CONFIG": json.dumps(auth_config)}
+        with patch.dict(os.environ, env, clear=True):
+            user, pwd = resolve_credentials("registry.example.com")
+            assert user == "env_config_user"
+            assert pwd == "env_config_pass"
+
+    def test_resolve_credentials_from_docker_hub_env(self):
+        """Test resolve_credentials from DOCKER_HUB_* and DOCKER_* env vars."""
+        from regis_cli.registry.auth import resolve_credentials
+
+        # Test DOCKER_HUB_*
+        env = {
+            "DOCKER_HUB_USERNAME": "hub_user",
+            "DOCKER_HUB_PASSWORD": "hub_password",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            user, pwd = resolve_credentials("docker.io")
+            assert user == "hub_user"
+            assert pwd == "hub_password"
+
+        # Test DOCKER_*
+        env = {
+            "DOCKER_USERNAME": "docker_user",
+            "DOCKER_PASSWORD": "docker_password",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            user, pwd = resolve_credentials("registry-1.docker.io")
+            assert user == "docker_user"
+            assert pwd == "docker_password"
+
+        # Verify not used for other registries
+        with patch.dict(os.environ, env, clear=True):
+            user, pwd = resolve_credentials("ghcr.io")
+            assert user is None
+            assert pwd is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -240,7 +240,7 @@ class TestRegistryAuth:
         with patch.dict(os.environ, env, clear=True):
             user, pwd = resolve_credentials("registry.example.com")
             assert user == "env_config_user"
-            assert pwd == "env_config_pass"
+            assert pwd == "env_config_pass"  # trunk-ignore(bandit/B105)
 
     def test_resolve_credentials_from_docker_hub_env(self):
         """Test resolve_credentials from DOCKER_HUB_* and DOCKER_* env vars."""
@@ -249,22 +249,22 @@ class TestRegistryAuth:
         # Test DOCKER_HUB_*
         env = {
             "DOCKER_HUB_USERNAME": "hub_user",
-            "DOCKER_HUB_PASSWORD": "hub_password",
+            "DOCKER_HUB_PASSWORD": "hub_password",  # trunk-ignore(bandit/B105)
         }
         with patch.dict(os.environ, env, clear=True):
             user, pwd = resolve_credentials("docker.io")
             assert user == "hub_user"
-            assert pwd == "hub_password"
+            assert pwd == "hub_password"  # trunk-ignore(bandit/B105)
 
         # Test DOCKER_*
         env = {
             "DOCKER_USERNAME": "docker_user",
-            "DOCKER_PASSWORD": "docker_password",
+            "DOCKER_PASSWORD": "docker_password",  # trunk-ignore(bandit/B105)
         }
         with patch.dict(os.environ, env, clear=True):
             user, pwd = resolve_credentials("registry-1.docker.io")
             assert user == "docker_user"
-            assert pwd == "docker_password"
+            assert pwd == "docker_password"  # trunk-ignore(bandit/B105)
 
         # Verify not used for other registries
         with patch.dict(os.environ, env, clear=True):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the regis-cli bootstrap command."""
 
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the CLI."""
 
 import json

--- a/tests/test_coverage_analyzers.py
+++ b/tests/test_coverage_analyzers.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner

--- a/tests/test_coverage_engine.py
+++ b/tests/test_coverage_engine.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from regis_cli.playbook.engine import (
     MissingDataTracker,
     _format_date,

--- a/tests/test_coverage_html.py
+++ b/tests/test_coverage_html.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 from regis_cli.report.html import render_html
 
 

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the end-of-life analyzer."""
 
 from regis_cli.analyzers.endoflife import (
@@ -6,7 +7,6 @@ from regis_cli.analyzers.endoflife import (
     _image_to_product,
     _match_cycle,
 )
-
 
 # ---------------------------------------------------------------------------
 # Unit tests

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the freshness analyzer."""
 
 import json

--- a/tests/test_gh_env.py
+++ b/tests/test_gh_env.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 import os
 from pathlib import Path

--- a/tests/test_gitlab_cli.py
+++ b/tests/test_gitlab_cli.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the gitlab CLI subcommands in regis-cli."""
 
 import json

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the hadolint analyzer."""
 
 import json

--- a/tests/test_namedlist.py
+++ b/tests/test_namedlist.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import pytest
 from json_logic import jsonLogic
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the URL parser."""
 
 import pytest

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the playbook evaluation engine."""
 
 from __future__ import annotations

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the popularity analyzer."""
 
 from regis_cli.analyzers.popularity import PopularityAnalyzer

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the provenance analyzer."""
 
 from regis_cli.analyzers.provenance import ProvenanceAnalyzer

--- a/tests/test_remote_playbook.py
+++ b/tests/test_remote_playbook.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for remote playbook loading."""
 
 from __future__ import annotations

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the SBOM analyzer."""
 
 import json

--- a/tests/test_scorecarddev.py
+++ b/tests/test_scorecarddev.py
@@ -1,10 +1,10 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the scorecard analyzer."""
 
 from regis_cli.analyzers.scorecarddev import (
     ScorecardDevAnalyzer,
     _parse_git_url,
 )
-
 
 # ---------------------------------------------------------------------------
 # Git URL parsing tests

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the size analyzer."""
 
 import json

--- a/tests/test_skopeo_analyzer.py
+++ b/tests/test_skopeo_analyzer.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for the skopeo analyzer."""
 
 import json

--- a/tests/test_trivy.py
+++ b/tests/test_trivy.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for Trivy analyzer."""
 
 import subprocess

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
Resolves #44 

This PR adds support for Docker authentication in `regis-cli` to prevent rate limiting issues in CI environments, specifically Docker Hub.

### Changes:
- **registry**: Added support for `DOCKER_AUTH_CONFIG` (standard Docker JSON config) and `DOCKER_HUB_USERNAME/PASSWORD` in `RegistryClient`.
- **ci**: Updated the GitLab CI template to mention these authentication methods.
- **docs**: Added a "Registry Authentication" section to the GitLab CI integration guide.
- **tests**: Added tests covering the new authentication resolution logic.
 
All tests passed locally.