### PR TITLE
fix(ci): fix trunk command path and ensure reliable formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,13 +31,11 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      - name: Setup Trunk
+      - name: Trunk Format
         uses: trunk-io/trunk-action@v1
         with:
           check-mode: none
-
-      - name: Trunk Format
-        run: trunk fmt --all
+          arguments: fmt --all
 
       - name: Commit and Push Changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
This PR fixes the 'trunk: command not found' error in the CI by running the formatting command through the  instead of a standalone shell script. This ensures the environment path and binary location are correctly managed by the action.