### PR TITLE
fix(ci): Fix Trunk auto-format workflow to avoid stale SHA issue

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -37,23 +37,22 @@ jobs:
       - name: Trunk Format
         run: ${{ env.TRUNK_PATH }} fmt
 
-      - name: Commit and Push Changes
+      - name: Commit and Push Formatting Fixes
         if: github.event_name == 'pull_request'
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: ${{ github.head_ref }}
-          commit_message: "style(cli): apply automated trunk fmt"
+          commit_message: "style: apply automated trunk fmt"
           commit_user_name: github-actions[bot]
           commit_user_email: github-actions[bot]@users.noreply.github.com
           commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 
-      - name: Re-checkout merge ref
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.commit.outputs.commit_sha }}
-          fetch-depth: 0
+      - name: Fail if formatting fixes were needed
+        if: steps.commit.outputs.changes_detected == 'true'
+        run: |
+          echo "::error::Formatting issues were auto-fixed and committed to your branch. A new CI run will start — no action needed."
+          exit 1
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
## Problem

`trunk-io/trunk-action@v1` on PRs resolves the head from `github.event.pull_request.head.sha`, which is captured at workflow trigger time. The previous `Re-checkout merge ref` step had no effect on which commit Trunk actually linted — it would still compare against the original (pre-format) SHA and report formatting failures even after auto-fixing them.

## Fix

Replace the broken re-checkout + continue pattern with a **fail-fast + re-run** approach:

1. `trunk fmt` runs and fixes formatting
2. If changes were made → auto-commit and push to the PR branch, then **fail with a clear annotation** ("no action needed, new run starting")
3. The auto-commit triggers a fresh CI run → `trunk fmt` is a no-op → `trunk check` passes cleanly

## Changes

- Remove `Re-checkout merge ref` step (was ineffective)
- Rename step to `Commit and Push Formatting Fixes` for clarity
- Add `Fail if formatting fixes were needed` step with a user-friendly `::error::` annotation
- Fix commit message scope: `style(cli)` → `style` (fmt applies to the whole repo, not just the CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)