### PR TITLE
feat(cli): display post-install notes after bootstrap

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -26,7 +26,7 @@ Documentation update following the pipeline refactoring and checklist enhancemen
   - `bootstrap repository` — recreates the project repository from renamed `cookiecutters/repository` template.
   - `bootstrap playbook` — creates a new custom playbook from the newly added `cookiecutters/playbook` template.
   - Removed the monolithic `generate` command.
-  - Updated `tests/test_bootstrap.py` (3 tests pass).
+  - Updated `tests/test_bootstrap.py` (4 tests pass).
   - Updated `get-started.adoc` and `cookiecutter.adoc` documentation.
 - Added `docs/modules/ROOT/pages/commands.adoc` listing all available CLI commands.
 - Updated `docs/modules/ROOT/nav.adoc` to include the new commands page.
@@ -48,11 +48,14 @@ Documentation update following the pipeline refactoring and checklist enhancemen
   - Moved `cookiecutters/` directory into the `regis_cli` package.
   - Updated `cli.py` to use `importlib.resources.files` for finding templates, ensuring compatibility with installed packages.
   - Updated `pyproject.toml` to include `cookiecutters/**/*` in package data.
-  - Updated `default.yaml` and documentation to reflect the new directory structure.
-- Added post-install notes display after bootstrap:
-  - `bootstrap` command now reads and displays `.regis-post-install.md` if present in the generated project.
-  - Added `.regis-post-install.md` templates to repository and playbook cookiecutters.
-  - Updated `tests/test_bootstrap.py` with 4 tests passing.
+- Fixed `fatal: ambiguous argument 'HEAD^2'` in Trunk Check workflow:
+  - Enabled `fetch-depth: 0` for full history checkout.
+  - Removed explicit `ref` override to allow Trunk's default merge-base detection on PRs.
+  - Updated auto-commit step to explicitly push to the PR branch.
+- Added **Post-install notes** feature to `bootstrap` commands:
+  - CLI now reads and displays `.regis-post-install.md` from the generated project.
+  - Templates for repository and playbook include personalized setup instructions (GitHub/GitLab setup, next steps).
+  - Updated `commands.adoc` to document this behavior.
 
 ## Next Steps
 
@@ -66,3 +69,5 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 
 - Create a PR for the `bootstrap` command fix and the Trunk Check fix.
 - Monitor CI/CD results for the new branch.
+- Monitor CI/CD results for the new branch.
+- Merge PR #52.

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -49,8 +49,11 @@ Documentation update following the pipeline refactoring and checklist enhancemen
   - Updated `cli.py` to use `importlib.resources.files` for finding templates, ensuring compatibility with installed packages.
   - Updated `pyproject.toml` to include `cookiecutters/**/*` in package data.
   - Updated `default.yaml` and documentation to reflect the new directory structure.
+- Added post-install notes display after bootstrap:
+  - `bootstrap` command now reads and displays `.regis-post-install.md` if present in the generated project.
+  - Added `.regis-post-install.md` templates to repository and playbook cookiecutters.
+  - Updated `tests/test_bootstrap.py` with 4 tests passing.
 
 ## Next Steps
 
-- Create a PR for the `bootstrap` command fix.
-- Monitor CI/CD results for the new branch.
+- Create a PR for the post-install notes feature.

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -11,6 +11,8 @@
 - Fixed Skopeo architecture mismatch handling for multi-arch image indexes.
 - Automated Antora documentation publishing to GitHub Pages.
 - Automated `trunk fmt` in CI with auto-commit of style changes.
+- Refactored `generate` command into a `bootstrap` command group (`bootstrap repository` and `bootstrap playbook`).
+- Display post-install notes after bootstrap.
 
 ## In Progress
 

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -11,9 +11,11 @@
 - Fixed Skopeo architecture mismatch handling for multi-arch image indexes.
 - Automated Antora documentation publishing to GitHub Pages.
 - Automated `trunk fmt` in CI with auto-commit of style changes.
+- Fixed Trunk Check `HEAD^2` error by optimizing git checkout and auto-commit configuration.
 - Refactored `generate` command into a `bootstrap` command group (`bootstrap repository` and `bootstrap playbook`).
 - Display post-install notes after bootstrap.
 - Fixed Trunk Check `HEAD^2` error by optimizing git checkout and auto-commit configuration.
+- Added post-install notes feature to `bootstrap` commands and updated documentation.
 
 ## In Progress
 

--- a/docs/modules/ROOT/pages/commands.adoc
+++ b/docs/modules/ROOT/pages/commands.adoc
@@ -74,6 +74,8 @@ Bootstrap a new custom RegiS playbook from a template.
 regis-cli bootstrap playbook [OUTPUT_DIR] [--no-input]
 ----
 
+NOTE: After a successful bootstrap, both `repository` and `playbook` commands will display **Post-install notes** provided by the template (and then remove the temporary `.regis-post-install.md` file). These notes typically contain setup instructions for GitHub/GitLab or next steps for customizing your playbook.
+
 == Utility Commands
 
 === `gitlab`

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -800,12 +800,23 @@ def bootstrap_repository(output_dir: str, no_input: bool) -> None:
 
     click.echo(f"Bootstrapping repository into {output_dir}...", err=True)
     try:
-        cookiecutter(
+        project_dir = cookiecutter(
             str(template_path),
             no_input=no_input,
             output_dir=output_dir,
         )
         click.echo("  ✓ Repository bootstrapped successfully.", err=True)
+
+        # Handle post-install notes
+        notes_file = Path(project_dir) / ".regis-post-install.md"
+        if notes_file.exists():
+            click.echo("\n" + "=" * 40, err=True)
+            click.echo("POST-INSTALL NOTES:", err=True)
+            click.echo("=" * 40, err=True)
+            click.echo(notes_file.read_text(encoding="utf-8"), err=True)
+            click.echo("=" * 40 + "\n", err=True)
+            notes_file.unlink()
+
     except Exception as exc:
         raise click.ClickException(f"Failed to bootstrap repository: {exc}") from exc
 
@@ -834,12 +845,23 @@ def bootstrap_playbook(output_dir: str, no_input: bool) -> None:
 
     click.echo(f"Bootstrapping playbook into {output_dir}...", err=True)
     try:
-        cookiecutter(
+        project_dir = cookiecutter(
             str(template_path),
             no_input=no_input,
             output_dir=output_dir,
         )
         click.echo("  ✓ Playbook bootstrapped successfully.", err=True)
+
+        # Handle post-install notes
+        notes_file = Path(project_dir) / ".regis-post-install.md"
+        if notes_file.exists():
+            click.echo("\n" + "=" * 40, err=True)
+            click.echo("POST-INSTALL NOTES:", err=True)
+            click.echo("=" * 40, err=True)
+            click.echo(notes_file.read_text(encoding="utf-8"), err=True)
+            click.echo("=" * 40 + "\n", err=True)
+            notes_file.unlink()
+
     except Exception as exc:
         raise click.ClickException(f"Failed to bootstrap playbook: {exc}") from exc
 

--- a/regis_cli/cookiecutters/playbook/{{cookiecutter.project_slug}}/.regis-post-install.md
+++ b/regis_cli/cookiecutters/playbook/{{cookiecutter.project_slug}}/.regis-post-install.md
@@ -1,0 +1,12 @@
+# Custom Playbook: {{ cookiecutter.project_name }}
+
+Your new RegiS playbook has been created successfully!
+
+## Next Steps
+
+1. Open `playbook.yaml` and define your security sections and rules.
+2. Use this playbook with the CLI:
+   ```bash
+   regis-cli analyze <image_url> --playbook playbook.yaml
+   ```
+3. You can also reference this playbook from a RegiS repository configuration.

--- a/regis_cli/cookiecutters/repository/{{cookiecutter.project_slug}}/.regis-post-install.md
+++ b/regis_cli/cookiecutters/repository/{{cookiecutter.project_slug}}/.regis-post-install.md
@@ -1,0 +1,22 @@
+# Post-install instructions for {{ cookiecutter.project_name }}
+
+{% if cookiecutter.platform == "github" -%}
+
+## GitHub Setup
+
+1. Go to your repository settings.
+2. Ensure **GitHub Actions** are enabled.
+3. The workflow in `.github/workflows/regis.yml` will run on every push to the main branch.
+   {%- elif cookiecutter.platform == "gitlab" -%}
+
+## GitLab Setup
+
+1. Go to **Settings > CI/CD > Variables**.
+2. Add a protected variable named `REGIS_TOKEN` with a GitLab Personal Access Token (API scope).
+3. The pipeline in `.gitlab-ci.yml` is ready to go.
+   {%- endif %}
+
+## Next Steps
+
+- Edit `playbook.yaml` to customize your security rules.
+- Run `regis-cli analyze <image>` to test locally.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -45,3 +45,20 @@ def test_bootstrap_playbook_success():
         pb_dir = Path("test-pb/custom-regis-playbook")
         assert pb_dir.exists()
         assert (pb_dir / "playbook.yaml").exists()
+
+
+def test_bootstrap_repository_post_install_notes():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            main, ["bootstrap", "repository", "test-notes", "--no-input"]
+        )
+
+        assert result.exit_code == 0
+        assert "POST-INSTALL NOTES:" in result.output
+        assert "GitHub Setup" in result.output or "GitLab Setup" in result.output
+
+        # Verify the file is deleted
+        project_dir = Path("test-notes/regis-image-security")
+        notes_file = project_dir / ".regis-post-install.md"
+        assert not notes_file.exists()


### PR DESCRIPTION
This PR adds a post-install notes feature to the  command. It reads and displays  if present in the generated project. Templates for repository and playbook cookiecutters have been added.

Closes #43 