### PR TITLE
fix(playbook): Remove duplicate rules when templates are instantiated by playbook

### DIFF
--- a/regis_cli/rules/evaluator.py
+++ b/regis_cli/rules/evaluator.py
@@ -113,6 +113,9 @@ def merge_rules(
 
     # 2. Process custom rules
     processed_custom: list[dict[str, Any]] = []
+    # Track template keys that are explicitly instantiated under a new slug so that
+    # the original template entry can be removed from the final set (prevents duplicates).
+    instantiated_template_keys: set[tuple[str, str]] = set()
     for rule_def in custom_rules:
         provider = rule_def.get("provider")
         template_name = rule_def.get("rule")
@@ -169,6 +172,9 @@ def merge_rules(
                 }
                 instance.update(overrides)
                 processed_custom.append(instance)
+                # Mark the source template as consumed so it is not included twice
+                # in the final rule set (the instance takes its place).
+                instantiated_template_keys.add((provider, template_name))
             else:
                 logger.warning(
                     "Rule template '%s' not found for provider '%s'",
@@ -204,9 +210,11 @@ def merge_rules(
     # 3. Merge processed custom rules into the final set
     # Final result is still a list of rules with their (provider, slug) identity
     final_dict: dict[tuple[str, str], dict[str, Any]] = {}
-    # Re-initialize with defaults
+    # Re-initialize with defaults, skipping templates that were explicitly
+    # instantiated under a new slug by a custom rule (avoids duplicates).
     for k, v in merged.items():
-        final_dict[k] = v
+        if k not in instantiated_template_keys:
+            final_dict[k] = v
 
     for rule in processed_custom:
         # Provider and slug are now properly formatted thanks to previous loop


### PR DESCRIPTION
## Problem

When a playbook instantiated a default rule template under a new slug, the original template was **kept in the final rule set alongside the new instance**, causing:
- The same rule appearing twice in the Rules list
- The same rule appearing at multiple severity levels (e.g. both WARNING and INFO)

**Example:**
- `skopeo.tag-blacklist` (default, `level: warning`) + playbook instantiates it as `no-latest` (`level: info`) → both appeared
- `trivy.fix-available` (default) + playbook instantiates as `cve-fixable` → both appeared
- `trivy.cve-count` (default) + two instantiations (`cve-critical`, `cve-high`) → all three appeared

## Fix

In `merge_rules`, track which template keys are consumed by a custom rule instantiation (`instantiated_template_keys`). When building the initial `final_dict` from defaults, skip any template that was explicitly instantiated under a different slug.

The fix is minimal (3 lines) and localized to `regis_cli/rules/evaluator.py`.

## Test plan

- [ ] Run `pipenv run pytest` — all 251 tests pass
- [ ] Verify the Rules page in the report no longer shows duplicate entries
- [ ] Verify `no-latest` appears only in the INFO section, not in WARNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)