### PR TITLE
feat: implement Playbook Tiers, Dynamic Badges and restore multi-page reporting

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -37,6 +37,9 @@ lint:
     - taplo@0.10.0
     - trufflehog@3.93.7
     - yamllint@1.38.0
+  ignore:
+    - linters: [bandit]
+      paths: [tests/**]
 actions:
   disabled:
     - trunk-announce

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -27,13 +27,13 @@ lint:
     - mypy@1.19.1
     - bandit@1.9.4
     - black@26.3.1
-    - checkov@3.2.508
+    - checkov@3.2.510
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.3
     - prettier@3.8.1
-    - ruff@0.15.6
+    - ruff@0.15.7
     - taplo@0.10.0
     - trufflehog@3.93.7
     - yamllint@1.38.0

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,6 +3,7 @@
 * xref:commands.adoc[Available Commands]
 * xref:playbooks.adoc[Understand Playbooks]
 ** xref:default-playbook.adoc[Default Playbook Reference]
+* xref:rules.adoc[Understanding Rules]
 * xref:overview.adoc[Architectural Overview]
 * Integrations
 ** xref:integrations/github.adoc[GitHub]

--- a/docs/modules/ROOT/pages/commands.adoc
+++ b/docs/modules/ROOT/pages/commands.adoc
@@ -34,6 +34,9 @@ regis-cli analyze [OPTIONS] URL
 * `--cache`: Use existing report.json as cache if available.
 * `-o, --output TEMPLATE`: Output filename template.
 * `-D, --output-dir TEMPLATE`: Base directory template for output files.
+* `--evaluate`: Run rules evaluation after analysis and add results to report.
+* `--fail`: Fail command execution if any rule is breached.
+* `--fail-level [info|warning|critical]`: Minimum rule level that triggers a command failure (default: critical).
 
 === `evaluate`
 
@@ -51,6 +54,37 @@ Check if an image manifest is accessible on the registry.
 [source,bash]
 ----
 regis-cli check [OPTIONS] URL
+----
+
+== Rules Commands
+
+Manage and evaluate rules against reports.
+
+=== `rules list`
+
+List all available default rules provided by analyzers, and optionally merge with overrides.
+
+[source,bash]
+----
+regis-cli rules list [--rules playbook.yaml]
+----
+
+=== `rules show`
+
+Show the full JSON definition of a specific rule.
+
+[source,bash]
+----
+regis-cli rules show <slug> [--rules rules.yaml]
+----
+
+=== `rules evaluate`
+
+Evaluate a regis-cli JSON report against rules.
+
+[source,bash]
+----
+regis-cli rules evaluate <report.json> [--rules playbook.yaml] [--fail] [--fail-level critical] [-o output.json]
 ----
 
 [#bootstrap]

--- a/docs/modules/ROOT/pages/default-playbook.adoc
+++ b/docs/modules/ROOT/pages/default-playbook.adoc
@@ -2,6 +2,45 @@
 
 The RegiS Default Playbook is the standard security and governance profile used by `regis-cli`. It provides a comprehensive set of checks to ensure container images meet baseline security requirements and follow best practices.
 
+== Default Tiers
+
+The default playbook categorizes reports into one of three tiers based on the overall compliance score:
+
+[cols="1,3"]
+|===
+| Tier | Condition
+
+| **Gold**
+| Compliance Score > 90%
+
+| **Silver**
+| Compliance Score > 70%
+
+| **Bronze**
+| Compliance Score > 50%
+|===
+
+== Default Badges
+
+The report header displays the following dynamic status badges:
+
+[cols="1,3"]
+|===
+| Badge | Logic
+
+| **Score**
+| Displays the overall `rules_summary.score`.
+
+| **CVE: Critical**
+| Displayed (Error) if any critical vulnerabilities are detected.
+
+| **CVE: High**
+| Displayed (Warning) if any high-severity vulnerabilities are detected.
+
+| **Freshness**
+| Displayed (Success) if the image is less than 30 days old.
+|===
+
 == Compliance Levels
 
 The playbook categorizes its security checks into two main levels: **Mandatory** and **Recommended**.
@@ -161,23 +200,25 @@ regis-cli analyze ghcr.io/trivoallan/regis-cli:latest -s -D docs/modules/ROOT/as
 
 The default playbook includes pre-configured GitLab integrations to automate MR management.
 
-=== Labels
+=== Badge Synchronization
 
-[cols="1,3"]
+The default playbook synchronizes the following status badges as GitLab labels:
+
+[cols="1,2"]
 |===
-| Label | Applied when
+| Badge Slug | Label Result
 
-| `regis::pass`
-| Overall compliance score ≥ 90 %
+| `score`
+| `Score: [value]` (Information)
 
-| `regis::warn`
-| 70 % ≤ score < 90 %
+| `freshness`
+| `Freshness: Fresh !` (Success) if passed.
 
-| `regis::fail`
-| Score < 70 %
+| `cve-critical`
+| `CVE: Critical` (Error) if failed.
 
-| `security::critical`
-| At least one CRITICAL vulnerability detected by Trivy
+| `cve-high`
+| `CVE: High` (Warning) if failed.
 |===
 
 === MR Description Checklist

--- a/docs/modules/ROOT/pages/integrations/gitlab.adoc
+++ b/docs/modules/ROOT/pages/integrations/gitlab.adoc
@@ -144,20 +144,26 @@ Security teams can review the MR, check the compliance score via the direct HTML
 
 The `regis-cli` integration automatically applies **scoped labels** to the Merge Request based on the analysis results and your playbook configuration.
 
-=== Scoped Labels Configuration
+=== Badge Synchronization
 
-In your `playbook.yaml`, you can define label rules under the `integrations.gitlab.labels` section:
+Instead of defining complex conditions for labels, `regis-cli` can automatically synchronize its **Badges** as GitLab labels.
+
+In your `playbook.yaml`, you simply list the badge slugs you want to import under the `integrations.gitlab.badges` section:
 
 [source,yaml]
 ----
 integrations:
   gitlab:
-    labels:
-      - name: regis::pass
-        condition: {">=": [{var: score}, 90]}
-      - name: security::critical
-        condition: {">": [{var: results.trivy.critical_count}, 0]}
+    badges:
+      - score
+      - freshness
+      - cve-critical
+      - cve-high
 ----
+
+This ensures that:
+1. Only the relevant status indicators are applied as labels.
+2. The color and text of the GitLab label match the badge's visual state (Success=Green, Warning=Yellow, Error=Red, Info=Blue).
 
 GitLab scoped labels (using the `::` separator) ensure that only one label of a given scope (e.g., `regis::*`) is applied at a time.
 

--- a/docs/modules/ROOT/pages/playbooks.adoc
+++ b/docs/modules/ROOT/pages/playbooks.adoc
@@ -27,15 +27,61 @@ Playbooks define how analysis results are presented in the HTML report through a
 *   **Sections**: Groups of related scorecards and widgets within a page.
 *   **Widgets**: UI components that display specific values or metrics. Widgets can be key-value summaries, KPI cards, or detailed tables rendered from templates.
 
-=== Named Addressing
-
-When referencing pages or sections in your logic or templates, `regis-cli` allows you to navigate the hierarchy using their **slug** or **name** instead of numeric indices (`playbooks.0.pages.0...`).
-
-When using a `name`, the engine automatically normalizes it:
-* Converts to lowercase
-* Replaces spaces and dashes with underscores (`_`)
-
 For example, a section named "Mandatory Requirements" becomes `mandatory_requirements`.
+
+=== Tiers
+
+Playbooks can define **Tiers** to categorize the overall quality of an image based on the compliance score. Each tier is defined by a name and a condition.
+
+[source,yaml]
+----
+tiers:
+  - name: Gold
+    condition: { ">": [{ var: rules_summary.score }, 90] }
+  - name: Silver
+    condition: { ">": [{ var: rules_summary.score }, 70] }
+  - name: Bronze
+    condition: { ">": [{ var: rules_summary.score }, 50] }
+----
+
+The evaluator checks tiers in the order they are defined. The first tier whose condition evaluates to truthy is assigned to the report.
+
+=== Badges
+
+**Badges** provide high-level visual status indicators in the report header. They are dynamic and support variable interpolation using the `${var.path}` syntax.
+
+[source,yaml]
+----
+badges:
+  - slug: score
+    scope: Score
+    value: "${rules_summary.score}"
+    class: information
+  - slug: freshness
+    scope: Freshness
+    condition: { "==": [{ var: rules.freshness-age.passed }, true] }
+    class: success
+----
+
+[cols="1,3", options="header"]
+|===
+| Field | Description
+
+| `slug`
+| A unique machine-readable identifier for the badge (used for lookups and integrations).
+
+| `scope`
+| The primary label for the badge (e.g., "Score", "CVE").
+
+| `value`
+| The value to display. Can use `${}` interpolation to reference report data.
+
+| `condition`
+| A JSON Logic expression. If provided, the badge is only displayed when the condition is truthy.
+
+| `class`
+| The visual style/color of the badge. Supported: `success` (green), `warning` (yellow), `error` (red), `information` (blue).
+|===
 
 == Evaluation Mechanism
 
@@ -85,22 +131,21 @@ For example, to display the overall compliance score in a widget, you might use:
 
 Playbooks can automate Merge Request (MR) management in GitLab through the `integrations.gitlab` key.
 
-=== Scoped Labels
+=== Badge Synchronization
 
-The `labels` list applies scoped labels to the MR based on JSON Logic conditions evaluated against the final analysis result. Each label is applied only when its condition is truthy.
+The `badges` list automatically synchronizes authorized status badges as GitLab labels. Each badge in the list is identified by its **slug**.
 
 [source,yaml]
 ----
 integrations:
   gitlab:
-    labels:
-      - name: regis::pass
-        condition: { ">=": [{ var: playbook.score }, 90] }
-      - name: regis::fail
-        condition: { "<": [{ var: playbook.score }, 70] }
-      - name: security::critical
-        condition: { ">": [{ var: results.trivy.critical_count }, 0] }
+    badges:
+      - score
+      - freshness
+      - cve-critical
 ----
+
+This ensures that the MR UI (labels) always reflects the visual status shown in the HTML report. Regular condition-based labels are deprecated in favor of this badge-driven approach.
 
 === MR Description Checklists
 

--- a/docs/modules/ROOT/pages/rules.adoc
+++ b/docs/modules/ROOT/pages/rules.adoc
@@ -1,0 +1,212 @@
+= Understanding Rules
+
+RegiS evaluates the security and compliance of Docker images through a robust rules engine. Rules define specific conditions that the analysis results must meet.
+
+== Default Analyzer Rules
+
+To provide immediate value out of the box, each analyzer (like Trivy, Dockle, or Skopeo) provides its own built-in default rules. When you run an analysis, `regis-cli` automatically collects the default rules for all analyzers that were executed.
+
+*   `trivy-no-critical`: Fails if Trivy finds any critical vulnerabilities.
+*   `dockle-no-fatal`: Fails if Dockle finds fatal issues.
+*   `skopeo-no-root`: Fails if the image is configured to run as root.
+*   `trusted-domain`: Fails if the image does not originate from a trusted registry registry.
+
+You can view all available default rules by running:
+
+[source,bash]
+----
+regis-cli rules list
+----
+
+To see the exact definition and JSON Logic of a specific rule:
+
+[source,bash]
+----
+regis-cli rules show trivy-no-critical
+----
+
+== Customizing Rules
+
+You can customize or completely replace default rules by defining a `rules` section at the top level of your `playbook.yaml`. The rules engine matches these overrides based on their `slug`.
+
+If you define a rule with the same `slug` as a default rule, your definition will be merged over the default one. You can use this to change the severity level, customize messages, or tweak parameters.
+
+=== Example Playbook with Rules
+
+[source,yaml]
+----
+name: Custom Security Playbook
+rules:
+  # Overriding a default rule
+  - slug: trivy-no-critical
+    title: Custom rules for critical CVEs
+    level: warning # Demoting from critical to warning
+    messages:
+      fail: We found ${results.trivy.critical_count} critical CVEs, please fix them soon!
+
+  # Adding a completely new custom rule
+  - slug: company-specific-label
+    title: Image must have company label
+    level: critical
+    tags: [compliance]
+    condition:
+      "in": [ "my-company.owner", { "keys": [{ "var": "results.skopeo.platforms.0.labels" }] } ]
+    messages:
+      pass: "Company label is present."
+      fail: "Missing 'my-company.owner' label."
+
+  # Disabling a default rule entirely
+  - slug: dockle-no-fatal
+    enable: false
+----
+
+=== Overriding Rule Parameters
+
+Many default rules expose configurable `params` that you can override without rewriting the entire `condition`. The rule engine automatically merges your parameters with the defaults.
+
+==== Common Parameter Examples
+
+[source,yaml]
+----
+rules:
+  # Change freshness threshold
+  - slug: freshness-age
+    params:
+      max_days: 7
+
+  # Allow some critical CVEs if necessary
+  - slug: trivy-no-critical
+    params:
+      max_count: 5
+
+  # Change the forbidden user
+  - slug: skopeo-no-root
+    params:
+      forbidden_user: "admin"
+
+  # Restrict to specific trusted domains
+  - slug: trusted-domain
+    params:
+      domains: ["my-private-registry.com"]
+----
+
+The rule engine applying them to the rule's built-in evaluation condition and output messages using the `${rule.params.key}` interpolation syntax.
+
+== Standard Rule Library
+
+RegiS includes a set of standard rules out-of-the-box. Below are the most common rules and their configurable parameters.
+
+=== Security Rules (Trivy & Dockle)
+
+[cols="1,2,2"]
+|===
+| Slug | Description | Default Parameters
+
+| `trivy-no-critical`
+| Fails if critical vulnerabilities are found.
+| `max_count: 0`
+
+| `trivy-no-high`
+| Fails if high vulnerabilities are found.
+| `max_count: 0`
+
+| `trivy-fix-available`
+| Fails if vulnerabilities have a fixed version.
+| `min_severity: "MEDIUM"`
+
+| `trivy-secret-scan`
+| Fails if embedded secrets are detected.
+| None
+
+| `dockle-no-fatal`
+| Fails if Dockle finds fatal issues.
+| `max_count: 0`
+
+| `dockle-max-warnings`
+| Limit the number of Dockle warnings.
+| `max_count: 5`
+|===
+
+=== Image Hygiene & Config (Skopeo)
+
+[cols="1,2,2"]
+|===
+| Slug | Description | Default Parameters
+
+| `skopeo-no-root`
+| Fails if image runs as a forbidden user.
+| `forbidden_user: "root"`
+
+| `skopeo-max-size`
+| Limit uncompressed image size.
+| `max_mb: 1000`
+
+| `skopeo-max-layers`
+| Limit number of filesystem layers.
+| `max_layers: 30`
+
+| `skopeo-tag-not-latest`
+| Enforce specific tags (blocks `latest`).
+| None
+
+| `skopeo-multi-arch`
+| Ensure multi-platform support.
+| `min_platforms: 2`
+
+| `skopeo-exposed-ports`
+| Restrict permitted exposed ports.
+| `allowed_ports: [80, 443]`
+
+| `skopeo-required-labels`
+| Ensure mandatory OCI/custom labels exist.
+| `labels: ["org.opencontainers.image.source"]`
+
+| `skopeo-forbidden-env`
+| Guard against forbidden environment keys.
+| `keys: ["DEBUG", "SECRET_KEY"]`
+|===
+
+=== Lifecycle Rules
+* `freshness-age`: Fails if the image is older than `max_days` (default: 30).
+* `trusted-domain`: Restricts image origin to a list of `domains`.
+
+== Rule Evaluation Mechanism
+
+Rules are evaluated using **JSON Logic**. The evaluation context provides access to the flattened report data.
+
+=== String Interpolation
+
+Rule messages (`pass` and `fail`) support string interpolation using the `${path.to.var}` syntax. These paths correspond to the flattened keys in the analysis report.
+
+[source,yaml]
+----
+    messages:
+       pass: Image is less than 30 days old (${results.freshness.age_days} days).
+       fail: Image is older than 30 days (${results.freshness.age_days} days).
+----
+
+=== Evaluating Rules
+
+To evaluate an analysis report against your rules:
+
+[source,bash]
+----
+regis-cli rules evaluate path/to/report.json --rules playbook.yaml
+----
+
+NOTE: The `--rules` (or `-r`) flag accepts both standalone `rules.yaml` files and full `playbook.yaml` files.
+
+The output will display a score percentage and the pass/fail status of each rule. You can also export the results to JSON using `-o rules_report.json`.
+
+=== CI/CD Integration
+
+Use the `--fail` flag to automatically exit with a non-zero code if critical rules fail, which is useful for blocking CI/CD pipelines:
+
+[source,bash]
+----
+# Fail if any CRITICAL rule is breached
+regis-cli rules evaluate <report.json> [--rules playbook.yaml] [--fail] [--fail-level critical]
+
+# Fail if any WARNING or CRITICAL rule is breached
+regis-cli rules evaluate report.json --rules playbook.yaml --fail --fail-level warning
+----

--- a/docs/modules/ROOT/pages/schemas/playbook.adoc
+++ b/docs/modules/ROOT/pages/schemas/playbook.adoc
@@ -13,6 +13,17 @@
 ** [[properties_pages_items]]**Items**: Refer to *<<%24defs_page,#/$defs/page>>*.
 * [[properties_sections]]**`sections`** *(array)*: List of playbook sections. Each section groups scorecards, levels, and display preferences. Length must be at least 1.
 ** [[properties_sections_items]]**Items**: Refer to *<<%24defs_section,#/$defs/section>>*.
+* [[properties_tiers]]**`tiers`** *(array)*: Optional Tier categorization rules.
+** [[properties_tiers_items]]**Items** *(object)*
+*** [[properties_tiers_items_properties_name]]**`name`** *(string, required)*: Tier name (e.g. Gold).
+*** [[properties_tiers_items_properties_condition]]**`condition`** *(object, required)*: JsonLogic expression evaluated against the report.
+* [[properties_badges]]**`badges`** *(array)*: Optional status badges for the report header.
+** [[properties_badges_items]]**Items** *(object)*
+*** [[properties_badges_items_properties_slug]]**`slug`** *(string)*: Unique identifier for the badge.
+*** [[properties_badges_items_properties_scope]]**`scope`** *(string, required)*: Badge category label.
+*** [[properties_badges_items_properties_value]]**`value`** *(string)*: Dynamic value (supports ${var.path} interpolation).
+*** [[properties_badges_items_properties_class]]**`class`** *(string)*: CSS style (success, warning, error, information).
+*** [[properties_badges_items_properties_condition]]**`condition`** *(object)*: Optional display condition.
 * [[properties_sidebar]]**`sidebar`** *(object)*: Optional sidebar navigation configuration.
 ** [[properties_sidebar_properties_sections]]**`sections`** *(array)*
 *** [[properties_sidebar_properties_sections_items]]**Items** *(object)*
@@ -29,10 +40,8 @@
 **** [[properties_sidebar_properties_links_items_properties_icon]]**`icon`** *(string)*
 * [[properties_integrations]]**`integrations`** *(object)*: Optional third-party platform integrations (e.g. GitLab, GitHub).
 ** [[properties_integrations_properties_gitlab]]**`gitlab`** *(object)*
-*** [[properties_integrations_properties_gitlab_properties_labels]]**`labels`** *(array)*: Custom scoped labels applied to GitLab Merge Requests based on conditions.
-**** [[properties_integrations_properties_gitlab_properties_labels_items]]**Items** *(object)*
-***** [[properties_integrations_properties_gitlab_properties_labels_items_properties_name]]**`name`** *(string, required)*: Label name, e.g. 'regis::fail' or 'security::critical'.
-***** [[properties_integrations_properties_gitlab_properties_labels_items_properties_condition]]**`condition`** *(object, required)*: JsonLogic expression evaluated against the analysis report.
+*** [[properties_integrations_properties_gitlab_properties_badges]]**`badges`** *(array)*: List of badge slugs to be imported as GitLab Merge Request labels.
+**** [[properties_integrations_properties_gitlab_properties_badges_items]]**Items** *(string)*: Badge slug.
 *** [[properties_integrations_properties_gitlab_properties_checklist]]**`checklist`** *(array)*: (Deprecated) Single checklist items added as checkboxes to the Merge Request description.
 **** [[properties_integrations_properties_gitlab_properties_checklist_items]]**Items**: Refer to *<<%24defs_checklist_item,#/$defs/checklist_item>>*.
 *** [[properties_integrations_properties_gitlab_properties_checklists]]**`checklists`** *(array)*: Configurable checklists added as checkboxes to the Merge Request description.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,12 @@ regis_cli = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.mypy]
+python_version = "3.10"
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["yaml.*", "requests.*", "json_logic.*", "referencing.*"]
+ignore_missing_imports = true

--- a/regis_cli/analyzers/base.py
+++ b/regis_cli/analyzers/base.py
@@ -32,6 +32,13 @@ class BaseAnalyzer(ABC):
     #: Filename of the JSON Schema inside ``regis_cli/schemas/``.
     schema_file: str = ""
 
+    @classmethod
+    def default_rules(cls) -> list[dict[str, Any]]:
+        """Return a list of default rules provided by this analyzer.
+        Override in subclasses to provide default evaluation rules.
+        """
+        return []
+
     @abstractmethod
     def analyze(
         self,

--- a/regis_cli/analyzers/dockle.py
+++ b/regis_cli/analyzers/dockle.py
@@ -20,6 +20,45 @@ class DockleAnalyzer(BaseAnalyzer):
     name = "dockle"
     schema_file = "dockle.schema.json"
 
+    @classmethod
+    def default_rules(cls) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "dockle-no-fatal",
+                "title": "No FATAL issues found by Dockle.",
+                "level": "critical",
+                "tags": ["security"],
+                "params": {"max_count": 0},
+                "condition": {
+                    "<=": [
+                        {"var": "results.dockle.issues_by_level.FATAL"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "No fatal issues detected.",
+                    "fail": "Dockle found ${results.dockle.issues_by_level.FATAL} fatal issues (max allowed: ${rule.params.max_count}).",
+                },
+            },
+            {
+                "slug": "dockle-max-warnings",
+                "title": "Too many Dockle warnings found.",
+                "level": "warning",
+                "tags": ["security"],
+                "params": {"max_count": 5},
+                "condition": {
+                    "<=": [
+                        {"var": "results.dockle.issues_by_level.WARN"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Dockle warnings are within acceptable limits (${results.dockle.issues_by_level.WARN}).",
+                    "fail": "Dockle found ${results.dockle.issues_by_level.WARN} warnings (max allowed: ${rule.params.max_count}).",
+                },
+            },
+        ]
+
     def analyze(
         self,
         client: RegistryClient,

--- a/regis_cli/analyzers/dockle.py
+++ b/regis_cli/analyzers/dockle.py
@@ -36,7 +36,7 @@ class DockleAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "No fatal issues detected.",
+                    "pass": "Image has no critical CVEs.",  # nosec B105
                     "fail": "Dockle found ${results.dockle.issues_by_level.FATAL} fatal issues (max allowed: ${rule.params.max_count}).",
                 },
             },
@@ -53,7 +53,7 @@ class DockleAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Dockle warnings are within acceptable limits (${results.dockle.issues_by_level.WARN}).",
+                    "pass": "Dockle warnings are within acceptable limits (${results.dockle.issues_by_level.WARN}).",  # nosec B105
                     "fail": "Dockle found ${results.dockle.issues_by_level.WARN} warnings (max allowed: ${rule.params.max_count}).",
                 },
             },

--- a/regis_cli/analyzers/freshness.py
+++ b/regis_cli/analyzers/freshness.py
@@ -69,7 +69,7 @@ class FreshnessAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Image is less than ${rule.params.max_days} days old (${results.freshness.age_days} days).",
+                    "pass": "Image is less than ${rule.params.max_days} days old (${results.freshness.age_days} days).",  # nosec B105
                     "fail": "Image is older than ${rule.params.max_days} days (${results.freshness.age_days} days).",
                 },
             }

--- a/regis_cli/analyzers/freshness.py
+++ b/regis_cli/analyzers/freshness.py
@@ -53,6 +53,28 @@ class FreshnessAnalyzer(BaseAnalyzer):
     name = "freshness"
     schema_file = "freshness.schema.json"
 
+    @classmethod
+    def default_rules(cls) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "freshness-age",
+                "title": "Image should be less than expected days old.",
+                "level": "warning",
+                "tags": ["freshness"],
+                "params": {"max_days": 30},
+                "condition": {
+                    "<": [
+                        {"var": "results.freshness.age_days"},
+                        {"var": "rule.params.max_days"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image is less than ${rule.params.max_days} days old (${results.freshness.age_days} days).",
+                    "fail": "Image is older than ${rule.params.max_days} days (${results.freshness.age_days} days).",
+                },
+            }
+        ]
+
     def analyze(
         self,
         client: RegistryClient,

--- a/regis_cli/analyzers/size.py
+++ b/regis_cli/analyzers/size.py
@@ -136,10 +136,15 @@ class SizeAnalyzer(BaseAnalyzer):
                 logger.warning(f"Platform {platform} not found in manifest index")
 
         for entry in entries:
-            platform = entry.get("platform", {})
-            arch = platform.get("architecture", "unknown")
-            os_name = platform.get("os", "unknown")
-            variant = platform.get("variant", "")
+            if not isinstance(entry, dict):
+                continue
+            plat_info = entry.get("platform")
+            if not isinstance(plat_info, dict):
+                plat_info = {}
+
+            arch = plat_info.get("architecture", "unknown")
+            os_name = plat_info.get("os", "unknown")
+            variant = plat_info.get("variant", "")
             platform_label = f"{os_name}/{arch}"
             if variant:
                 platform_label += f"/{variant}"

--- a/regis_cli/analyzers/skopeo.py
+++ b/regis_cli/analyzers/skopeo.py
@@ -90,7 +90,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                 "tags": ["lifecycle"],
                 "condition": {"!=": [{"var": "request.tag"}, "latest"]},
                 "messages": {
-                    "pass": "Image tag is not 'latest'.",
+                    "pass": "Image tag is not 'latest'.",  # nosec B105
                     "fail": "Image is using the 'latest' tag. Use immutable version tags instead.",
                 },
             },
@@ -130,7 +130,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "All exposed ports are allowed.",
+                    "pass": "All exposed ports are allowed.",  # nosec B105
                     "fail": "Image exposes unauthorized ports: ${results.skopeo.platforms.0.exposed_ports}.",
                 },
             },
@@ -147,7 +147,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "All required labels are present.",
+                    "pass": "All required labels are present.",  # nosec B105
                     "fail": "Image is missing one or more required labels: ${rule.params.labels}.",
                 },
             },
@@ -166,7 +166,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     }
                 },
                 "messages": {
-                    "pass": "No forbidden environment variables found.",
+                    "pass": "No forbidden environment variables found.",  # nosec B105
                     "fail": "Image contains one or more forbidden environment variables.",
                 },
             },

--- a/regis_cli/analyzers/skopeo.py
+++ b/regis_cli/analyzers/skopeo.py
@@ -45,7 +45,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Image does not run as '${rule.params.forbidden_user}'.",
+                    "pass": "Image does not run as '${rule.params.forbidden_user}'.",  # nosec B105
                     "fail": "Image configured to run as '${rule.params.forbidden_user}'.",
                 },
             },
@@ -62,7 +62,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Image size is within limits (${results.skopeo.platforms.0.size} bytes).",
+                    "pass": "Image size is within limits (${results.skopeo.platforms.0.size} bytes).",  # nosec B105
                     "fail": "Image size exceeds ${rule.params.max_mb} MB (${results.skopeo.platforms.0.size} bytes).",
                 },
             },
@@ -79,7 +79,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Image has ${results.skopeo.platforms.0.layers_count} layers.",
+                    "pass": "Image has ${results.skopeo.platforms.0.layers_count} layers.",  # nosec B105
                     "fail": "Image has too many layers (${results.skopeo.platforms.0.layers_count}). Max allowed: ${rule.params.max_layers}.",
                 },
             },
@@ -113,7 +113,7 @@ class SkopeoAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "Image supports ${results.skopeo.platforms.length} platforms.",
+                    "pass": "Image supports ${results.skopeo.platforms.length} platforms.",  # nosec B105
                     "fail": "Image only supports ${results.skopeo.platforms.length} platforms (min required: ${rule.params.min_platforms}).",
                 },
             },

--- a/regis_cli/analyzers/skopeo.py
+++ b/regis_cli/analyzers/skopeo.py
@@ -29,6 +29,149 @@ class SkopeoAnalyzer(BaseAnalyzer):
     name = "skopeo"
     schema_file = "skopeo.schema.json"
 
+    @classmethod
+    def default_rules(cls) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "skopeo-no-root",
+                "title": "Image must not run as root.",
+                "level": "critical",
+                "tags": ["security"],
+                "params": {"forbidden_user": "root"},
+                "condition": {
+                    "!=": [
+                        {"var": "results.skopeo.platforms.0.user"},
+                        {"var": "rule.params.forbidden_user"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image does not run as '${rule.params.forbidden_user}'.",
+                    "fail": "Image configured to run as '${rule.params.forbidden_user}'.",
+                },
+            },
+            {
+                "slug": "skopeo-max-size",
+                "title": "Image size is within limits.",
+                "level": "warning",
+                "tags": ["hygiene"],
+                "params": {"max_mb": 1000},
+                "condition": {
+                    "<=": [
+                        {"var": "results.skopeo.platforms.0.size"},
+                        {"*": [{"var": "rule.params.max_mb"}, 1048576]},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image size is within limits (${results.skopeo.platforms.0.size} bytes).",
+                    "fail": "Image size exceeds ${rule.params.max_mb} MB (${results.skopeo.platforms.0.size} bytes).",
+                },
+            },
+            {
+                "slug": "skopeo-max-layers",
+                "title": "Image has an acceptable number of layers.",
+                "level": "warning",
+                "tags": ["performance"],
+                "params": {"max_layers": 30},
+                "condition": {
+                    "<=": [
+                        {"var": "results.skopeo.platforms.0.layers_count"},
+                        {"var": "rule.params.max_layers"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image has ${results.skopeo.platforms.0.layers_count} layers.",
+                    "fail": "Image has too many layers (${results.skopeo.platforms.0.layers_count}). Max allowed: ${rule.params.max_layers}.",
+                },
+            },
+            {
+                "slug": "skopeo-tag-not-latest",
+                "title": "Image tag should not be 'latest'.",
+                "level": "warning",
+                "tags": ["lifecycle"],
+                "condition": {"!=": [{"var": "request.tag"}, "latest"]},
+                "messages": {
+                    "pass": "Image tag is not 'latest'.",
+                    "fail": "Image is using the 'latest' tag. Use immutable version tags instead.",
+                },
+            },
+            {
+                "slug": "skopeo-multi-arch",
+                "title": "Image should support multiple platforms.",
+                "level": "info",
+                "tags": ["compatibility"],
+                "params": {"min_platforms": 2},
+                "condition": {
+                    ">=": [
+                        {
+                            "reduce": [
+                                {"var": "results.skopeo.platforms"},
+                                {"+": [1, {"var": "accumulator"}]},
+                                0,
+                            ]
+                        },
+                        {"var": "rule.params.min_platforms"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image supports ${results.skopeo.platforms.length} platforms.",
+                    "fail": "Image only supports ${results.skopeo.platforms.length} platforms (min required: ${rule.params.min_platforms}).",
+                },
+            },
+            {
+                "slug": "skopeo-exposed-ports",
+                "title": "Image exposes permitted ports.",
+                "level": "warning",
+                "tags": ["security"],
+                "params": {"allowed_ports": ["80", "443"]},
+                "condition": {
+                    "subset": [
+                        {"var": "results.skopeo.platforms.0.exposed_ports"},
+                        {"var": "rule.params.allowed_ports"},
+                    ]
+                },
+                "messages": {
+                    "pass": "All exposed ports are allowed.",
+                    "fail": "Image exposes unauthorized ports: ${results.skopeo.platforms.0.exposed_ports}.",
+                },
+            },
+            {
+                "slug": "skopeo-required-labels",
+                "title": "Image must have required OCI labels.",
+                "level": "warning",
+                "tags": ["metadata"],
+                "params": {"labels": ["org.opencontainers.image.source"]},
+                "condition": {
+                    "contains_all": [
+                        {"keys": [{"var": "results.skopeo.platforms.0.labels"}]},
+                        {"var": "rule.params.labels"},
+                    ]
+                },
+                "messages": {
+                    "pass": "All required labels are present.",
+                    "fail": "Image is missing one or more required labels: ${rule.params.labels}.",
+                },
+            },
+            {
+                "slug": "skopeo-forbidden-env",
+                "title": "Image must not contain forbidden environment variables.",
+                "level": "critical",
+                "tags": ["security"],
+                "params": {"keys": ["DEBUG", "SECRET_KEY"]},
+                "condition": {
+                    "!": {
+                        "env_contains": [
+                            {"var": "results.skopeo.platforms.0.env"},
+                            {"var": "rule.params.keys"},
+                        ]
+                    }
+                },
+                "messages": {
+                    "pass": "No forbidden environment variables found.",
+                    "fail": "Image contains one or more forbidden environment variables.",
+                },
+            },
+        ]
+
     def analyze(
         self,
         client: RegistryClient,
@@ -74,8 +217,6 @@ class SkopeoAnalyzer(BaseAnalyzer):
                 client, registry, repository, tag, {"os": os_name, "architecture": arch}
             )
             platforms.append(detail)
-            inspect_data = {}  # Will be fetched inside _inspect_platform if needed,
-            # but we'll stick to platforms list for consistency.
         elif media_type in _INDEX_TYPES:
             # Multi-arch image — iterate over each platform manifest in parallel.
             entries = manifest.get("manifests", [])
@@ -110,11 +251,11 @@ class SkopeoAnalyzer(BaseAnalyzer):
             platforms.append(detail)
 
         # 4. Fetch primary inspect data (raw metadata) if NOT an index and NO platform override.
-        inspect_data: dict[str, Any] = {}
+        primary_metadata: dict[str, Any] = {}
         if not platform and media_type not in _INDEX_TYPES:
             try:
                 primary_inspect_stdout = self._run_skopeo(client, ["inspect", target])
-                inspect_data = json.loads(primary_inspect_stdout)
+                primary_metadata = json.loads(primary_inspect_stdout)
             except Exception as e:
                 logger.warning(
                     "Could not fetch primary inspect data for %s: %s", target, e
@@ -126,19 +267,16 @@ class SkopeoAnalyzer(BaseAnalyzer):
             # skopeo list-tags docker://registry/repository
             list_tags_target = f"docker://{registry}/{repository}"
             list_tags_stdout = self._run_skopeo(client, ["list-tags", list_tags_target])
-            tags_data = json.loads(list_tags_stdout)
-            tags = tags_data.get("Tags", [])
-            # Natural sort or just take the ones from skopeo (usually unsorted or alphabetical)
-            # We'll return the raw list and let the renderer handle it, but we can also store a subset.
+            tags = json.loads(list_tags_stdout).get("Tags", [])
         except Exception as e:
-            logger.warning("Could not list tags for %s: %s", repository, e)
+            logger.warning("Could not fetch tag list for %s: %s", repository, e)
 
         return {
             "analyzer": self.name,
             "repository": repository,
             "tag": tag,
-            "inspect": inspect_data,
             "platforms": platforms,
+            "inspect": primary_metadata,
             "tags": tags,
         }
 
@@ -209,6 +347,14 @@ class SkopeoAnalyzer(BaseAnalyzer):
             result["created"] = data.get("Created")
             result["labels"] = data.get("Labels") or {}
             result["layers_count"] = len(data.get("Layers", []))
+            result["size"] = data.get("Size", 0)
+
+            # Extract exposed ports if available
+            # Skopeo inspect sometimes has these in different places depending on version/source
+            # Usually in a Config object if present.
+            config = data.get("Config", {}) or {}
+            result["exposed_ports"] = list((config.get("ExposedPorts") or {}).keys())
+            result["env"] = config.get("Env", [])
 
             if result["architecture"] == "unknown":
                 result["architecture"] = data.get("Architecture", "unknown")

--- a/regis_cli/analyzers/trivy.py
+++ b/regis_cli/analyzers/trivy.py
@@ -88,7 +88,7 @@ class TrivyAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "No critical vulnerabilities detected.",
+                    "pass": "No critical vulnerabilities detected.",  # nosec B105
                     "fail": "Image has ${results.trivy.critical_count} critical CVEs (max allowed: ${rule.params.max_count}).",
                 },
             },
@@ -105,7 +105,7 @@ class TrivyAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "No high vulnerabilities detected.",
+                    "pass": "No high vulnerabilities detected.",  # nosec B105
                     "fail": "Image has ${results.trivy.high_count} high CVEs (max allowed: ${rule.params.max_count}).",
                 },
             },
@@ -122,7 +122,7 @@ class TrivyAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "All vulnerabilities with available fixes have been patched.",
+                    "pass": "All vulnerabilities with available fixes have been patched.",  # nosec B105
                     "fail": "Image has ${results.trivy.fixed_count} vulnerabilities with available fixes.",
                 },
             },
@@ -139,7 +139,7 @@ class TrivyAnalyzer(BaseAnalyzer):
                     ]
                 },
                 "messages": {
-                    "pass": "No secrets detected in the image.",
+                    "pass": "No secrets detected in the image.",  # nosec B105
                     "fail": "Trivy detected ${results.trivy.secrets_count} secrets or credentials in the image.",
                 },
             },

--- a/regis_cli/analyzers/trivy.py
+++ b/regis_cli/analyzers/trivy.py
@@ -72,6 +72,79 @@ class TrivyAnalyzer(BaseAnalyzer):
     name = "trivy"
     schema_file = "trivy.schema.json"
 
+    @classmethod
+    def default_rules(cls) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "trivy-no-critical",
+                "title": "No CRITICAL vulnerabilities found by Trivy.",
+                "level": "critical",
+                "tags": ["security"],
+                "params": {"max_count": 0},
+                "condition": {
+                    "<=": [
+                        {"var": "results.trivy.critical_count"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "No critical vulnerabilities detected.",
+                    "fail": "Image has ${results.trivy.critical_count} critical CVEs (max allowed: ${rule.params.max_count}).",
+                },
+            },
+            {
+                "slug": "trivy-no-high",
+                "title": "No HIGH vulnerabilities found by Trivy.",
+                "level": "warning",
+                "tags": ["security"],
+                "params": {"max_count": 0},
+                "condition": {
+                    "<=": [
+                        {"var": "results.trivy.high_count"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "No high vulnerabilities detected.",
+                    "fail": "Image has ${results.trivy.high_count} high CVEs (max allowed: ${rule.params.max_count}).",
+                },
+            },
+            {
+                "slug": "trivy-fix-available",
+                "title": "All vulnerabilities should be fixed if a patch exists.",
+                "level": "warning",
+                "tags": ["security"],
+                "params": {"max_count": 0},
+                "condition": {
+                    "<=": [
+                        {"var": "results.trivy.fixed_count"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "All vulnerabilities with available fixes have been patched.",
+                    "fail": "Image has ${results.trivy.fixed_count} vulnerabilities with available fixes.",
+                },
+            },
+            {
+                "slug": "trivy-secret-scan",
+                "title": "No secrets or credentials should be embedded in the image.",
+                "level": "critical",
+                "tags": ["security"],
+                "params": {"max_count": 0},
+                "condition": {
+                    "<=": [
+                        {"var": "results.trivy.secrets_count"},
+                        {"var": "rule.params.max_count"},
+                    ]
+                },
+                "messages": {
+                    "pass": "No secrets detected in the image.",
+                    "fail": "Trivy detected ${results.trivy.secrets_count} secrets or credentials in the image.",
+                },
+            },
+        ]
+
     def analyze(
         self,
         client: RegistryClient,
@@ -80,10 +153,8 @@ class TrivyAnalyzer(BaseAnalyzer):
         platform: str | None = None,
     ) -> dict[str, Any]:
         """Run trivy analysis."""
-        # We need the full image reference for trivy (e.g. registry/repo:tag)
+        # ... (rest of image string logic)
         if client.registry == "docker.io" or client.registry == "registry-1.docker.io":
-            # For Docker Hub, trivy expects just repo:tag or library/repo:tag
-            # It handles the registry URL internally
             full_image = f"{repository}:{tag}"
         else:
             full_image = f"{client.registry}/{repository}:{tag}"
@@ -96,10 +167,6 @@ class TrivyAnalyzer(BaseAnalyzer):
                 platform=platform,
             )
         except AnalyzerError as exc:
-            # If analysis fails, we return a partial report or raise?
-            # BaseAnalyzer usually expects a valid report conforming to schema.
-            # But if trivy fails, we can't produce the schema.
-            # cli.py catches AnalyzerError and prints it.
             raise exc
 
         # Process results
@@ -111,19 +178,25 @@ class TrivyAnalyzer(BaseAnalyzer):
             "LOW": 0,
             "UNKNOWN": 0,
         }
+        fixed_count = 0
+        secrets_count = 0
 
         for result in data.get("Results", []):
             target_data = {
                 "Target": result.get("Target"),
                 "Vulnerabilities": [],
+                "Secrets": [],
             }
 
+            # Handle Vulnerabilities
             vulns = result.get("Vulnerabilities", [])
             if vulns:
                 clean_vulns = []
                 for v in vulns:
                     severity = v.get("Severity", "UNKNOWN")
                     counts[severity] = counts.get(severity, 0) + 1
+                    if v.get("FixedVersion"):
+                        fixed_count += 1
 
                     clean_vulns.append(
                         {
@@ -140,6 +213,22 @@ class TrivyAnalyzer(BaseAnalyzer):
             else:
                 target_data["Vulnerabilities"] = None
 
+            # Handle Secrets
+            secrets = result.get("Secrets", [])
+            if secrets:
+                secrets_count += len(secrets)
+                target_data["Secrets"] = [
+                    {
+                        "RuleID": s.get("RuleID"),
+                        "Title": s.get("Title"),
+                        "Severity": s.get("Severity"),
+                        "Match": s.get("Match"),
+                    }
+                    for s in secrets
+                ]
+            else:
+                target_data["Secrets"] = None
+
             targets.append(target_data)
 
         total = sum(counts.values())
@@ -155,5 +244,7 @@ class TrivyAnalyzer(BaseAnalyzer):
             "medium_count": counts["MEDIUM"],
             "low_count": counts["LOW"],
             "unknown_count": counts["UNKNOWN"],
+            "fixed_count": fixed_count,
+            "secrets_count": secrets_count,
             "targets": targets,
         }

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -160,7 +160,10 @@ main.add_command(gitlab_cmd, name="gitlab")
 
 
 def _run_playbooks(
-    playbook_paths: tuple[str, ...], analysis_report: dict[str, Any], formats: list[str]
+    playbook_paths: tuple[str, ...],
+    analysis_report: dict[str, Any],
+    formats: list[str],
+    show_rules: bool = False,
 ) -> dict[str, Any]:
     """Load and evaluate playbooks against an analysis report."""
     from regis_cli.playbook.engine import evaluate, load_playbook
@@ -199,11 +202,20 @@ def _run_playbooks(
 
                 summary_str = " · ".join(summary_parts)
                 click.echo(
-                    f"    {summary_str}  "
+                    f"    {summary_str} "
                     f"({pb_result['passed_scorecards']}/{pb_result['total_scorecards']} scorecards passed, "
                     f"{pb_result['score']}%)\n",
                     err=True,
                 )
+
+                if show_rules and pb_result.get("rules"):
+                    click.echo("    Rules Evaluation Summary:", err=True)
+                    for r in pb_result["rules"]:
+                        icon = "✅" if r["passed"] else "❌"
+                        if r["status"] == "incomplete":
+                            icon = "⚠️"
+                        click.echo(f"      {icon} [{r['slug']}] {r['message']}")
+                    click.echo("", err=True)
 
     # Build the final report.
     final_report = {
@@ -275,12 +287,36 @@ def _render_and_save_reports(
     pretty: bool,
 ) -> None:
     """Render and save reports in requested formats."""
-    from regis_cli.report.html import render_html
+    import shutil
 
     for fmt in formats:
         if fmt == "html":
+            from regis_cli.report.html import render_html
+
             # For HTML, generate one file per playbook if playbooks exist.
             playbook_results = report.get("playbooks", [])
+
+            # Copy theme assets (if any)
+            from importlib import resources as importlib_resources
+
+            try:
+                theme_assets = (
+                    importlib_resources.files("regis_cli.templates") / theme / "assets"
+                )
+                if theme_assets.is_dir():
+                    out_dir = _format_output_path(
+                        output_dir_template or ".", report, "json"
+                    )
+                    out_dir.mkdir(parents=True, exist_ok=True)
+                    for item in theme_assets.iterdir():
+                        dest = out_dir / item.name
+                        if item.is_dir():
+                            shutil.copytree(str(item), str(dest), dirs_exist_ok=True)
+                        else:
+                            shutil.copy2(str(item), str(dest))
+            except (FileNotFoundError, ModuleNotFoundError):
+                pass
+
             if playbook_results:
                 for pb in playbook_results:
                     # Pre-calculate filenames for all pages in this playbook to build navigation
@@ -301,7 +337,10 @@ def _render_and_save_reports(
                         elif source_name:
                             filename = f"{source_name}-{page.get('title', 'page').lower()}.{fmt}"
                         else:
-                            filename = f"report_{pb.get('playbook_name', 'unnamed')}_{page.get('title', 'page').lower()}.{fmt}"
+                            filename = (
+                                f"report_{pb.get('playbook_name', 'unnamed')}_"
+                                f"{page.get('title', 'page').lower()}.{fmt}"
+                            )
 
                         page_navigation.append(
                             {
@@ -333,6 +372,18 @@ def _render_and_save_reports(
                             fmt=fmt,
                             rendered=rendered,
                         )
+
+                # Generate a main report.json in the output directory
+                out_dir = _format_output_path(
+                    output_dir_template or ".", report, "json"
+                )
+                out_dir.mkdir(parents=True, exist_ok=True)
+                report_json_path = out_dir / "report.json"
+                indent = 2 if pretty else None
+                report_json_path.write_text(
+                    json.dumps(report, indent=indent, ensure_ascii=False),
+                    encoding="utf-8",
+                )
             else:
                 # No playbooks, just render the base report
                 rendered = render_html(report, theme=theme)
@@ -344,6 +395,12 @@ def _render_and_save_reports(
                     fmt=fmt,
                     rendered=rendered,
                 )
+
+            click.echo(
+                f"  Report site generated at "
+                f"{_format_output_path(output_dir_template or '.', report, fmt)}",
+                err=True,
+            )
         else:
             # JSON (and other formats): Single unified report file
             indent = 2 if pretty else None
@@ -466,13 +523,31 @@ def _render_mr_templates(
     help="Credentials in registry.domain=user:pass format. Can be repeated.",
 )
 @click.option(
+    "--platform",
+    help="Target platform for multi-arch images (e.g. linux/amd64).",
+)
+@click.option(
     "--cache",
     is_flag=True,
     help="Use existing report.json as cache if available.",
 )
 @click.option(
-    "--platform",
-    help="Target platform for multi-arch images (e.g. linux/amd64).",
+    "--evaluate",
+    is_flag=True,
+    default=False,
+    help="Run rules evaluation after analysis and add results to report.",
+)
+@click.option(
+    "--fail",
+    is_flag=True,
+    default=False,
+    help="Fail command execution if any rule is breached.",
+)
+@click.option(
+    "--fail-level",
+    default="critical",
+    type=click.Choice(["info", "warning", "critical"], case_sensitive=False),
+    help="Minimum rule level that triggers a command failure (default: critical).",
 )
 def analyze(
     url: str,
@@ -487,6 +562,9 @@ def analyze(
     auth: tuple[str, ...],
     cache: bool,
     platform: str | None = None,
+    evaluate: bool = False,
+    fail: bool = False,
+    fail_level: str = "critical",
 ) -> None:
     """Analyze a Docker image and evaluate playbooks.
 
@@ -560,11 +638,9 @@ def analyze(
         except Exception as exc:
             logger.debug("Cache lookup failed: %s", exc)
 
-    if final_report:
-        # If we have a cached report, we skip analysis and playbook evaluation.
-        # We might want to re-run playbooks eventually, but for now we follow the "cache report" intent.
-        pass
-    else:
+    analysis_report = final_report
+
+    if not analysis_report:
         # Discover analyzers.
         all_analyzers = _discover_analyzers()
         if not all_analyzers:
@@ -627,7 +703,7 @@ def analyze(
             else:
                 _set_nested_value(metadata_dict, item, "true")
 
-        analysis_report: dict[str, Any] = {
+        analysis_report = {
             "version": version("regis-cli"),
             "request": {
                 "url": url,
@@ -644,8 +720,19 @@ def analyze(
             analysis_report["metadata"] = metadata_dict
             analysis_report["request"]["metadata"] = metadata_dict
 
-        # 2. Run playbooks
-        final_report = _run_playbooks(playbook_paths, analysis_report, formats)
+    # 2. Run playbooks (always re-run if --evaluate or custom playbooks requested, or if not yet run)
+    if not final_report or evaluate or playbook_paths:
+        final_report = _run_playbooks(
+            playbook_paths, analysis_report, formats, show_rules=evaluate
+        )
+
+    if evaluate and "playbooks" in final_report and final_report["playbooks"]:
+        # Promote rules from the first playbook to the top level for visibility
+        pb0 = final_report["playbooks"][0]
+        final_report["rules"] = pb0.get("rules", [])
+        final_report["rules_summary"] = pb0.get("rules_summary", {})
+        final_report["tier"] = pb0.get("tier")
+        final_report["badges"] = pb0.get("badges", [])
 
     # 3. Validate final report
     _validate_report(final_report)
@@ -662,6 +749,28 @@ def analyze(
 
     # 5. Execute MR templates
     _render_mr_templates(final_report, output_dir_template)
+
+    # 6. Check for failures if requested
+    if evaluate and fail:
+        level_order = {"critical": 1, "warning": 2, "info": 3, "none": 4}
+        threshold = level_order.get(fail_level.lower(), 1)
+        breached_rules = []
+        # Rules from the final_report (either promoted or from previous analysis)
+        rules = final_report.get("rules", [])
+        for r in rules:
+            if not r.get("passed", False):
+                lvl = r.get("level", "info").lower()
+                if level_order.get(lvl, 3) <= threshold:
+                    breached_rules.append(r.get("slug", "unknown"))
+
+        if breached_rules:
+            click.echo(
+                f"\nError: Analysis failed due to {len(breached_rules)} rule breaches at level '{fail_level}' or above.",
+                err=True,
+            )
+            import sys
+
+            sys.exit(1)
 
 
 @main.command(name="evaluate")
@@ -912,8 +1021,187 @@ def check(url: str, auth: tuple[str, ...]) -> None:
 
 @main.command(name="version")
 def version_cmd() -> None:
-    """Display regis-cli version."""
+    """Show regis-cli version and exit."""
     click.echo(f"regis-cli version {version('regis-cli')}")
+
+
+@main.group(name="rules")
+def rules_group():
+    """Manage and evaluate rules."""
+    pass
+
+
+@rules_group.command(name="list")
+@click.option(
+    "-r",
+    "--rules",
+    "rules_path",
+    help="Path to an optional rules.yaml file to merge overrides.",
+)
+def list_rules(rules_path: str | None) -> None:
+    """List all available default rules and any overrides."""
+    import yaml
+
+    from regis_cli.cli import _discover_analyzers
+    from regis_cli.rules.evaluator import get_default_rules, merge_rules
+
+    analyzers = _discover_analyzers()
+    defaults = get_default_rules(list(analyzers.keys()))
+
+    custom = []
+    if rules_path:
+        path = Path(rules_path)
+        if path.exists():
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            custom = data.get("rules", [])
+
+    final_rules = merge_rules(defaults, custom)
+    final_rules.sort(key=lambda r: r.get("slug", ""))
+
+    if not final_rules:
+        click.echo("No rules found.")
+        return
+
+    for rule in final_rules:
+        enabled = rule.get("enable", True)
+        enabled_mark = "[x]" if enabled else "[ ]"
+        params = rule.get("params", {})
+        params_str = ""
+        if params:
+            params_str = f" ({', '.join(f'{k}={v}' for k, v in params.items())})"
+
+        click.echo(
+            f"  {enabled_mark} {rule.get('slug', 'unnamed'):25s} {rule.get('level', 'info'):8s} {rule.get('title', '')}{params_str}"
+        )
+
+
+@rules_group.command(name="show")
+@click.argument("slug")
+@click.option(
+    "-r",
+    "--rules",
+    "rules_path",
+    help="Path to an optional rules.yaml file to merge overrides.",
+)
+def show_rule(slug: str, rules_path: str | None) -> None:
+    """Display the full definition of a specific rule."""
+    import json
+
+    import yaml
+
+    from regis_cli.cli import _discover_analyzers
+    from regis_cli.rules.evaluator import get_default_rules, merge_rules
+
+    analyzers = _discover_analyzers()
+    defaults = get_default_rules(list(analyzers.keys()))
+
+    custom = []
+    if rules_path:
+        path = Path(rules_path)
+        if path.exists():
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            custom = data.get("rules", [])
+
+    final_rules = merge_rules(defaults, custom)
+    matching_rule = next((r for r in final_rules if r.get("slug") == slug), None)
+
+    if not matching_rule:
+        raise click.ClickException(f"Rule '{slug}' not found.")
+
+    click.echo(json.dumps(matching_rule, indent=2))
+
+
+@rules_group.command(name="evaluate")
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "-r",
+    "--rules",
+    "rules_path",
+    help="Path to custom rules.yaml file.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_file",
+    help="Output filename for the evaluation result (JSON format).",
+)
+@click.option(
+    "--fail",
+    is_flag=True,
+    default=False,
+    help="Fail command execution if any rule is breached.",
+)
+@click.option(
+    "--fail-level",
+    default="critical",
+    type=click.Choice(["info", "warning", "critical"], case_sensitive=False),
+    help="Minimum rule level that triggers a command failure (default: critical).",
+)
+def eval_rules(
+    input_path: str,
+    rules_path: str | None,
+    output_file: str | None,
+    fail: bool,
+    fail_level: str,
+) -> None:
+    """Evaluate a regis-cli JSON report against rules."""
+    import json
+
+    import yaml
+
+    from regis_cli.rules.evaluator import evaluate_rules
+
+    try:
+        report_data = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise click.ClickException(f"Failed to load report file: {exc}") from exc
+
+    rules_def = None
+    if rules_path:
+        try:
+            rules_def = yaml.safe_load(Path(rules_path).read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise click.ClickException(f"Failed to load rules file: {exc}") from exc
+
+    result = evaluate_rules(report_data, rules_def)
+
+    if output_file:
+        Path(output_file).write_text(
+            json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        click.echo(f"Evaluation report written to {output_file}", err=True)
+    else:
+        # Default text output if no JSON output is requested
+        score = result["score"]
+        click.echo(
+            f"\nRules Evaluation Score: {score}% ({result['passed_rules']}/{result['total_rules']})"
+        )
+        click.echo("-" * 40)
+        for r in result["rules"]:
+            icon = "✅" if r["passed"] else "❌"
+            if r["status"] == "incomplete":
+                icon = "⚠️"
+            click.echo(f"{icon} [{r['slug']}] {r['message']}")
+
+    if fail:
+        # Same level order as in evaluator.py
+        level_order = {"critical": 1, "warning": 2, "info": 3, "none": 4}
+        threshold = level_order.get(fail_level.lower(), 1)
+
+        breaches = []
+        for r in result["rules"]:
+            if not r["passed"]:
+                rule_level = r.get("level", "info").lower()
+                if level_order.get(rule_level, 3) <= threshold:
+                    breaches.append(r["slug"])
+
+        if breaches:
+            click.echo(
+                f"\nError: Evaluation failed due to {len(breaches)} rule breaches at level '{fail_level}' or above.",
+                err=True,
+            )
+            # Use sys.exit(1) for shell scripts/CI
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/regis_cli/gitlab_cli.py
+++ b/regis_cli/gitlab_cli.py
@@ -86,15 +86,15 @@ def update_mr(report_path: str, report_url: str, mr_url: str, token: str) -> Non
             proj_idx = path_parts.index("projects")
             project_id = int(path_parts[proj_idx + 1])
             mr_iid = int(path_parts[proj_idx + 3])
-        except (ValueError, IndexError):
+        except (ValueError, IndexError) as exc:
             raise click.ClickException(
                 f"Invalid MR URL format: {mr_url}. Expected format containing /projects/<id>/merge_requests/<iid>"
-            )
+            ) from exc
 
     except Exception as exc:
         if isinstance(exc, click.ClickException):
             raise
-        raise click.ClickException(f"Failed to parse MR URL: {exc}")
+        raise click.ClickException(f"Failed to parse MR URL: {exc}") from exc
 
     # Read the JSON report
     try:
@@ -128,9 +128,41 @@ def update_mr(report_path: str, report_url: str, mr_url: str, token: str) -> Non
     # 2. Extract labels and checklists from the playbook in the report
     playbook_data = report_data.get("playbook", {})
     labels = playbook_data.get("labels", [])
+    badge_labels = playbook_data.get("badge_labels", [])
     checklists = playbook_data.get("mr_description_checklists", [])
 
-    # 3. Build new MR description
+    # 3. Handle badge labels with colors
+    final_labels = list(labels)
+    class_colors = {
+        "success": "388e3c",
+        "warning": "fbc02d",
+        "error": "d32f2f",
+        "information": "1976d2",
+    }
+
+    for badge in badge_labels:
+        name = badge["name"]
+        cls = badge["class"]
+        color = class_colors.get(cls, "607d8b")  # default grey
+
+        try:
+            # Check if label exists, otherwise create it
+            try:
+                project.labels.get(name)
+            except gitlab.GitlabGetError:
+                project.labels.create({"name": name, "color": f"#{color}"})
+                click.echo(
+                    f"Created GitLab label '{name}' with color {color}", err=True
+                )
+
+            if name not in final_labels:
+                final_labels.append(name)
+        except Exception as exc:
+            click.echo(
+                f"Warning: Failed to manage GitLab label '{name}': {exc}", err=True
+            )
+
+    # 4. Build new MR description
     current_desc = mr.description or ""
     report_link_md = f"📝 **[View Analysis Report]({report_url})**"
 
@@ -168,10 +200,10 @@ def update_mr(report_path: str, report_url: str, mr_url: str, token: str) -> Non
     if new_desc != current_desc:
         update_kwargs["description"] = new_desc
 
-    if labels:
+    if final_labels:
         # Get existing labels to append new ones
         ext_labels = list(mr.labels)
-        for label in labels:
+        for label in final_labels:
             if label not in ext_labels:
                 ext_labels.append(label)
         update_kwargs["labels"] = ext_labels

--- a/regis_cli/playbook/evaluator.py
+++ b/regis_cli/playbook/evaluator.py
@@ -17,6 +17,7 @@ from regis_cli.playbook.context import NamedList, _build_context
 from regis_cli.playbook.integrations.gitlab import resolve_gitlab_integration
 from regis_cli.playbook.sections import _evaluate_section, resolve_widgets_final
 from regis_cli.playbook.templates import _resolve_template
+from regis_cli.rules.evaluator import evaluate_rules
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +170,19 @@ def evaluate(
     - ``sections``       — per-section breakdown (scorecards, levels, display, widgets)
     - ``score``          — overall percentage of scorecards passed (0–100)
     """
+    # 0. Evaluate rules (merges analyzer defaults with playbook 'rules' section)
+    rules_results = evaluate_rules(report, playbook)
+
+    # Inject rule results into the report so they are available in context (via dots)
+    # NamedList allows lookup by slug (e.g. rules.trivy-no-critical.passed)
+    report["rules"] = NamedList(rules_results["rules"])
+    report["rules_summary"] = {
+        "score": rules_results["score"],
+        "total": rules_results["all_rules"],
+        "passed": rules_results["passed_rules"],
+        "by_tag": rules_results["by_tag"],
+    }
+
     raw_context, nested_context = _build_context(report)
     pages_defs = _normalize_pages(playbook)
     pages_results, total_scorecards_all, total_passed_all = _evaluate_pages(
@@ -185,6 +199,8 @@ def evaluate(
         "total_scorecards": total_scorecards_all,
         "passed_scorecards": total_passed_all,
         "pages": NamedList(pages_results),
+        "rules": report["rules"],
+        "rules_summary": report["rules_summary"],
         "slug": playbook.get("slug"),
     }
 
@@ -200,6 +216,72 @@ def evaluate(
 
     # Final widget resolution pass (filters conditions, re-resolves playbook-aware paths)
     resolve_widgets_final(result["pages"], full_context)
+
+    # Resolve tiers
+    tiers = playbook.get("tiers", [])
+    if tiers:
+        from json_logic import jsonLogic
+
+        for tier in tiers:
+            condition = tier.get("condition")
+            if condition:
+                try:
+                    if jsonLogic(condition, full_context):
+                        result["tier"] = tier.get("name")
+                        break
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Tier condition evaluation failed: %s", exc)
+
+    # Resolve badges
+    badges = playbook.get("badges", [])
+    if badges:
+        resolved_badges = []
+        import re
+
+        from json_logic import jsonLogic
+
+        from regis_cli.playbook.templates import _resolve_path
+
+        # Regex for ${var.path} interpolation
+        interp_re = re.compile(r"\$\{([^}]+)\}")
+
+        def interpolate(tmpl: str, ctx: dict[str, Any]) -> str:
+            def _repl(m: re.Match[str]) -> str:
+                path = m.group(1).strip()
+                val = _resolve_path(path, ctx)
+                return str(val) if val is not None else m.group(0)
+
+            return interp_re.sub(_repl, tmpl)
+
+        for badge_def in badges:
+            condition = badge_def.get("condition")
+            if condition:
+                try:
+                    if not jsonLogic(condition, full_context):
+                        continue
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Badge condition evaluation failed: %s", exc)
+                    continue
+
+            scope = badge_def.get("scope", "")
+            value_tmpl = badge_def.get("value")
+            resolved_value = (
+                interpolate(value_tmpl, full_context) if value_tmpl else None
+            )
+
+            badge_res = {
+                "slug": badge_def.get("slug"),
+                "scope": scope,
+                "value": resolved_value,
+                "class": badge_def.get("class", "information"),
+            }
+            if badge_res["value"]:
+                badge_res["label"] = f"{scope}: {badge_res['value']}"
+            else:
+                badge_res["label"] = scope
+
+            resolved_badges.append(badge_res)
+        result["badges"] = resolved_badges
 
     # Resolve sidebar, links, and GitLab integration
     sidebar = playbook.get("sidebar")

--- a/regis_cli/playbook/integrations/gitlab.py
+++ b/regis_cli/playbook/integrations/gitlab.py
@@ -14,28 +14,34 @@ from regis_cli.playbook.conditions import evaluate_condition
 logger = logging.getLogger(__name__)
 
 
-def _resolve_labels(
+def _resolve_badge_labels(
     integration: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Evaluate GitLab label conditions and return resolved label names."""
-    label_defs = integration.get("labels", [])
-    if not label_defs:
+    """Resolve explicit badge slugs to be imported as GitLab labels."""
+    badge_slugs = integration.get("badges", [])
+    if not badge_slugs:
         return {}
 
-    resolved_labels: list[str] = []
-    for label_def in label_defs:
-        condition = label_def.get("condition")
-        if condition:
-            result = evaluate_condition(
-                condition, full_context, label=label_def.get("name", "")
-            )
-            if result and result.passed:
-                resolved_labels.append(label_def["name"])
-        else:
-            resolved_labels.append(label_def["name"])
+    # Get available badges for lookup
+    available_badges = {
+        b["slug"]: b for b in full_context.get("badges", []) if "slug" in b
+    }
 
-    return {"labels": list(set(resolved_labels))}
+    resolved_badge_labels: list[dict[str, Any]] = []
+    for slug in badge_slugs:
+        if slug in available_badges:
+            badge = available_badges[slug]
+            resolved_badge_labels.append(
+                {
+                    "name": badge["label"],
+                    "class": badge["class"],
+                }
+            )
+
+    if resolved_badge_labels:
+        return {"badge_labels": resolved_badge_labels}
+    return {}
 
 
 def _resolve_checklists(
@@ -130,13 +136,14 @@ def resolve_gitlab_integration(
     playbook: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Resolve all GitLab integration directives (labels, checklists, templates).
+    """Resolve all GitLab integration directives (badges, checklists, templates).
 
     Returns a dict merged into the evaluation result by the orchestrator.
     """
     integration = playbook.get("integrations", {}).get("gitlab", {})
     result: dict[str, Any] = {}
-    result.update(_resolve_labels(integration, full_context))
+    result.update(_resolve_badge_labels(integration, full_context))
     result.update(_resolve_checklists(integration, full_context))
     result.update(_resolve_templates(integration, full_context))
+
     return result

--- a/regis_cli/playbook/sections.py
+++ b/regis_cli/playbook/sections.py
@@ -28,6 +28,23 @@ def _evaluate_scorecards(
     """Evaluate each scorecard definition against the raw (flat) context."""
     scorecard_results: list[dict[str, Any]] = []
     for scorecard in scorecards_defs:
+        if scorecard.get("_pre_evaluated"):
+            # Use pre-evaluated result
+            res = scorecard["_rule_result"]
+            scorecard_results.append(
+                {
+                    "name": res["slug"],
+                    "title": res["title"],
+                    "level": res["level"],
+                    "tags": res["tags"],
+                    "analyzers": res["analyzers"],
+                    "passed": res["passed"],
+                    "status": res["status"],
+                    "message": res["message"],
+                }
+            )
+            continue
+
         condition = scorecard.get("condition", {})
         tracker = MissingDataTracker(raw_context)
         try:
@@ -209,7 +226,30 @@ def _evaluate_section(
 
     Returns a result dict for the section with scorecards, levels_summary, display, etc.
     """
-    scorecard_results = _evaluate_scorecards(section.get("scorecards", []), raw_context)
+    scorecards_defs = list(section.get("scorecards", []))
+
+    # Support 'rules' list (slugs) in section
+    # These rules were evaluated at the start of evaluate() and are in raw_context['rules']
+    rules_refs = section.get("rules", [])
+    if rules_refs:
+        rules_registry = raw_context.get("rules", {})
+        for ref in rules_refs:
+            if isinstance(ref, str) and ref in rules_registry:
+                # Map evaluated rule back to scorecard format for report compatibility
+                rule = rules_registry[ref]
+                scorecards_defs.append(
+                    {
+                        "name": rule["slug"],
+                        "title": rule["title"],
+                        "level": rule["level"],
+                        "tags": rule["tags"],
+                        "condition": "Already evaluated",
+                        "_pre_evaluated": True,
+                        "_rule_result": rule,
+                    }
+                )
+
+    scorecard_results = _evaluate_scorecards(scorecards_defs, raw_context)
     levels_summary = _compute_levels_summary(
         scorecard_results, section.get("levels", [])
     )

--- a/regis_cli/playbooks/default.yaml
+++ b/regis_cli/playbooks/default.yaml
@@ -1,6 +1,41 @@
 # yaml-language-server: $schema=../schemas/playbook.schema.json
 name: RegiS Default Playbook
 
+tiers:
+  - name: Gold
+    condition:
+      ">": [{ var: rules_summary.score }, 90]
+  - name: Silver
+    condition:
+      ">": [{ var: rules_summary.score }, 70]
+  - name: Bronze
+    condition:
+      ">": [{ var: rules_summary.score }, 50]
+
+badges:
+  - slug: score
+    scope: Score
+    value: ${rules_summary.score}
+    class: information
+  - slug: cve-critical
+    scope: CVE
+    value: Critical
+    condition:
+      "!!": [{ var: rules.trivy-no-critical.passed }]
+    class: error
+  - slug: cve-high
+    scope: CVE
+    value: High
+    condition:
+      "!!": [{ var: rules.trivy-no-high.passed }]
+    class: warning
+  - slug: freshness
+    scope: Freshness
+    value: Fresh !
+    condition:
+      "==": [{ var: rules.freshness-age.passed }, true]
+    class: success
+
 pages:
   - title: Overview
     slug: index
@@ -100,49 +135,22 @@ pages:
             options:
               align: center
       - name: Mandatory Requirements
-        scorecards:
-          - name: no-root
-            title: Image must not run as root.
-            level: critical
-            tags: [security]
-            condition:
-              "!=": [{ var: results.skopeo.platforms.0.user }, root]
-          - name: no-critical
-            title: No CRITICAL vulnerabilities found by Trivy.
-            level: critical
-            tags: [security]
-            condition:
-              "==": [{ var: results.trivy.critical_count }, 0]
-          - name: no-fatal
-            title: No FATAL issues found by Dockle.
-            level: critical
-            tags: [security]
-            condition:
-              "==": [{ var: results.dockle.issues_by_level.FATAL }, 0]
-          - name: trusted-domain
-            title: Image must originate from a trusted domain.
-            tags: [security]
-            condition:
-              "in":
-                [
-                  { var: request.registry },
-                  [docker.io, registry-1.docker.io, quay.io, ghcr.io],
-                ]
+        rules:
+          - trusted-domain
+          - skopeo-no-root
+          - trivy-no-critical
+          - dockle-no-fatal
+          - trivy-fix-available
+          - trivy-secret-scan
 
       - name: Recommended Requirements
-        scorecards:
-          - name: no-high
-            title: No HIGH vulnerabilities found by Trivy.
-            level: warning
-            tags: [security]
-            condition:
-              "==": [{ var: results.trivy.high_count }, 0]
-          - name: age
-            title: Image should be less than 30 days old.
-            level: warning
-            tags: [freshness]
-            condition:
-              "<": [{ var: results.freshness.age_days }, 30]
+        rules:
+          - trivy-no-high
+          - freshness-age
+          - skopeo-max-size
+          - skopeo-max-layers
+          - skopeo-tag-not-latest
+          - skopeo-required-labels
 
   - title: Security
     slug: security
@@ -261,46 +269,21 @@ pages:
 
 integrations:
   gitlab:
-    labels:
-      - name: regis::pass
-        condition: { ">=": [{ var: playbook.score }, 90] }
-      - name: regis::warn
-        condition:
-          {
-            and:
-              [
-                { ">=": [{ var: playbook.score }, 70] },
-                { "<": [{ var: playbook.score }, 90] },
-              ],
-          }
-      - name: regis::fail
-        condition: { "<": [{ var: playbook.score }, 70] }
-      - name: security::critical
-        condition: { ">": [{ var: results.trivy.critical_count }, 0] }
+    badges:
+      - score
+      - freshness
+      - cve-critical
+      - cve-high
     checklists:
       - title: 📝 Review Checklist
         items:
           - label: Revue de sécurité réalisée
           - label: Aucune vulnérabilité CRITIQUE détectée
-            show_if: { "==": [{ var: results.trivy.critical_count }, 0] }
-            check_if: { "==": [{ var: results.trivy.critical_count }, 0] }
+            show_if: { var: rules.trivy-no-critical.passed }
+            check_if: { var: rules.trivy-no-critical.passed }
           - label: Image issue d'un registre de confiance
-            show_if:
-              {
-                "in":
-                  [
-                    { var: request.registry },
-                    [docker.io, registry-1.docker.io, quay.io, ghcr.io],
-                  ],
-              }
-            check_if:
-              {
-                "in":
-                  [
-                    { var: request.registry },
-                    [docker.io, registry-1.docker.io, quay.io, ghcr.io],
-                  ],
-              }
+            show_if: { var: rules.trusted-domain.passed }
+            check_if: { var: rules.trusted-domain.passed }
     templates:
       - url: https://github.com/trivoallan/regis-cli
         directory: regis_cli/cookiecutters/mr-evidence

--- a/regis_cli/rules/__init__.py
+++ b/regis_cli/rules/__init__.py
@@ -1,0 +1,1 @@
+"""Rules engine module."""

--- a/regis_cli/rules/evaluator.py
+++ b/regis_cli/rules/evaluator.py
@@ -1,0 +1,305 @@
+"""Rules evaluation engine."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import json_logic
+from json_logic import jsonLogic
+
+from regis_cli.playbook.context import MissingDataTracker, _build_context
+
+logger = logging.getLogger(__name__)
+
+# Pattern for interpolating ${path.to.var}
+_INTERPOLATION_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _interpolate_string(template: str, context: dict[str, Any]) -> str:
+    """Interpolate ${vars} in a string using the context."""
+    if not template:
+        return template
+
+    def _repl(match: re.Match[str]) -> str:
+        var_path = match.group(1).strip()
+        # Find in context (can be flat key or nested)
+        if var_path in context:
+            return str(context[var_path])
+        parts = var_path.split(".")
+        curr: Any = context
+        for part in parts:
+            if isinstance(curr, dict) and part in curr:
+                curr = curr[part]
+            elif isinstance(curr, list):
+                if part == "length":
+                    curr = len(curr)
+                else:
+                    try:
+                        idx = int(part)
+                        curr = curr[idx]
+                    except (ValueError, IndexError):
+                        return match.group(0)
+            else:
+                return match.group(0)  # leave unresolved
+        return str(curr)
+
+    return _INTERPOLATION_RE.sub(_repl, template)
+
+
+def get_default_rules(analyzers_present: list[str]) -> list[dict[str, Any]]:
+    """Gather default rules from analyzers present in the report."""
+    from regis_cli.cli import _discover_analyzers
+
+    analyzers = _discover_analyzers()
+    default_rules = []
+
+    # Add core rules manually
+    default_rules.append(
+        {
+            "slug": "trusted-domain",
+            "title": "Image must originate from a trusted domain.",
+            "level": "critical",
+            "tags": ["security"],
+            "params": {
+                "domains": ["docker.io", "registry-1.docker.io", "quay.io", "ghcr.io"]
+            },
+            "condition": {
+                "in": [
+                    {"var": "request.registry"},
+                    {"var": "rule.params.domains"},
+                ]
+            },
+            "messages": {
+                "pass": "Image originates from a trusted domain.",
+                "fail": "Image registry '${request.registry}' is not in the trusted list.",
+            },
+        }
+    )
+
+    for name in analyzers_present:
+        if name in analyzers:
+            cls = analyzers[name]
+            default_rules.extend(cls.default_rules())
+
+    return default_rules
+
+
+def merge_rules(
+    default_rules: list[dict[str, Any]], custom_rules: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Merge custom rules over default rules based on 'slug'. Deeply merges nested dicts."""
+    merged = {}
+    for rule in default_rules:
+        slug = rule.get("slug")
+        if slug:
+            merged[slug] = rule
+        else:
+            merged[str(id(rule))] = rule
+
+    for rule in custom_rules:
+        slug = rule.get("slug")
+        key = slug if slug else str(id(rule))
+
+        if key in merged:
+            # Specifically merge 'messages' which is a nested dict
+            base_rule = merged[key]
+            override_rule = dict(rule)
+
+            if "messages" in override_rule and "messages" in base_rule:
+                merged_msg = dict(base_rule["messages"])
+                merged_msg.update(override_rule["messages"])
+                override_rule["messages"] = merged_msg
+
+            if "params" in override_rule and "params" in base_rule:
+                merged_params = dict(base_rule["params"])
+                merged_params.update(override_rule["params"])
+                override_rule["params"] = merged_params
+
+            merged[key] = {**base_rule, **override_rule}
+        else:
+            merged[key] = rule
+
+    return list(merged.values())
+
+
+def _add_custom_operations():
+    """Add custom regis-specific operations to jsonLogic."""
+    # intersects: any element of a is in b
+    # Usage: {"intersects": [["val1", "val2"], ["val2", "val3"]]} -> True
+    json_logic.add_operation(
+        "intersects",
+        lambda a, b: (
+            any(x in b for x in a)
+            if isinstance(a, list) and isinstance(b, list)
+            else False
+        ),
+    )
+
+    # contains_all: all elements of b are in a
+    # Usage: {"contains_all": [["val1", "val2", "val3"], ["val1", "val2"]]} -> True
+    json_logic.add_operation(
+        "contains_all",
+        lambda a, b: (
+            all(x in a for x in b)
+            if isinstance(a, list) and isinstance(b, list)
+            else False
+        ),
+    )
+
+    # subset: all elements of a are in b
+    # Usage: {"subset": [["val1", "val2"], ["val1", "val2", "val3"]]} -> True
+    json_logic.add_operation(
+        "subset",
+        lambda a, b: (
+            all(x in b for x in a)
+            if isinstance(a, list) and isinstance(b, list)
+            else False
+        ),
+    )
+
+    # keys: get keys of a dictionary
+    # Usage: {"keys": [{"var": "labels"}]} -> ["key1", "key2"]
+    json_logic.add_operation(
+        "keys", lambda a: list(a.keys()) if isinstance(a, dict) else []
+    )
+
+    # env_contains: any string in b is a substring of any string in a
+    # Usage: {"env_contains": [{"var": "results.skopeo.platforms.0.env"}, ["DEBUG", "SECRET"]]}
+    json_logic.add_operation(
+        "env_contains",
+        lambda a, b: (
+            any(any(sub in s for s in a) for sub in b)
+            if isinstance(a, list) and isinstance(b, list)
+            else False
+        ),
+    )
+
+
+_add_custom_operations()
+
+
+def evaluate_rules(
+    report: dict[str, Any], rules_def: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Evaluate a set of rules against the analysis report.
+
+    Args:
+        report: The analysis report dict.
+        rules_def: Optional parsed rules.yaml.
+    """
+    flat_context, _ = _build_context(report)
+
+    request_info = report.get("request", {})
+    analyzers_present = request_info.get("analyzers", [])
+
+    defaults = get_default_rules(analyzers_present)
+
+    custom = []
+    if rules_def and isinstance(rules_def.get("rules"), list):
+        custom = rules_def["rules"]
+
+    final_rules = merge_rules(defaults, custom)
+
+    results = []
+
+    # Filter out disabled rules first
+    enabled_rules = [r for r in final_rules if r.get("enable", True)]
+
+    for rule in enabled_rules:
+        # Inject the current rule into the flattened context
+        # This makes it accessible via e.g. {"var": "rule.params.max_days"}
+        flat_context["rule"] = rule
+
+        condition = rule.get("condition", {})
+        tracker = MissingDataTracker(flat_context)
+        try:
+            passed = bool(jsonLogic(condition, tracker))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Rule '%s' evaluation error: %s", rule.get("slug", "unknown"), exc
+            )
+            passed = False
+
+        status = (
+            "incomplete"
+            if tracker.missing_accessed
+            else ("passed" if passed else "failed")
+        )
+
+        messages = rule.get("messages", {})
+        message_tmpl = messages.get("pass" if passed else "fail", "")
+        message_resolved = _interpolate_string(message_tmpl, flat_context)
+
+        involved_analyzers = set()
+        for key in tracker.accessed_keys:
+            if key.startswith("results."):
+                parts = key.split(".")
+                if len(parts) > 1:
+                    involved_analyzers.add(parts[1])
+
+        results.append(
+            {
+                "slug": rule.get("slug", ""),
+                "title": rule.get("title", ""),
+                "level": rule.get("level", "info"),
+                "tags": rule.get("tags", []),
+                "passed": passed,
+                "status": status,
+                "message": message_resolved,
+                "analyzers": sorted(involved_analyzers),
+            }
+        )
+
+    # Sort results to be deterministic: failures first over passes, then by level, then slug
+    # Levels ordered by severity
+    level_order = {"critical": 1, "warning": 2, "info": 3, "none": 4}
+
+    results.sort(
+        key=lambda r: (
+            not r["passed"],
+            level_order.get(str(r["level"]).lower(), 99),
+            r["slug"],
+        )
+    )
+
+    all_rule_slugs = [r["slug"] for r in results]
+    passed_rule_slugs = [r["slug"] for r in results if r["passed"]]
+
+    # Group by tag
+    by_tag: dict[str, dict[str, Any]] = {}
+    for r in results:
+        for tag in r.get("tags", []):
+            if tag not in by_tag:
+                by_tag[tag] = {"rules": [], "passed_rules": [], "score": 0}
+
+            # Use explicit cast or type checking for mypy
+            rules_list = by_tag[tag]["rules"]
+            passed_list = by_tag[tag]["passed_rules"]
+
+            if isinstance(rules_list, list):
+                rules_list.append(r["slug"])
+            if r["passed"] and isinstance(passed_list, list):
+                passed_list.append(r["slug"])
+
+    for tag_stats in by_tag.values():
+        t_rules = tag_stats.get("rules", [])
+        t_passed = tag_stats.get("passed_rules", [])
+        if isinstance(t_rules, list) and isinstance(t_passed, list):
+            n_total = len(t_rules)
+            n_passed = len(t_passed)
+            if n_total > 0:
+                tag_stats["score"] = round(n_passed / n_total * 100)
+
+    return {
+        "score": (
+            round(len(passed_rule_slugs) / len(all_rule_slugs) * 100)
+            if all_rule_slugs
+            else 0
+        ),
+        "all_rules": all_rule_slugs,
+        "passed_rules": passed_rule_slugs,
+        "by_tag": by_tag,
+        "rules": results,
+    }

--- a/regis_cli/rules/evaluator.py
+++ b/regis_cli/rules/evaluator.py
@@ -72,7 +72,7 @@ def get_default_rules(analyzers_present: list[str]) -> list[dict[str, Any]]:
                 ]
             },
             "messages": {
-                "pass": "Image originates from a trusted domain.",
+                "pass": "Image originates from a trusted domain.",  # nosec B105
                 "fail": "Image registry '${request.registry}' is not in the trusted list.",
             },
         }

--- a/regis_cli/schemas/playbook.schema.json
+++ b/regis_cli/schemas/playbook.schema.json
@@ -101,23 +101,10 @@
         "gitlab": {
           "type": "object",
           "properties": {
-            "labels": {
+            "badges": {
               "type": "array",
-              "description": "Custom scoped labels applied to GitLab Merge Requests based on conditions.",
-              "items": {
-                "type": "object",
-                "required": ["name", "condition"],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Label name, e.g. 'regis::fail' or 'security::critical'."
-                  },
-                  "condition": {
-                    "type": "object",
-                    "description": "JsonLogic expression evaluated against the analysis report."
-                  }
-                }
-              }
+              "description": "List of badge slugs to be imported as GitLab Merge Request labels.",
+              "items": { "type": "string" }
             },
             "checklist": {
               "type": "array",

--- a/regis_cli/schemas/playbook_result.schema.json
+++ b/regis_cli/schemas/playbook_result.schema.json
@@ -16,6 +16,77 @@
     "sidebar": {
       "type": "object"
     },
+    "version": {
+      "type": ["string", "null"]
+    },
+    "tier": {
+      "type": ["string", "null"],
+      "description": "The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions."
+    },
+    "badges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "class"],
+        "properties": {
+          "slug": { "type": "string" },
+          "scope": { "type": "string" },
+          "value": { "type": ["string", "null"] },
+          "class": {
+            "type": "string",
+            "enum": ["success", "warning", "error", "information"]
+          },
+          "label": {
+            "type": "string",
+            "description": "The full label string (scope or scope: value)."
+          }
+        }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slug", "title", "passed", "status", "message"],
+        "properties": {
+          "slug": { "type": "string" },
+          "title": { "type": "string" },
+          "level": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "passed": { "type": "boolean" },
+          "status": {
+            "type": "string",
+            "enum": ["passed", "failed", "incomplete"]
+          },
+          "message": { "type": "string" },
+          "analyzers": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "rules_summary": {
+      "type": "object",
+      "required": ["score", "total", "passed"],
+      "properties": {
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "total": { "type": "array", "items": { "type": "string" } },
+        "passed": { "type": "array", "items": { "type": "string" } },
+        "by_tag": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["rules", "passed_rules", "score"],
+            "properties": {
+              "rules": { "type": "array", "items": { "type": "string" } },
+              "passed_rules": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "score": { "type": "integer", "minimum": 0, "maximum": 100 }
+            }
+          }
+        }
+      }
+    },
     "score": {
       "type": "integer",
       "minimum": 0,

--- a/regis_cli/schemas/report.schema.json
+++ b/regis_cli/schemas/report.schema.json
@@ -7,8 +7,29 @@
   "required": ["request", "results", "version"],
   "properties": {
     "version": {
-      "type": "string",
+      "type": ["string", "null"],
       "description": "Version of regis-cli that generated this report."
+    },
+    "tier": {
+      "type": ["string", "null"],
+      "description": "The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions."
+    },
+    "badges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "class"],
+        "properties": {
+          "slug": { "type": "string" },
+          "scope": { "type": "string" },
+          "value": { "type": ["string", "null"] },
+          "class": {
+            "type": "string",
+            "enum": ["success", "warning", "error", "information"]
+          },
+          "label": { "type": "string" }
+        }
+      }
     },
     "metadata": {
       "type": "object",
@@ -92,6 +113,51 @@
     "playbook": {
       "description": "Primary playbook result (shorthand for playbooks[0]).",
       "$ref": "playbook_result.schema.json"
+    },
+    "rules": {
+      "type": "array",
+      "description": "List of unified rule results (promoted from playbooks[0]).",
+      "items": {
+        "type": "object",
+        "required": ["slug", "title", "passed", "status", "message"],
+        "properties": {
+          "slug": { "type": "string" },
+          "title": { "type": "string" },
+          "level": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "passed": { "type": "boolean" },
+          "status": {
+            "type": "string",
+            "enum": ["passed", "failed", "incomplete"]
+          },
+          "message": { "type": "string" },
+          "analyzers": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "rules_summary": {
+      "type": "object",
+      "description": "Summary of rule evaluation results.",
+      "properties": {
+        "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "total": { "type": "array", "items": { "type": "string" } },
+        "passed": { "type": "array", "items": { "type": "string" } },
+        "by_tag": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["rules", "passed_rules", "score"],
+            "properties": {
+              "rules": { "type": "array", "items": { "type": "string" } },
+              "passed_rules": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "score": { "type": "integer", "minimum": 0, "maximum": 100 }
+            }
+          }
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/regis_cli/schemas/rules.schema.json
+++ b/regis_cli/schemas/rules.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://regis-cli.dev/schemas/rules.schema.json",
+  "title": "Rules definition",
+  "description": "Schema for regis-cli evaluating rules (rules.yaml).",
+  "type": "object",
+  "required": ["rules"],
+  "properties": {
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slug", "title", "condition", "messages"],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Identifier for the rule."
+          },
+          "title": {
+            "type": "string",
+            "description": "Human-readable title."
+          },
+          "level": {
+            "type": "string",
+            "enum": ["critical", "warning", "info", "none"],
+            "description": "Severity level of the rule."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Arbitrary tags to group rules."
+          },
+          "enable": {
+            "type": "boolean",
+            "description": "Whether the rule is enabled. Defaults to true.",
+            "default": true
+          },
+          "params": {
+            "type": "object",
+            "description": "Configurable parameters for the rule condition.",
+            "additionalProperties": true
+          },
+          "messages": {
+            "type": "object",
+            "required": ["pass", "fail"],
+            "properties": {
+              "pass": {
+                "type": "string",
+                "description": "Message rendered when rule passes."
+              },
+              "fail": {
+                "type": "string",
+                "description": "Message rendered when rule fails."
+              }
+            }
+          },
+          "condition": {
+            "type": "object",
+            "description": "JsonLogic condition evaluated against the flattened analysis report."
+          }
+        }
+      }
+    }
+  }
+}

--- a/regis_cli/templates/default/base.html
+++ b/regis_cli/templates/default/base.html
@@ -80,7 +80,19 @@
             {{ report.request.registry|e }}/{{ report.request.repository|e }}:{{
             report.request.tag|e }}
           </h1>
-          {% if report.links %}
+          {% if report.tier %}
+          <div style="margin-top: 0.5rem">
+            <span class="tier-badge tier-{{ report.tier|lower }}">
+              {{ report.tier }} Tier
+            </span>
+          </div>
+          {% endif %} {% if report.badges %}
+          <div style="margin-top: 0.5rem">
+            {% for badge in report.badges %}
+            <span class="badge bg-{{ badge.class }}"> {{ badge.label }} </span>
+            {% endfor %}
+          </div>
+          {% endif %} {% if report.links %}
           <hr />
           <section>
             <div class="custom-links" style="margin-top: 1rem">

--- a/regis_cli/templates/default/index.html
+++ b/regis_cli/templates/default/index.html
@@ -1,7 +1,11 @@
 {% extends theme ~ "/base.html" %} {% import theme ~ "/macros.html" as m with
 context %} {% block body %} {# Track which analyzers are claimed by scorecards
 #} {% set ns = namespace(claimed_analyzers=[]) %} {% for pb in
-report.playbooks|default([]) %}
+report.playbooks|default([]) %} {% if report.navigation and
+report.navigation[0].active %}
+<section id="rules">{% include theme ~ "/rules.html" with context %}</section>
+{% endif %}
+
 <section id="playbook-{{ loop.index0 }}">
   {% include theme ~ "/playbooks/default.html" with context %}
 </section>

--- a/regis_cli/templates/default/rules.html
+++ b/regis_cli/templates/default/rules.html
@@ -1,0 +1,151 @@
+{% if report.rules_summary and report.rules %}
+<section id="rules-summary" style="margin-bottom: 3rem">
+  <h3>Rules Evaluation</h3>
+
+  {% if report.rules_summary.by_tag %}
+  <div class="grid">
+    {% for tag, stats in report.rules_summary.by_tag.items()|sort %}
+    <article
+      class="tag-card"
+      onclick="filterByTag('{{ tag }}')"
+      style="cursor: pointer; transition: transform 0.2s"
+    >
+      <header
+        style="
+          padding: 0.5rem 1rem;
+          margin-bottom: 0.5rem;
+          background: var(--pico-secondary-background);
+          border-radius: var(--pico-border-radius) var(--pico-border-radius) 0 0;
+        "
+      >
+        <small
+          style="
+            text-transform: uppercase;
+            font-weight: bold;
+            letter-spacing: 0.05em;
+          "
+          >{{ tag }}</small
+        >
+      </header>
+      <div style="text-align: center">
+        <span style="font-size: 2rem; font-weight: bold; line-height: 1"
+          >{{ stats.score }}%</span
+        >
+        <br />
+        <small style="opacity: 0.7"
+          >{{ stats.passed_rules|length }} / {{ stats.rules|length }}
+          passed</small
+        >
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div
+    style="
+      margin-top: 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    "
+  >
+    <h4 style="margin: 0">Detailed Results</h4>
+    <div style="display: flex; gap: 0.5rem; align-items: center">
+      <small>Filter by tag:</small>
+      <select
+        id="tag-filter"
+        onchange="filterByTag(this.value)"
+        style="
+          margin-bottom: 0;
+          padding: 0.2rem 2rem 0.2rem 0.5rem;
+          width: auto;
+        "
+      >
+        <option value="all">All Tags</option>
+        {% for tag in report.rules_summary.by_tag.keys()|sort %}
+        <option value="{{ tag }}">{{ tag|capitalize }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+
+  <div class="overflow-auto" style="margin-top: 1rem">
+    <table class="striped" id="rules-table">
+      <thead>
+        <tr>
+          <th>Status</th>
+          <th>Level</th>
+          <th>Rule</th>
+          <th>Tags</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in report.rules %}
+        <tr class="rule-row" data-tags="{{ r.tags|join(' ') }}">
+          <td style="text-align: center">{{ m.bool_icon(r.passed) }}</td>
+          <td><small>{{ m.badge(r.level, status="outline") }}</small></td>
+          <td>
+            <strong>{{ r.title|e }}</strong>
+            <div style="font-size: 0.85rem; opacity: 0.8; margin-top: 0.2rem">
+              {{ r.message|e }}
+            </div>
+            {% if r.analyzers %}
+            <div style="margin-top: 0.4rem">
+              {% for a in r.analyzers %}
+              <small
+                style="
+                  background: var(--pico-muted-background);
+                  padding: 0.1rem 0.4rem;
+                  border-radius: 4px;
+                  font-size: 0.7rem;
+                  opacity: 0.7;
+                "
+                >{{ a }}</small
+              >
+              {% endfor %}
+            </div>
+            {% endif %}
+          </td>
+          <td>{% for tag in r.tags %} {{ m.badge(tag) }} {% endfor %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<script>
+  function filterByTag(tag) {
+    const table = document.getElementById("rules-table");
+    const select = document.getElementById("tag-filter");
+    const rows = table.getElementsByClassName("rule-row");
+    const cards = document.getElementsByClassName("tag-card");
+
+    // Update select value if called from card
+    select.value = tag;
+
+    for (let i = 0; i < rows.size || i < rows.length; i++) {
+      const row = rows[i];
+      const rowTags = row.getAttribute("data-tags").split(" ");
+      if (tag === "all" || rowTags.includes(tag)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    }
+
+    // Highlight active card
+    for (let i = 0; i < cards.length; i++) {
+      const card = cards[i];
+      if (card.getAttribute("onclick").includes("'" + tag + "'")) {
+        card.style.border = "2px solid var(--pico-primary)";
+        card.style.transform = "scale(1.05)";
+      } else {
+        card.style.border = "1px solid var(--pico-muted-border-color)";
+        card.style.transform = "scale(1)";
+      }
+    }
+  }
+</script>
+{% endif %}

--- a/regis_cli/templates/default/style.css
+++ b/regis_cli/templates/default/style.css
@@ -169,3 +169,76 @@ header h2 {
   margin-bottom: 0.5rem;
   text-align: center;
 }
+.tag-card {
+  margin-bottom: var(--pico-spacing);
+  border: 1px solid var(--pico-muted-border-color);
+}
+
+.tag-card:hover {
+  border-color: var(--pico-primary);
+  background: var(--pico-primary-background);
+}
+
+.rule-row td {
+  vertical-align: top;
+}
+
+/* Tier Badges */
+.tier-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 2rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.tier-gold {
+  background: linear-gradient(135deg, #ffd700, #ffae00);
+  color: #5c4b00;
+  border: 1px solid #d4af37;
+}
+
+.tier-silver {
+  background: linear-gradient(135deg, #c0c0c0, #a9a9a9);
+  color: #333;
+  border: 1px solid #999;
+}
+
+.tier-bronze {
+  background: linear-gradient(135deg, #cd7f32, #a0522d);
+  color: #fff;
+  border: 1px solid #8b4513;
+}
+
+/* Badge Classes */
+.bg-success {
+  background-color: #28a745 !important;
+  color: white !important;
+}
+.bg-warning {
+  background-color: #ffc107 !important;
+  color: black !important;
+}
+.bg-error {
+  background-color: #dc3545 !important;
+  color: white !important;
+}
+.bg-information {
+  background-color: #17a2b8 !important;
+  color: white !important;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-right: 0.25rem;
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)

--- a/tests/test_analyzer_dockle.py
+++ b/tests/test_analyzer_dockle.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_dockle.py
+++ b/tests/test_analyzer_dockle.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_freshness.py
+++ b/tests/test_analyzer_freshness.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_freshness.py
+++ b/tests/test_analyzer_freshness.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_hadolint.py
+++ b/tests/test_analyzer_hadolint.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_hadolint.py
+++ b/tests/test_analyzer_hadolint.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_popularity.py
+++ b/tests/test_analyzer_popularity.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import pytest
 import requests
 import responses

--- a/tests/test_analyzer_popularity.py
+++ b/tests/test_analyzer_popularity.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import pytest
 import requests
 import responses

--- a/tests/test_analyzer_provenance.py
+++ b/tests/test_analyzer_provenance.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_analyzer_provenance.py
+++ b/tests/test_analyzer_provenance.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_analyzer_scorecard.py
+++ b/tests/test_analyzer_scorecard.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzer_scorecard.py
+++ b/tests/test_analyzer_scorecard.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzer_size.py
+++ b/tests/test_analyzer_size.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_size.py
+++ b/tests/test_analyzer_size.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_analyzer_skopeo.py
+++ b/tests/test_analyzer_skopeo.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_skopeo.py
+++ b/tests/test_analyzer_skopeo.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_analyzer_trivy.py
+++ b/tests/test_analyzer_trivy.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzer_trivy.py
+++ b/tests/test_analyzer_trivy.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import pytest
 
 from regis_cli.analyzers.base import AnalyzerError

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import pytest
 
 from regis_cli.analyzers.base import AnalyzerError

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the regis-cli bootstrap command."""
 
 from pathlib import Path

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the regis-cli bootstrap command."""
 
 from pathlib import Path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the CLI."""
 
 import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the CLI."""
 
 import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,16 +169,15 @@ class TestCliBasics:
             )
             assert result.exit_code == 0
 
-            # Default HTML report filename is index.html (from first page of default playbook)
+            # Report data is written to report.json alongside the static SPA
             report_file = Path(
-                "reports/registry-1.docker.io/library-nginx/latest/index.html"
+                "reports/registry-1.docker.io/library-nginx/latest/report.json"
             )
-            html_content = report_file.read_text(encoding="utf-8")
+            report_data = json.loads(report_file.read_text(encoding="utf-8"))
 
-            assert "build" in html_content
-            assert "123" in html_content
-            assert "env" in html_content
-            assert "prod" in html_content
+            assert "metadata" in report_data
+            assert report_data["metadata"]["build"] == "123"
+            assert report_data["metadata"]["env"] == "prod"
 
 
 class TestCliCheck:

--- a/tests/test_coverage_analyzers.py
+++ b/tests/test_coverage_analyzers.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_coverage_analyzers.py
+++ b/tests/test_coverage_analyzers.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import subprocess
 from unittest.mock import MagicMock, patch

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner

--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner

--- a/tests/test_coverage_engine.py
+++ b/tests/test_coverage_engine.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from regis_cli.playbook.engine import (
     MissingDataTracker,
     _format_date,

--- a/tests/test_coverage_engine.py
+++ b/tests/test_coverage_engine.py
@@ -96,11 +96,7 @@ def test_evaluate_errors_and_edge_cases(caplog):
             {"label": "Link3", "url": "{{ 1/0 }}"},  # Template error
         ],
         "sidebar": {"title": "Sidebar"},
-        "integrations": {
-            "gitlab": {
-                "labels": [{"name": "L1", "condition": {"/": [1, 0]}}]  # Label error
-            }
-        },
+        "integrations": {"gitlab": {"badges": ["non-existent"]}},
     }
     report = {"results": {}}
 
@@ -113,9 +109,7 @@ def test_evaluate_errors_and_edge_cases(caplog):
     # Line 643 calls _resolve_template. _resolve_template catches Exception and returns template_str.
     # So the URL is "{{ 1/0 }}".
     assert "links" in result
-    assert (
-        result.get("labels") == []
-    )  # Labels is empty list if defined in playbook but none matched
+    assert result.get("badge_labels") is None  # No badges matched
 
 
 def test_render_order_tags_append():

--- a/tests/test_coverage_engine.py
+++ b/tests/test_coverage_engine.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from regis_cli.playbook.engine import (
     MissingDataTracker,
     _format_date,

--- a/tests/test_coverage_html.py
+++ b/tests/test_coverage_html.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 from regis_cli.report.html import render_html
 
 

--- a/tests/test_coverage_html.py
+++ b/tests/test_coverage_html.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 from regis_cli.report.html import render_html
 
 

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the end-of-life analyzer."""
 
 from regis_cli.analyzers.endoflife import (

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the end-of-life analyzer."""
 
 from regis_cli.analyzers.endoflife import (

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the freshness analyzer."""
 
 import json

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the freshness analyzer."""
 
 import json

--- a/tests/test_gh_env.py
+++ b/tests/test_gh_env.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 import os
 from pathlib import Path

--- a/tests/test_gh_env.py
+++ b/tests/test_gh_env.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 import os
 from pathlib import Path

--- a/tests/test_gitlab_cli.py
+++ b/tests/test_gitlab_cli.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the gitlab CLI subcommands in regis-cli."""
 
 import json

--- a/tests/test_gitlab_cli.py
+++ b/tests/test_gitlab_cli.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the gitlab CLI subcommands in regis-cli."""
 
 import json

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the hadolint analyzer."""
 
 import json

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the hadolint analyzer."""
 
 import json

--- a/tests/test_namedlist.py
+++ b/tests/test_namedlist.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import pytest
 from json_logic import jsonLogic
 

--- a/tests/test_namedlist.py
+++ b/tests/test_namedlist.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import pytest
 from json_logic import jsonLogic
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the URL parser."""
 
 import pytest

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the URL parser."""
 
 import pytest

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import yaml
 
@@ -334,10 +336,10 @@ class TestGitLabChecklist:
         ],
     }
 
-    def _make_playbook(self, checklist: list) -> dict:
+    def _make_playbook(self, checklist: list[Any]) -> dict[str, Any]:
         import copy
 
-        pb = copy.deepcopy(self.BASE_PLAYBOOK)
+        pb: dict[str, Any] = copy.deepcopy(self.BASE_PLAYBOOK)
         pb["integrations"] = {"gitlab": {"checklist": checklist}}
         return pb
 
@@ -544,10 +546,10 @@ class TestGitLabTemplates:
         ],
     }
 
-    def _make_playbook(self, templates: list) -> dict:
+    def _make_playbook(self, templates: list[Any]) -> dict[str, Any]:
         import copy
 
-        pb = copy.deepcopy(self.BASE_PLAYBOOK)
+        pb: dict[str, Any] = copy.deepcopy(self.BASE_PLAYBOOK)
         pb["integrations"] = {"gitlab": {"templates": templates}}
         return pb
 

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the playbook evaluation engine."""
 
 from __future__ import annotations

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the playbook evaluation engine."""
 
 from __future__ import annotations

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the popularity analyzer."""
 
 from regis_cli.analyzers.popularity import PopularityAnalyzer

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the popularity analyzer."""
 
 from regis_cli.analyzers.popularity import PopularityAnalyzer

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the provenance analyzer."""
 
 from regis_cli.analyzers.provenance import ProvenanceAnalyzer

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the provenance analyzer."""
 
 from regis_cli.analyzers.provenance import ProvenanceAnalyzer

--- a/tests/test_remote_playbook.py
+++ b/tests/test_remote_playbook.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for remote playbook loading."""
 
 from __future__ import annotations

--- a/tests/test_remote_playbook.py
+++ b/tests/test_remote_playbook.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for remote playbook loading."""
 
 from __future__ import annotations

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -1,3 +1,4 @@
+# trunk-ignore-all(bandit/B101)
 """Tests for rules evaluator."""
 
 from regis_cli.rules.evaluator import evaluate_rules, get_default_rules, merge_rules

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -1,4 +1,3 @@
-# trunk-ignore-all(bandit/B101)
 """Tests for rules evaluator."""
 
 from regis_cli.rules.evaluator import evaluate_rules, get_default_rules, merge_rules
@@ -36,9 +35,7 @@ def test_evaluate_rules():
             {
                 "slug": "freshness-age",
                 "condition": {"<": [{"var": "results.freshness.age_days"}, 30]},
-                "messages": {
-                    "pass": "Age is ${results.freshness.age_days}"
-                },  # nosec B105
+                "messages": {"pass": "Age is ${results.freshness.age_days}"},
             }
         ]
     }
@@ -50,7 +47,7 @@ def test_evaluate_rules():
     # Check interpolation
     rule_res = next(r for r in res["rules"] if r["slug"] == "freshness-age")
     assert rule_res["passed"] is True
-    assert rule_res["message"] == "Age is 10"  # nosec B105
+    assert rule_res["message"] == "Age is 10"
 
     # Check incomplete evaluations when data is missing
     rules_def_broken = {
@@ -91,6 +88,4 @@ def test_evaluate_rule_params():
     res2 = evaluate_rules(report, rules_def)
     freshness2 = next(r for r in res2["rules"] if r["slug"] == "freshness-age")
     assert freshness2["passed"] is False
-    assert (
-        freshness2["message"] == "Image is older than 7 days (15 days)."
-    )  # nosec B105
+    assert freshness2["message"] == "Image is older than 7 days (15 days)."

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -41,8 +41,8 @@ def test_evaluate_rules():
     }
 
     res = evaluate_rules(report, rules_def)
-    assert res["total_rules"] > 0
-    assert res["passed_rules"] > 0
+    assert len(res["all_rules"]) > 0
+    assert len(res["passed_rules"]) > 0
 
     # Check interpolation
     rule_res = next(r for r in res["rules"] if r["slug"] == "freshness-age")

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -35,7 +35,9 @@ def test_evaluate_rules():
             {
                 "slug": "freshness-age",
                 "condition": {"<": [{"var": "results.freshness.age_days"}, 30]},
-                "messages": {"pass": "Age is ${results.freshness.age_days}"},
+                "messages": {
+                    "pass": "Age is ${results.freshness.age_days}"
+                },  # nosec B105
             }
         ]
     }
@@ -47,7 +49,7 @@ def test_evaluate_rules():
     # Check interpolation
     rule_res = next(r for r in res["rules"] if r["slug"] == "freshness-age")
     assert rule_res["passed"] is True
-    assert rule_res["message"] == "Age is 10"
+    assert rule_res["message"] == "Age is 10"  # nosec B105
 
     # Check incomplete evaluations when data is missing
     rules_def_broken = {
@@ -88,4 +90,6 @@ def test_evaluate_rule_params():
     res2 = evaluate_rules(report, rules_def)
     freshness2 = next(r for r in res2["rules"] if r["slug"] == "freshness-age")
     assert freshness2["passed"] is False
-    assert freshness2["message"] == "Image is older than 7 days (15 days)."
+    assert (
+        freshness2["message"] == "Image is older than 7 days (15 days)."
+    )  # nosec B105

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -1,0 +1,91 @@
+"""Tests for rules evaluator."""
+
+from regis_cli.rules.evaluator import evaluate_rules, get_default_rules, merge_rules
+
+
+def test_get_default_rules():
+    rules = get_default_rules(["skopeo", "freshness"])
+    slugs = [r.get("slug") for r in rules]
+    assert "trusted-domain" in slugs
+    assert "skopeo-no-root" in slugs
+    assert "freshness-age" in slugs
+
+
+def test_merge_rules():
+    defaults = [{"slug": "test-1", "title": "A", "messages": {"pass": "ok"}}]
+    custom = [{"slug": "test-1", "title": "B", "messages": {"fail": "bad"}}]
+
+    merged = merge_rules(defaults, custom)
+    assert len(merged) == 1
+    assert merged[0]["title"] == "B"
+    assert merged[0]["messages"]["pass"] == "ok"
+    assert merged[0]["messages"]["fail"] == "bad"
+
+    # Deep merging didn't destroy existing properties that weren't overridden
+    assert merged[0]["slug"] == "test-1"
+
+
+def test_evaluate_rules():
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["freshness"]},
+        "results": {"freshness": {"age_days": 10}},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "freshness-age",
+                "condition": {"<": [{"var": "results.freshness.age_days"}, 30]},
+                "messages": {"pass": "Age is ${results.freshness.age_days}"},
+            }
+        ]
+    }
+
+    res = evaluate_rules(report, rules_def)
+    assert res["total_rules"] > 0
+    assert res["passed_rules"] > 0
+
+    # Check interpolation
+    rule_res = next(r for r in res["rules"] if r["slug"] == "freshness-age")
+    assert rule_res["passed"] is True
+    assert rule_res["message"] == "Age is 10"
+
+    # Check incomplete evaluations when data is missing
+    rules_def_broken = {
+        "rules": [
+            {
+                "slug": "missing-data-rule",
+                "condition": {"==": [{"var": "results.nonexistent.val"}, 1]},
+                "messages": {"fail": "Should be incomplete"},
+            },
+            {
+                "slug": "disabled-rule",
+                "enable": False,
+                "condition": {"==": [1, 1]},
+                "messages": {"pass": "Should not run"},
+            },
+        ]
+    }
+    res2 = evaluate_rules(report, rules_def_broken)
+
+    # Disabled rule should not be in results
+    assert len(res2["rules"]) == 3  # trusted-domain + freshness-age + missing-data-rule
+    assert not any(r["slug"] == "disabled-rule" for r in res2["rules"])
+
+
+def test_evaluate_rule_params():
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["freshness"]},
+        "results": {"freshness": {"age_days": 15}},
+    }
+
+    # 1. Defaults: freshness max_days is 30. Age is 15. Condition: 15 < 30 -> Pass.
+    res1 = evaluate_rules(report)
+    freshness = next(r for r in res1["rules"] if r["slug"] == "freshness-age")
+    assert freshness["passed"] is True
+
+    # 2. Override configured param to 7. Condition 15 < 7 -> Fail.
+    rules_def = {"rules": [{"slug": "freshness-age", "params": {"max_days": 7}}]}
+    res2 = evaluate_rules(report, rules_def)
+    freshness2 = next(r for r in res2["rules"] if r["slug"] == "freshness-age")
+    assert freshness2["passed"] is False
+    assert freshness2["message"] == "Image is older than 7 days (15 days)."

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the SBOM analyzer."""
 
 import json

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the SBOM analyzer."""
 
 import json

--- a/tests/test_scorecarddev.py
+++ b/tests/test_scorecarddev.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the scorecard analyzer."""
 
 from regis_cli.analyzers.scorecarddev import (

--- a/tests/test_scorecarddev.py
+++ b/tests/test_scorecarddev.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the scorecard analyzer."""
 
 from regis_cli.analyzers.scorecarddev import (

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the size analyzer."""
 
 import json

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the size analyzer."""
 
 import json

--- a/tests/test_skopeo_analyzer.py
+++ b/tests/test_skopeo_analyzer.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for the skopeo analyzer."""
 
 import json

--- a/tests/test_skopeo_analyzer.py
+++ b/tests/test_skopeo_analyzer.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for the skopeo analyzer."""
 
 import json

--- a/tests/test_trivy.py
+++ b/tests/test_trivy.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 """Tests for Trivy analyzer."""
 
 import subprocess

--- a/tests/test_trivy.py
+++ b/tests/test_trivy.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 """Tests for Trivy analyzer."""
 
 import subprocess

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,4 +1,5 @@
 # trunk-ignore-all(bandit/B101)
+# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(bandit/B101)
-# trunk-ignore-all(bandit/B101)
 import json
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
# Description

This PR implements a comprehensive status and categorization system for `regis-cli` and restores its core multi-page HTML reporting functionality.

## Core Features
- **Playbook Tiers**: Automatically categorize reports into Bronze, Silver, or Gold tiers based on scoring.
- **Dynamic Badges**: Support for ${var.path} interpolation in playbook badges with machine-readable slugs.
- **Rules Evaluation**: A new detailed summary section in the HTML report for rules-level assessment with tag filtering.
- **Multi-Page Reporting**: Restored the segmented HTML output (one file per playbook page) with functional sidebar navigation, matching `v0.15.0` behavior.

## Integrations
- **GitLab**: Simplified badge synchronization. Sync any badge to GitLab labels by slug.

## Documentation
- Updated `playbooks.adoc`, `gitlab.adoc`, and added `rules.adoc` to the Antora documentation.
- Updated Playbook JSON schemas.