### PR TITLE
feat(cli): Add `bootstrap archive --sync-from` to sync UI changes back to template

### DIFF
--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -1028,6 +1028,129 @@ def bootstrap_playbook(output_dir: str, no_input: bool) -> None:
         raise click.ClickException(f"Failed to bootstrap playbook: {exc}") from exc
 
 
+def _sync_archive_template(working_copy: str) -> None:
+    """Sync UI changes from a working copy back to the archive cookiecutter template.
+
+    For each file in the template:
+    - Files with no Jinja2 variable references → copied back verbatim.
+    - Files with ``{{ cookiecutter.X }}`` references → concrete values are
+      substituted back to their placeholder form.
+    - Files containing Jinja2 block tags (``{%``) → skipped with a warning;
+      auto-merging conditional blocks is not safe.
+    """
+    from importlib import resources
+
+    working_path = Path(working_copy).resolve()
+    if not working_path.is_dir():
+        raise click.ClickException(f"Path '{working_copy}' is not a directory.")
+
+    sync_file = working_path / ".regis-sync.json"
+    if not sync_file.exists():
+        raise click.ClickException(
+            f"No .regis-sync.json found in {working_path}.\n"
+            "Only working copies bootstrapped with 'regis-cli bootstrap archive' are supported."
+        )
+
+    sync_meta = json.loads(sync_file.read_text(encoding="utf-8"))
+    context: dict[str, str] = sync_meta.get("context", {})
+    if not context:
+        raise click.ClickException(".regis-sync.json is missing the 'context' key.")
+
+    template_path = Path(
+        str(
+            resources.files("regis_cli")
+            / "cookiecutters"
+            / "archive"
+            / "{{cookiecutter.project_slug}}"
+        )
+    )
+
+    _SKIP_NAMES = {
+        ".regis-sync.json",
+        ".regis-post-install.md",
+        "pnpm-lock.yaml",
+        "package-lock.json",
+    }
+    _SKIP_DIRS = {"node_modules", ".next", "build", ".git"}
+    _SKIP_DIR_PREFIXES = {"static/archive"}
+
+    # Sort values longest-first to prevent shorter values masking longer ones
+    # during reverse substitution (e.g. "regis-archive" before "archive").
+    sorted_context = sorted(
+        context.items(), key=lambda kv: len(str(kv[1])), reverse=True
+    )
+
+    updated: list[Path] = []
+    skipped_complex: list[Path] = []
+    missing: list[Path] = []
+
+    for tmpl_file in sorted(template_path.rglob("*")):
+        if not tmpl_file.is_file():
+            continue
+
+        rel = tmpl_file.relative_to(template_path)
+
+        # Skip by directory
+        if any(part in _SKIP_DIRS for part in rel.parts):
+            continue
+        if any(str(rel).startswith(prefix) for prefix in _SKIP_DIR_PREFIXES):
+            continue
+        if rel.name in _SKIP_NAMES:
+            continue
+
+        working_file = working_path / rel
+        if not working_file.exists():
+            missing.append(rel)
+            continue
+
+        try:
+            tmpl_content = tmpl_file.read_text(encoding="utf-8")
+            working_content = working_file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue  # binary file — skip
+
+        # Files with Jinja2 block tags cannot be safely auto-merged
+        if "{%" in tmpl_content:
+            skipped_complex.append(rel)
+            continue
+
+        if "{{cookiecutter." in tmpl_content.replace(" ", ""):
+            # Reverse-substitute: replace concrete values with placeholders
+            new_content = working_content
+            for key, value in sorted_context:
+                if value and isinstance(value, str):
+                    new_content = new_content.replace(
+                        value, f"{{{{ cookiecutter.{key} }}}}"
+                    )
+        else:
+            # No variables in template — working copy content is the new template
+            new_content = working_content
+
+        if new_content != tmpl_content:
+            tmpl_file.write_text(new_content, encoding="utf-8")
+            updated.append(rel)
+
+    # Report
+    click.echo(f"\nSync: {working_path} → template", err=True)
+    if updated:
+        click.echo(f"\n  Updated ({len(updated)}):", err=True)
+        for f in sorted(updated):
+            click.echo(f"    ✓ {f}", err=True)
+    if skipped_complex:
+        click.echo(
+            f"\n  Skipped — Jinja2 block tags, manual sync required ({len(skipped_complex)}):",
+            err=True,
+        )
+        for f in sorted(skipped_complex):
+            click.echo(f"    ⚠ {f}", err=True)
+    if missing:
+        click.echo(f"\n  Not found in working copy ({len(missing)}):", err=True)
+        for f in sorted(missing):
+            click.echo(f"    - {f}", err=True)
+    if not updated:
+        click.echo("\n  No changes detected.", err=True)
+
+
 @bootstrap.command(name="archive")
 @click.argument(
     "output_dir", type=click.Path(file_okay=False, dir_okay=True), default="."
@@ -1074,6 +1197,13 @@ def bootstrap_playbook(output_dir: str, no_input: bool) -> None:
     default=None,
     help="Organisation or group to create the repo in (only with --repo).",
 )
+@click.option(
+    "--sync-from",
+    "sync_from",
+    default=None,
+    metavar="PATH",
+    help="Sync UI changes from a working copy back to the cookiecutter template.",
+)
 def bootstrap_archive(
     output_dir: str,
     no_input: bool,
@@ -1084,12 +1214,18 @@ def bootstrap_archive(
     repo_name: str | None,
     public: bool | None,
     org: str | None,
+    sync_from: str | None,
 ) -> None:
     """Bootstrap a standalone archive viewer site for regis-cli reports.
 
     Use --dev to start a local dev server after scaffolding.
     Use --repo to create a remote repository and enable Pages.
+    Use --sync-from PATH to sync UI changes back to the cookiecutter template.
     """
+    if sync_from:
+        _sync_archive_template(sync_from)
+        return
+
     if dev and repo:
         raise click.UsageError("--dev and --repo are mutually exclusive.")
 

--- a/regis_cli/cookiecutters/archive/{{cookiecutter.project_slug}}/.regis-sync.json
+++ b/regis_cli/cookiecutters/archive/{{cookiecutter.project_slug}}/.regis-sync.json
@@ -1,0 +1,10 @@
+{
+  "template": "archive",
+  "context": {
+    "project_name": "{{ cookiecutter.project_name }}",
+    "project_slug": "{{ cookiecutter.project_slug }}",
+    "description": "{{ cookiecutter.description }}",
+    "version": "{{ cookiecutter.version }}",
+    "platform": "{{ cookiecutter.platform }}"
+  }
+}

--- a/regis_cli/cookiecutters/archive/{{cookiecutter.project_slug}}/docusaurus.config.ts
+++ b/regis_cli/cookiecutters/archive/{{cookiecutter.project_slug}}/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
     },
     footer: {
       style: "dark",
-      copyright: `Powered by <a href="https://github.com/trivoallan/regis-cli">regis-cli</a>`,
+      copyright: `Powered by <a href="https://{{ cookiecutter.platform }}.com/trivoallan/regis-cli">regis-cli</a>`,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -318,7 +318,6 @@ class TestBootstrapArchiveSyncFrom:
 
     def test_changed_file_is_synced_back(self, tmp_path):
         """Modifying a file in the working copy syncs the change back to the template."""
-        import json
         from importlib import resources
 
         runner = CliRunner()
@@ -361,7 +360,6 @@ class TestBootstrapArchiveSyncFrom:
 
     def test_variable_placeholders_restored(self, tmp_path):
         """Cookiecutter variables are re-inserted when syncing docusaurus.config.ts."""
-        import json
         from importlib import resources
 
         runner = CliRunner()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -198,6 +198,13 @@ class TestBootstrapArchiveRepo:
 
     @patch("regis_cli.cli.shutil.which", return_value="/usr/bin/fake")
     @patch("regis_cli.cli.subprocess.run")
+    def test_sync_from_option_in_help(self, mock_run, _mock_which):
+        runner = CliRunner()
+        result = runner.invoke(main, ["bootstrap", "archive", "--help"])
+        assert "--sync-from" in result.output
+
+    @patch("regis_cli.cli.shutil.which", return_value="/usr/bin/fake")
+    @patch("regis_cli.cli.subprocess.run")
     def test_org_passed_to_gh(self, mock_run, _mock_which):
         gh_create_args: list[str] = []
 
@@ -227,3 +234,171 @@ class TestBootstrapArchiveRepo:
             )
         assert result.exit_code == 0, result.output
         assert any("myorg/regis-archive" in arg for arg in gh_create_args)
+
+
+class TestBootstrapArchiveSyncFrom:
+    """Tests for `bootstrap archive --sync-from`."""
+
+    _SYNC_META = {
+        "template": "archive",
+        "context": {
+            "project_name": "My Test Archive",
+            "project_slug": "my-test-archive",
+            "description": "A test archive site.",
+            "version": "0.19.0",
+            "platform": "github",
+        },
+    }
+
+    def _make_working_copy(self, tmp_path: Path, sync_meta: dict | None = None) -> Path:
+        """Create a minimal working copy with .regis-sync.json."""
+        import json
+
+        wc = tmp_path / "my-test-archive"
+        wc.mkdir()
+        meta = sync_meta or self._SYNC_META
+        (wc / ".regis-sync.json").write_text(json.dumps(meta), encoding="utf-8")
+        return wc
+
+    def test_missing_working_copy_errors(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["bootstrap", "archive", "--sync-from", "/nonexistent/path"]
+        )
+        assert result.exit_code != 0
+
+    def test_missing_sync_json_errors(self, tmp_path):
+        wc = tmp_path / "no-sync"
+        wc.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(main, ["bootstrap", "archive", "--sync-from", str(wc)])
+        assert result.exit_code != 0
+        assert ".regis-sync.json" in result.output
+
+    def test_sync_json_written_at_bootstrap(self, tmp_path):
+        """Bootstrapping an archive site produces a .regis-sync.json in the project."""
+        import json
+
+        runner = CliRunner()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        result = runner.invoke(
+            main, ["bootstrap", "archive", str(out_dir), "--no-input"]
+        )
+        assert result.exit_code == 0, result.output
+
+        project_dir = out_dir / "regis-archive"
+        sync_file = project_dir / ".regis-sync.json"
+        assert sync_file.exists()
+
+        meta = json.loads(sync_file.read_text(encoding="utf-8"))
+        assert meta["template"] == "archive"
+        assert meta["context"]["project_name"] == "RegiS Archive"
+        assert meta["context"]["project_slug"] == "regis-archive"
+        assert "platform" in meta["context"]
+
+    def test_sync_succeeds_on_fresh_working_copy(self, tmp_path):
+        """Syncing a fresh working copy exits cleanly with no error."""
+        runner = CliRunner()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        result = runner.invoke(
+            main, ["bootstrap", "archive", str(out_dir), "--no-input"]
+        )
+        assert result.exit_code == 0, result.output
+
+        project_dir = out_dir / "regis-archive"
+
+        result = runner.invoke(
+            main, ["bootstrap", "archive", "--sync-from", str(project_dir)]
+        )
+        assert result.exit_code == 0, result.output
+        # No crash, and the sync report was emitted
+        assert "Sync:" in result.output
+
+    def test_changed_file_is_synced_back(self, tmp_path):
+        """Modifying a file in the working copy syncs the change back to the template."""
+        import json
+        from importlib import resources
+
+        runner = CliRunner()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        result = runner.invoke(
+            main, ["bootstrap", "archive", str(out_dir), "--no-input"]
+        )
+        assert result.exit_code == 0, result.output
+        project_dir = out_dir / "regis-archive"
+
+        # Modify a plain file (no cookiecutter vars) in the working copy
+        custom_css = project_dir / "src" / "css" / "custom.css"
+        original = custom_css.read_text(encoding="utf-8")
+        custom_css.write_text(original + "\n/* my custom style */\n", encoding="utf-8")
+
+        result = runner.invoke(
+            main, ["bootstrap", "archive", "--sync-from", str(project_dir)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Updated" in result.output
+        assert "src/css/custom.css" in result.output
+
+        # The template file should now contain the new style
+        template_css = Path(
+            str(
+                resources.files("regis_cli")
+                / "cookiecutters"
+                / "archive"
+                / "{{cookiecutter.project_slug}}"
+                / "src"
+                / "css"
+                / "custom.css"
+            )
+        )
+        assert "/* my custom style */" in template_css.read_text(encoding="utf-8")
+
+        # Restore the template file to avoid polluting other test runs
+        template_css.write_text(original, encoding="utf-8")
+
+    def test_variable_placeholders_restored(self, tmp_path):
+        """Cookiecutter variables are re-inserted when syncing docusaurus.config.ts."""
+        import json
+        from importlib import resources
+
+        runner = CliRunner()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        result = runner.invoke(
+            main, ["bootstrap", "archive", str(out_dir), "--no-input"]
+        )
+        assert result.exit_code == 0, result.output
+        project_dir = out_dir / "regis-archive"
+
+        # Append a comment to docusaurus.config.ts in the working copy
+        config = project_dir / "docusaurus.config.ts"
+        original_wc = config.read_text(encoding="utf-8")
+        config.write_text(original_wc + "\n// end of config\n", encoding="utf-8")
+
+        template_config = Path(
+            str(
+                resources.files("regis_cli")
+                / "cookiecutters"
+                / "archive"
+                / "{{cookiecutter.project_slug}}"
+                / "docusaurus.config.ts"
+            )
+        )
+        original_tmpl = template_config.read_text(encoding="utf-8")
+
+        result = runner.invoke(
+            main, ["bootstrap", "archive", "--sync-from", str(project_dir)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "docusaurus.config.ts" in result.output
+
+        new_tmpl = template_config.read_text(encoding="utf-8")
+        # Concrete value replaced by placeholder
+        assert "{{ cookiecutter.project_name }}" in new_tmpl
+        assert "RegiS Archive" not in new_tmpl
+
+        # Restore
+        template_config.write_text(original_tmpl, encoding="utf-8")


### PR DESCRIPTION
Closes #77

## Summary

- Adds `regis-cli bootstrap archive --sync-from <path>` to sync UI edits from a working copy back to the cookiecutter template
- Adds a `.regis-sync.json` file to every bootstrapped working copy, storing the resolved cookiecutter context — this is what makes the reverse substitution possible without prompting the developer again

## How it works

The developer workflow becomes:
1. `regis-cli bootstrap archive --dev` → scaffold + start dev server
2. Edit UI files freely
3. `regis-cli bootstrap archive --sync-from ./my-archive/` → sync back to template

For each template file, the sync logic:
- **No Jinja2 variables** → direct copy (verbatim)
- **Has `{{ cookiecutter.X }}` references** → concrete values are reverse-substituted back to placeholder form (sorted by value length to avoid partial matches)
- **Has `{%` block tags** → skipped with a warning (conditional blocks can't be safely auto-merged)

The command reports which files were updated, skipped (complex), or missing from the working copy.

## Test plan

- [ ] `pipenv run pytest tests/test_bootstrap.py` — 19 tests pass
- [ ] Bootstrap an archive site, modify `src/components/ArchiveView.tsx`, run `--sync-from`, verify template is updated
- [ ] Verify `docusaurus.config.ts` has `{{ cookiecutter.project_name }}` restored after sync
- [ ] Verify `deploy.yml` is skipped with warning (has `{%` blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)