### PR TITLE
test: improve test coverage from 84% to 89%

### DIFF
--- a/regis_cli/commands/rules.py
+++ b/regis_cli/commands/rules.py
@@ -340,7 +340,7 @@ def eval_rules(
     else:
         score = result["score"]
         click.echo(
-            f"\nRules Evaluation Score: {score}% ({result['passed_rules']}/{result['total_rules']})"
+            f"\nRules Evaluation Score: {score}% ({result['passed_rules']}/{result['all_rules']})"
         )
         click.echo("-" * 40)
         for r in result["rules"]:

--- a/tests/test_archive_command.py
+++ b/tests/test_archive_command.py
@@ -1,7 +1,6 @@
 """Tests for 'regis-cli archive' command group."""
 
 import json
-from pathlib import Path
 
 from click.testing import CliRunner
 

--- a/tests/test_archive_command.py
+++ b/tests/test_archive_command.py
@@ -1,0 +1,72 @@
+"""Tests for 'regis-cli archive' command group."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from regis_cli.cli import main
+
+
+class TestArchiveAdd:
+    def test_happy_path(self, tmp_path):
+        report_file = tmp_path / "report.json"
+        report_file.write_text(
+            json.dumps(
+                {
+                    "request": {
+                        "registry": "docker.io",
+                        "repository": "library/nginx",
+                        "tag": "latest",
+                        "timestamp": "2024-01-15T10:00:00+00:00",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "add", str(report_file), "-A", str(archive_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Archived to" in result.output
+        assert "Manifest updated" in result.output
+        assert (archive_dir / "manifest.json").exists()
+
+    def test_invalid_json_fails(self, tmp_path):
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not valid json", encoding="utf-8")
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "add", str(bad_file), "-A", str(archive_dir)],
+        )
+
+        assert result.exit_code != 0
+        assert "Could not read" in result.output
+
+    def test_nonexistent_report_file_fails(self, tmp_path):
+        archive_dir = tmp_path / "archive"
+        archive_dir.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "add", str(tmp_path / "ghost.json"), "-A", str(archive_dir)],
+        )
+
+        assert result.exit_code != 0
+
+    def test_archive_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["archive", "--help"])
+        assert result.exit_code == 0
+        assert "add" in result.output

--- a/tests/test_archive_store.py
+++ b/tests/test_archive_store.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-import pytest
-
 from regis_cli.archive.store import (
     _load_json_array,
     _make_summary,

--- a/tests/test_archive_store.py
+++ b/tests/test_archive_store.py
@@ -1,0 +1,199 @@
+"""Tests for regis_cli.archive.store."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from regis_cli.archive.store import (
+    _load_json_array,
+    _make_summary,
+    _safe_segment,
+    add_to_archive,
+)
+
+_MINIMAL_REPORT = {
+    "request": {
+        "registry": "docker.io",
+        "repository": "library/nginx",
+        "tag": "latest",
+        "timestamp": "2024-01-15T10:00:00+00:00",
+        "digest": "sha256:abc123",
+    },
+    "rules_summary": {"passed": ["r1", "r2"], "total": ["r1", "r2", "r3"], "score": 66},
+    "results": {
+        "trivy": {
+            "critical_count": 0,
+            "high_count": 1,
+            "medium_count": 3,
+            "low_count": 5,
+        },
+        "freshness": {"age_days": 10},
+        "sbom": {"component_count": 42},
+        "scorecarddev": {"score": 7.5},
+    },
+}
+
+
+class TestMakeSummary:
+    def test_full_report_list_based(self):
+        summary = _make_summary(
+            _MINIMAL_REPORT, "docker.io/nginx/latest/ts/report.json"
+        )
+        assert summary["registry"] == "docker.io"
+        assert summary["repository"] == "library/nginx"
+        assert summary["tag"] == "latest"
+        assert summary["rules_passed"] == 2
+        assert summary["rules_total"] == 3
+        assert summary["score"] == 66
+        assert summary["cve_critical"] == 0
+        assert summary["cve_high"] == 1
+        assert summary["age_days"] == 10
+        assert summary["sbom_component_count"] == 42
+        assert summary["scorecard_score"] == 7.5
+        assert summary["digest"] == "sha256:abc123"
+        assert summary["path"] == "docker.io/nginx/latest/ts/report.json"
+
+    def test_int_based_rules_summary(self):
+        report = {
+            **_MINIMAL_REPORT,
+            "rules_summary": {"passed": 5, "total": 10, "score": 50},
+        }
+        summary = _make_summary(report, "path")
+        assert summary["rules_passed"] == 5
+        assert summary["rules_total"] == 10
+
+    def test_missing_request_and_results(self):
+        summary = _make_summary({}, "path")
+        assert summary["registry"] == "unknown"
+        assert summary["repository"] == "unknown"
+        assert summary["tag"] == "unknown"
+        assert summary["rules_passed"] == 0
+        assert summary["rules_total"] == 0
+        assert summary["cve_critical"] is None
+        assert summary["age_days"] is None
+
+    def test_tier_from_top_level(self):
+        report = {**_MINIMAL_REPORT, "tier": "gold"}
+        summary = _make_summary(report, "path")
+        assert summary["tier"] == "gold"
+
+    def test_tier_from_playbook(self):
+        report = {**_MINIMAL_REPORT, "playbook": {"tier": "silver"}}
+        summary = _make_summary(report, "path")
+        assert summary["tier"] == "silver"
+
+    def test_timestamp_auto_generated_when_missing(self):
+        report = {"request": {"registry": "r", "repository": "repo", "tag": "t"}}
+        summary = _make_summary(report, "path")
+        assert isinstance(summary["timestamp"], str)
+        assert len(summary["timestamp"]) > 0
+
+    def test_id_format(self):
+        summary = _make_summary(_MINIMAL_REPORT, "path")
+        assert summary["id"].startswith("docker.io/library/nginx/latest/")
+
+
+class TestSafeSegment:
+    def test_replaces_slash(self):
+        assert _safe_segment("a/b") == "a_b"
+
+    def test_replaces_backslash(self):
+        assert _safe_segment("a\\b") == "a_b"
+
+    def test_replaces_colon(self):
+        assert _safe_segment("host:port") == "host_port"
+
+    def test_plain_string_unchanged(self):
+        assert _safe_segment("nginx") == "nginx"
+
+
+class TestLoadJsonArray:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _load_json_array(tmp_path / "missing.json") == []
+
+    def test_invalid_json_returns_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("not json", encoding="utf-8")
+        assert _load_json_array(p) == []
+
+    def test_json_object_returns_empty(self, tmp_path):
+        p = tmp_path / "obj.json"
+        p.write_text('{"key": "value"}', encoding="utf-8")
+        assert _load_json_array(p) == []
+
+    def test_valid_array_returned(self, tmp_path):
+        p = tmp_path / "data.json"
+        p.write_text('[{"id": "x"}]', encoding="utf-8")
+        assert _load_json_array(p) == [{"id": "x"}]
+
+
+class TestAddToArchive:
+    def test_creates_report_file(self, tmp_path):
+        dest = add_to_archive(_MINIMAL_REPORT, tmp_path / "archive")
+        assert dest.exists()
+        assert dest.name == "report.json"
+
+    def test_creates_manifest_and_data(self, tmp_path):
+        archive = tmp_path / "archive"
+        add_to_archive(_MINIMAL_REPORT, archive)
+        assert (archive / "manifest.json").exists()
+        assert (archive / "data.json").exists()
+
+    def test_manifest_contains_summary(self, tmp_path):
+        archive = tmp_path / "archive"
+        add_to_archive(_MINIMAL_REPORT, archive)
+        manifest = json.loads((archive / "manifest.json").read_text(encoding="utf-8"))
+        assert len(manifest) == 1
+        assert manifest[0]["registry"] == "docker.io"
+
+    def test_second_entry_appended(self, tmp_path):
+        archive = tmp_path / "archive"
+        report2 = {
+            **_MINIMAL_REPORT,
+            "request": {
+                **_MINIMAL_REPORT["request"],
+                "timestamp": "2024-01-16T10:00:00+00:00",
+            },
+        }
+        add_to_archive(_MINIMAL_REPORT, archive)
+        add_to_archive(report2, archive)
+        manifest = json.loads((archive / "manifest.json").read_text(encoding="utf-8"))
+        assert len(manifest) == 2
+
+    def test_deduplication_by_id(self, tmp_path):
+        archive = tmp_path / "archive"
+        add_to_archive(_MINIMAL_REPORT, archive)
+        add_to_archive(_MINIMAL_REPORT, archive)
+        manifest = json.loads((archive / "manifest.json").read_text(encoding="utf-8"))
+        assert len(manifest) == 1
+
+    def test_sorted_newest_first(self, tmp_path):
+        archive = tmp_path / "archive"
+        old = {
+            **_MINIMAL_REPORT,
+            "request": {
+                **_MINIMAL_REPORT["request"],
+                "timestamp": "2024-01-10T00:00:00+00:00",
+            },
+        }
+        new = {
+            **_MINIMAL_REPORT,
+            "request": {
+                **_MINIMAL_REPORT["request"],
+                "timestamp": "2024-01-20T00:00:00+00:00",
+            },
+        }
+        add_to_archive(old, archive)
+        add_to_archive(new, archive)
+        manifest = json.loads((archive / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest[0]["timestamp"] > manifest[1]["timestamp"]
+
+    def test_pretty_false_compact_json(self, tmp_path):
+        dest = add_to_archive(_MINIMAL_REPORT, tmp_path / "archive", pretty=False)
+        content = dest.read_text(encoding="utf-8")
+        assert "\n" not in content
+
+    def test_returns_path_object(self, tmp_path):
+        dest = add_to_archive(_MINIMAL_REPORT, tmp_path / "archive")
+        assert isinstance(dest, Path)

--- a/tests/test_rules_command.py
+++ b/tests/test_rules_command.py
@@ -1,12 +1,9 @@
 """Tests for 'regis-cli rules show' and 'rules evaluate' commands."""
 
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-import yaml
 from click.testing import CliRunner
 
 from regis_cli.cli import main

--- a/tests/test_rules_command.py
+++ b/tests/test_rules_command.py
@@ -1,0 +1,194 @@
+"""Tests for 'regis-cli rules show' and 'rules evaluate' commands."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from regis_cli.cli import main
+
+# Minimal analysis report that satisfies the evaluator
+_MINIMAL_REPORT = {
+    "request": {
+        "registry": "docker.io",
+        "repository": "library/nginx",
+        "tag": "latest",
+        "analyzers": [],
+    },
+    "results": {},
+}
+
+
+class TestRulesShow:
+    def test_show_existing_rule(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "show", "registry-domain-whitelist"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["slug"] == "registry-domain-whitelist"
+        assert data["level"] == "critical"
+
+    def test_show_unknown_rule_fails(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "show", "nonexistent-slug"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_show_with_nonexistent_rules_file(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "rules",
+                "show",
+                "registry-domain-whitelist",
+                "--rules",
+                str(tmp_path / "missing.yaml"),
+            ],
+        )
+        # Should still work — missing file is silently ignored
+        assert result.exit_code == 0
+
+
+class TestRulesList:
+    def test_markdown_with_params_shows_options(self):
+        """rules list --format markdown renders params for rules that have them."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "list", "--format", "markdown"])
+        assert result.exit_code == 0
+        # registry-domain-whitelist has params.domains
+        assert "domains" in result.output
+
+    def test_nonexistent_rules_file_ignored(self, tmp_path):
+        """Passing a non-existent --rules file should not crash."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "list", "--rules", str(tmp_path / "ghost.yaml")],
+        )
+        assert result.exit_code == 0
+        # Default rules still shown
+        assert "registry-domain-whitelist" in result.output
+
+
+class TestRulesEvaluate:
+    def _write_report(self, tmp_path: Path, report: dict | None = None) -> Path:
+        p = tmp_path / "report.json"
+        p.write_text(json.dumps(report or _MINIMAL_REPORT), encoding="utf-8")
+        return p
+
+    def test_stdout_output(self, tmp_path):
+        report_file = self._write_report(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "evaluate", str(report_file)])
+        assert result.exit_code == 0
+        assert "Rules Evaluation Score" in result.output
+
+    def test_file_output(self, tmp_path):
+        report_file = self._write_report(tmp_path)
+        out_file = tmp_path / "eval.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "evaluate", str(report_file), "-o", str(out_file)],
+        )
+        assert result.exit_code == 0
+        assert out_file.exists()
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert "score" in data
+        assert "rules" in data
+
+    def test_with_rules_yaml(self, tmp_path):
+        report_file = self._write_report(tmp_path)
+        rules_yaml = tmp_path / "rules.yaml"
+        rules_yaml.write_text("rules: []\n", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "evaluate", str(report_file), "--rules", str(rules_yaml)],
+        )
+        assert result.exit_code == 0
+
+    def test_invalid_report_json_fails(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "evaluate", str(bad)])
+        assert result.exit_code != 0
+        assert "Failed to load report file" in result.output
+
+    def test_invalid_rules_yaml_fails(self, tmp_path):
+        report_file = self._write_report(tmp_path)
+        bad_rules = tmp_path / "bad.yaml"
+        bad_rules.write_text(":\ninvalid:\n  - yaml: [unclosed", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "evaluate", str(report_file), "--rules", str(bad_rules)],
+        )
+        assert result.exit_code != 0
+        assert "Failed to load rules file" in result.output
+
+    def test_fail_flag_exits_nonzero_on_breach(self, tmp_path):
+        """--fail exits 1 when a failing rule meets the fail-level threshold."""
+        report_file = self._write_report(
+            tmp_path,
+            {
+                **_MINIMAL_REPORT,
+                "request": {
+                    **_MINIMAL_REPORT["request"],
+                    "registry": "unknown.registry.io",
+                },
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "rules",
+                "evaluate",
+                str(report_file),
+                "--fail",
+                "--fail-level",
+                "critical",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_fail_flag_exits_zero_no_breach(self, tmp_path):
+        """--fail exits 0 when the failing rule is below the fail-level threshold."""
+        # Use docker.io which passes the whitelist check
+        report_file = self._write_report(tmp_path)
+        runner = CliRunner()
+        with patch("regis_cli.rules.evaluator.evaluate_rules") as mock_eval:
+            mock_eval.return_value = {
+                "score": 100,
+                "all_rules": ["r1"],
+                "passed_rules": ["r1"],
+                "by_tag": {},
+                "rules": [
+                    {
+                        "slug": "r1",
+                        "passed": True,
+                        "level": "info",
+                        "status": "passed",
+                        "message": "",
+                    }
+                ],
+            }
+            result = runner.invoke(
+                main,
+                [
+                    "rules",
+                    "evaluate",
+                    str(report_file),
+                    "--fail",
+                    "--fail-level",
+                    "critical",
+                ],
+            )
+        assert result.exit_code == 0

--- a/tests/test_utils_report.py
+++ b/tests/test_utils_report.py
@@ -1,10 +1,6 @@
 """Tests for regis_cli.utils.report — uncovered paths."""
 
-import json
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from regis_cli.utils.report import escape_jinja, run_playbooks
 
@@ -84,8 +80,6 @@ class TestRunPlaybooks:
     def test_remote_path_shows_downloading(self, mock_eval, mock_load, capsys):
         mock_load.return_value = {}
         mock_eval.return_value = self._make_pb_result()
-
-        import click
 
         with patch("regis_cli.utils.report.click.echo") as mock_echo:
             run_playbooks(

--- a/tests/test_utils_report.py
+++ b/tests/test_utils_report.py
@@ -1,0 +1,171 @@
+"""Tests for regis_cli.utils.report — uncovered paths."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from regis_cli.utils.report import escape_jinja, run_playbooks
+
+
+class TestEscapeJinja:
+    def test_double_brace_wrapped(self):
+        result = escape_jinja("{{ variable }}")
+        assert result == "{% raw %}{{ variable }}{% endraw %}"
+
+    def test_percent_brace_wrapped(self):
+        result = escape_jinja("{% block content %}")
+        assert result == "{% raw %}{% block content %}{% endraw %}"
+
+    def test_plain_string_unchanged(self):
+        assert escape_jinja("hello world") == "hello world"
+
+    def test_dict_values_escaped(self):
+        result = escape_jinja({"key": "{{ val }}", "plain": "text"})
+        assert result["key"] == "{% raw %}{{ val }}{% endraw %}"
+        assert result["plain"] == "text"
+
+    def test_list_values_escaped(self):
+        result = escape_jinja(["{{ a }}", "plain"])
+        assert result[0] == "{% raw %}{{ a }}{% endraw %}"
+        assert result[1] == "plain"
+
+    def test_non_string_passthrough(self):
+        assert escape_jinja(42) == 42
+        assert escape_jinja(None) is None
+
+
+class TestRunPlaybooks:
+    """Test run_playbooks with various options."""
+
+    _ANALYSIS_REPORT = {
+        "request": {
+            "registry": "docker.io",
+            "repository": "library/nginx",
+            "tag": "latest",
+            "analyzers": [],
+        },
+        "results": {},
+    }
+
+    def _make_pb_result(
+        self, *, passed: bool = True, with_rules: bool = False, with_links: bool = False
+    ) -> dict:
+        rules = []
+        if with_rules:
+            rules = [
+                {"slug": "r1", "passed": True, "status": "passed", "message": "ok"},
+                {"slug": "r2", "passed": False, "status": "failed", "message": "fail"},
+                {
+                    "slug": "r3",
+                    "passed": False,
+                    "status": "incomplete",
+                    "message": "missing data",
+                },
+            ]
+        result = {
+            "score": 100 if passed else 0,
+            "sections": [],
+            "rules_summary": {
+                "passed": ["r1"] if passed else [],
+                "total": ["r1"],
+                "score": 100 if passed else 0,
+            },
+            "rules": rules,
+            "tier": None,
+        }
+        if with_links:
+            result["links"] = [{"url": "https://example.com", "label": "Docs"}]
+        return result
+
+    @patch("regis_cli.playbook.engine.load_playbook")
+    @patch("regis_cli.playbook.engine.evaluate")
+    def test_remote_path_shows_downloading(self, mock_eval, mock_load, capsys):
+        mock_load.return_value = {}
+        mock_eval.return_value = self._make_pb_result()
+
+        import click
+
+        with patch("regis_cli.utils.report.click.echo") as mock_echo:
+            run_playbooks(
+                ("http://example.com/playbook.yaml",),
+                self._ANALYSIS_REPORT,
+                formats=["json"],
+            )
+            calls = [str(c) for c in mock_echo.call_args_list]
+            assert any("Downloading" in c for c in calls)
+
+    @patch("regis_cli.playbook.engine.load_playbook")
+    @patch("regis_cli.playbook.engine.evaluate")
+    def test_local_path_shows_evaluating(self, mock_eval, mock_load, tmp_path):
+        mock_load.return_value = {}
+        mock_eval.return_value = self._make_pb_result()
+
+        with patch("regis_cli.utils.report.click.echo") as mock_echo:
+            run_playbooks(
+                (str(tmp_path / "playbook.yaml"),),
+                self._ANALYSIS_REPORT,
+                formats=["json"],
+            )
+            calls = [str(c) for c in mock_echo.call_args_list]
+            assert any("Evaluating" in c for c in calls)
+
+    @patch("regis_cli.playbook.engine.load_playbook")
+    @patch("regis_cli.playbook.engine.evaluate")
+    def test_show_rules_prints_icons(self, mock_eval, mock_load):
+        mock_load.return_value = {}
+        mock_eval.return_value = self._make_pb_result(with_rules=True)
+
+        with patch("regis_cli.utils.report.click.echo") as mock_echo:
+            run_playbooks(
+                ("local.yaml",),
+                self._ANALYSIS_REPORT,
+                formats=["json"],
+                show_rules=True,
+            )
+            all_output = " ".join(str(c) for c in mock_echo.call_args_list)
+            assert "✅" in all_output
+            assert "❌" in all_output
+            assert "⚠️" in all_output
+
+    @patch("regis_cli.playbook.engine.load_playbook")
+    @patch("regis_cli.playbook.engine.evaluate")
+    def test_links_accumulated_in_final_report(self, mock_eval, mock_load):
+        mock_load.return_value = {}
+        mock_eval.return_value = self._make_pb_result(with_links=True)
+
+        result = run_playbooks(
+            ("local.yaml",),
+            self._ANALYSIS_REPORT,
+            formats=["json"],
+        )
+        assert "links" in result
+        assert result["links"][0]["url"] == "https://example.com"
+
+    @patch("regis_cli.playbook.engine.load_playbook")
+    @patch("regis_cli.playbook.engine.evaluate")
+    def test_links_deduplicated(self, mock_eval, mock_load):
+        mock_load.return_value = {}
+        link = {"url": "https://example.com", "label": "Docs"}
+        pb_result = self._make_pb_result()
+        pb_result["links"] = [link]
+        mock_eval.return_value = pb_result
+
+        result = run_playbooks(
+            ("a.yaml", "b.yaml"),
+            self._ANALYSIS_REPORT,
+            formats=["json"],
+        )
+        assert result["links"].count(link) == 1
+
+    def test_no_playbook_paths_uses_default(self):
+        """When no paths given, default playbook is loaded (if it exists)."""
+        with patch("regis_cli.playbook.engine.load_playbook") as mock_load, patch(
+            "regis_cli.playbook.engine.evaluate"
+        ) as mock_eval:
+            mock_load.return_value = {}
+            mock_eval.return_value = self._make_pb_result()
+            result = run_playbooks((), self._ANALYSIS_REPORT, formats=["json"])
+            # Either the default was loaded or no paths existed
+            assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

- New `tests/test_archive_store.py` (23 tests): brings `archive/store.py` from **0% → 100%** — `_make_summary`, `_safe_segment`, `_load_json_array`, and `add_to_archive` fully covered
- New `tests/test_archive_command.py`: brings `commands/archive.py` from **56% → 100%** — happy path, invalid JSON, missing file
- New `tests/test_rules_command.py`: brings `commands/rules.py` from **73% → 96%** — `rules show` (happy path, unknown slug, missing rules file), `rules evaluate` (stdout, file output, `--rules`, invalid inputs, `--fail` flag)
- New `tests/test_utils_report.py`: covers `escape_jinja` `{%…%}` branch, `run_playbooks` remote path, `show_rules` icons (✅/❌/⚠️), and links deduplication

Also fixes a bug in `commands/rules.py`: `eval_rules` referenced `result['total_rules']` but `evaluate_rules` returns `all_rules` — would have caused `KeyError` on stdout output path.

## Test plan

- [x] `pipenv run pytest` — 309 passed
- [x] `pipenv run pytest --cov=regis_cli` — total coverage 89% (was 84%)
- [x] `trunk check` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)