### PR TITLE
feat(report): load report from a custom URL via query parameter

### DIFF
--- a/apps/report-viewer/src/components/ReportUrlDialog.tsx
+++ b/apps/report-viewer/src/components/ReportUrlDialog.tsx
@@ -1,0 +1,72 @@
+/**
+ * ReportUrlDialog — modal dialog to load a report from a custom URL.
+ *
+ * On submit, navigates to the current page with `?report=<url>`, which
+ * Root.tsx picks up to pass a new URL to ReportProvider.
+ */
+
+import React, { useEffect, useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+
+interface ReportUrlDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ReportUrlDialog({
+  isOpen,
+  onClose,
+}: ReportUrlDialogProps): React.JSX.Element {
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setUrl(new URLSearchParams(window.location.search).get("report") ?? "");
+    }
+  }, [isOpen]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = url.trim();
+    const search = trimmed ? `?report=${encodeURIComponent(trimmed)}` : "";
+    window.location.href = window.location.pathname + search;
+  }
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="relative z-50">
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="w-full max-w-lg rounded-xl bg-white dark:bg-gray-900 p-6 shadow-2xl border border-gray-200 dark:border-gray-700">
+          <DialogTitle className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Load report from URL
+          </DialogTitle>
+          <form onSubmit={handleSubmit}>
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com/report.json"
+              autoFocus
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-4"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium transition-colors cursor-pointer"
+              >
+                Load
+              </button>
+            </div>
+          </form>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/report-viewer/src/components/ReportUrlDialog.tsx
+++ b/apps/report-viewer/src/components/ReportUrlDialog.tsx
@@ -34,7 +34,10 @@ export function ReportUrlDialog({
 
   return (
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" aria-hidden="true" />
+      <div
+        className="fixed inset-0 bg-black/40 backdrop-blur-sm"
+        aria-hidden="true"
+      />
       <div className="fixed inset-0 flex items-center justify-center p-4">
         <DialogPanel className="w-full max-w-lg rounded-xl bg-white dark:bg-gray-900 p-6 shadow-2xl border border-gray-200 dark:border-gray-700">
           <DialogTitle className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-4">

--- a/apps/report-viewer/src/theme/Navbar/Logo/index.tsx
+++ b/apps/report-viewer/src/theme/Navbar/Logo/index.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from "react";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { RiLinkM } from "@remixicon/react";
+import { ReportUrlDialog } from "../../../components/ReportUrlDialog";
 import { useReport } from "../../../components/ReportProvider";
 
 export default function NavbarLogo(): React.JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   const { report, loading } = useReport();
   const [copied, setCopied] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const req = report?.request ?? {};
   const fields = [
     { label: "Registry", value: req.registry, full: req.registry },
@@ -32,10 +35,20 @@ export default function NavbarLogo(): React.JSX.Element {
       <Link to="/" className="navbar__brand">
         <b className="navbar__title">{siteConfig.title}</b>
       </Link>
+      <button
+        onClick={() => setDialogOpen(true)}
+        className="navbar__item navbar__link inline-flex items-center gap-1"
+        style={{ marginLeft: "auto", flexShrink: 0, background: "none", border: "none", cursor: "pointer" }}
+        title="Load report from URL"
+      >
+        <RiLinkM size={14} />
+        Load URL
+      </button>
+      <ReportUrlDialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)} />
       <a
         href={`${siteConfig.baseUrl}report.json`}
         className="navbar__item navbar__link"
-        style={{ marginLeft: "auto", marginRight: "0.5rem", flexShrink: 0 }}
+        style={{ marginRight: "0.5rem", flexShrink: 0 }}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/apps/report-viewer/src/theme/Navbar/Logo/index.tsx
+++ b/apps/report-viewer/src/theme/Navbar/Logo/index.tsx
@@ -38,13 +38,22 @@ export default function NavbarLogo(): React.JSX.Element {
       <button
         onClick={() => setDialogOpen(true)}
         className="navbar__item navbar__link inline-flex items-center gap-1"
-        style={{ marginLeft: "auto", flexShrink: 0, background: "none", border: "none", cursor: "pointer" }}
+        style={{
+          marginLeft: "auto",
+          flexShrink: 0,
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+        }}
         title="Load report from URL"
       >
         <RiLinkM size={14} />
         Load URL
       </button>
-      <ReportUrlDialog isOpen={dialogOpen} onClose={() => setDialogOpen(false)} />
+      <ReportUrlDialog
+        isOpen={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+      />
       <a
         href={`${siteConfig.baseUrl}report.json`}
         className="navbar__item navbar__link"

--- a/apps/report-viewer/src/theme/Root.tsx
+++ b/apps/report-viewer/src/theme/Root.tsx
@@ -1,12 +1,17 @@
 /**
  * Docusaurus Root wrapper — wraps the entire app in ReportProvider.
  *
+ * Supports a `?report=<url>` query parameter to load a report from an
+ * arbitrary URL. Falls back to the default `report.json` served alongside
+ * the site when the parameter is absent.
+ *
  * @see https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root
  */
 
 import React from "react";
 import { ReportProvider } from "@site/src/components/ReportProvider";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { useLocation } from "@docusaurus/router";
 
 interface RootProps {
   children: React.ReactNode;
@@ -14,7 +19,11 @@ interface RootProps {
 
 export default function Root({ children }: RootProps): React.JSX.Element {
   const { siteConfig } = useDocusaurusContext();
-  const reportUrl = `${siteConfig.baseUrl}report.json`;
+  const { search } = useLocation();
+
+  const reportUrl =
+    new URLSearchParams(search).get("report") ??
+    `${siteConfig.baseUrl}report.json`;
 
   return <ReportProvider reportUrl={reportUrl}>{children}</ReportProvider>;
 }

--- a/apps/report-viewer/static/report.json
+++ b/apps/report-viewer/static/report.json
@@ -1,11 +1,11 @@
 {
   "version": "0.18.0",
   "request": {
-    "url": "ghcr.io/trivoallan/regis-cli:0.18.0",
-    "registry": "ghcr.io",
-    "repository": "trivoallan/regis-cli",
-    "tag": "0.18.0",
-    "digest": "sha256-b58d5e51fe453d368bc130ff0dc2e4cae34ea848147b9fea979cf854f3505a3e",
+    "url": "busybox",
+    "registry": "registry-1.docker.io",
+    "repository": "library/busybox",
+    "tag": "latest",
+    "digest": "sha256-1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e",
     "analyzers": [
       "dockle",
       "endoflife",
@@ -20,6455 +20,446 @@
       "trivy",
       "versioning"
     ],
-    "timestamp": "2026-03-21T01:41:47.291167+00:00"
+    "timestamp": "2026-03-29T20:31:41.211875+00:00"
   },
   "results": {
-    "dockle": {
-      "analyzer": "dockle",
-      "error": {
-        "type": "validation",
-        "message": "Failed to parse dockle output: 2026-03-21T02:41:28.666+0100\t\u001b[31mFATAL\u001b[0m\tunable to initialize a image struct: failed to initialize source: failed to initialize: choosing image instance: no image found in image index for architecture \"arm64\", variant \"v8\", OS \"linux\"\n"
-      }
-    },
     "endoflife": {
       "analyzer": "endoflife",
-      "repository": "trivoallan/regis-cli",
-      "product": "regis-cli",
+      "repository": "library/busybox",
+      "product": "busybox",
       "product_found": false,
-      "tag": "0.18.0",
+      "tag": "latest",
       "matched_cycle": null,
       "is_eol": null,
       "active_cycles_count": null,
       "eol_cycles_count": null
     },
+    "popularity": {
+      "analyzer": "popularity",
+      "repository": "library/busybox",
+      "available": true,
+      "pull_count": 12455410657,
+      "star_count": 3492,
+      "description": "Busybox base image.",
+      "last_updated": "2026-03-24T19:59:26.535531Z",
+      "date_registered": "2013-04-30T20:54:42Z",
+      "is_official": true
+    },
     "freshness": {
       "analyzer": "freshness",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
-      "tag_created": "2026-03-21T01:34:50.907884378Z",
-      "latest_created": "2026-03-21T01:34:50.907884378Z",
-      "age_days": 0,
-      "behind_latest_days": 0,
+      "repository": "library/busybox",
+      "tag": "latest",
+      "tag_created": "2024-09-26T21:31:42Z",
+      "latest_created": null,
+      "age_days": 548,
+      "behind_latest_days": null,
       "is_latest": true
     },
     "hadolint": {
       "analyzer": "hadolint",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
+      "repository": "library/busybox",
+      "tag": "latest",
       "passed": false,
-      "issues_count": 25,
+      "issues_count": 1,
       "issues_by_level": {
         "error": 1,
-        "warning": 11,
-        "info": 13,
+        "warning": 0,
+        "info": 0,
         "style": 0
       },
       "issues": [
         {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 3
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 4
-        },
-        {
-          "code": "DL3008",
-          "level": "warning",
-          "message": "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`",
-          "line": 5
-        },
-        {
-          "code": "DL3009",
-          "level": "info",
-          "message": "Delete the apt lists (/var/lib/apt/lists) after installing something",
-          "line": 5
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 7
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 8
-        },
-        {
-          "code": "DL3003",
-          "level": "warning",
-          "message": "Use WORKDIR to switch to a directory",
-          "line": 9
-        },
-        {
-          "code": "DL3047",
-          "level": "info",
-          "message": "Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`. Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).",
-          "line": 9
-        },
-        {
-          "code": "DL4006",
-          "level": "warning",
-          "message": "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check",
-          "line": 9
-        },
-        {
-          "code": "DL3008",
-          "level": "warning",
-          "message": "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`",
-          "line": 9
-        },
-        {
-          "code": "SC2086",
-          "level": "info",
-          "message": "Double quote to prevent globbing and word splitting.",
-          "line": 9
-        },
-        {
-          "code": "DL4006",
-          "level": "warning",
-          "message": "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check",
-          "line": 10
-        },
-        {
-          "code": "DL3008",
-          "level": "warning",
-          "message": "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`",
-          "line": 14
-        },
-        {
-          "code": "DL4006",
-          "level": "warning",
-          "message": "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check",
-          "line": 17
-        },
-        {
-          "code": "DL4001",
-          "level": "warning",
-          "message": "Either use Wget or Curl but not both",
-          "line": 18
-        },
-        {
-          "code": "SC2154",
-          "level": "warning",
-          "message": "arch is referenced but not assigned.",
-          "line": 18
-        },
-        {
-          "code": "DL4001",
-          "level": "warning",
-          "message": "Either use Wget or Curl but not both",
-          "line": 20
-        },
-        {
-          "code": "SC2086",
-          "level": "info",
-          "message": "Double quote to prevent globbing and word splitting.",
-          "line": 20
-        },
-        {
-          "code": "DL3015",
-          "level": "info",
-          "message": "Avoid additional packages by specifying `--no-install-recommends`",
-          "line": 24
-        },
-        {
-          "code": "DL3008",
-          "level": "warning",
-          "message": "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`",
-          "line": 24
-        },
-        {
-          "code": "SC1072",
+          "code": "SC1088",
           "level": "error",
-          "message": "Expected comparison operator (don't wrap commands in []/[[]]). Fix any mentioned problems and try again.",
-          "line": 26
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 26
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 27
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 28
-        },
-        {
-          "code": "DL3059",
-          "level": "info",
-          "message": "Multiple consecutive `RUN` instructions. Consider consolidation.",
-          "line": 29
+          "message": "Parsing stopped here. Invalid use of parentheses?",
+          "line": 2
         }
       ],
-      "dockerfile": "FROM scratch\nRUN # debian.sh --arch 'amd64' out/ 'trixie' '@1773619200'\nRUN ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nRUN ENV LANG=C.UTF-8\nRUN RUN /bin/sh -c set -eux; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tca-certificates \t\tnetbase \t\ttzdata \t; \tapt-get dist-clean # buildkit\nRUN ENV GPG_KEY=7169605F62C751356D054A26A821E680E5FA6305\nRUN ENV PYTHON_VERSION=3.12.13\nRUN ENV PYTHON_SHA256=c08bc65a81971c1dd5783182826503369466c7e67374d1646519adf05207b684\nRUN RUN /bin/sh -c set -eux; \t\tsavedAptMark=\"$(apt-mark showmanual)\"; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tdpkg-dev \t\tgcc \t\tgnupg \t\tlibbluetooth-dev \t\tlibbz2-dev \t\tlibc6-dev \t\tlibdb-dev \t\tlibffi-dev \t\tlibgdbm-dev \t\tliblzma-dev \t\tlibncursesw5-dev \t\tlibreadline-dev \t\tlibsqlite3-dev \t\tlibssl-dev \t\tmake \t\ttk-dev \t\tuuid-dev \t\twget \t\txz-utils \t\tzlib1g-dev \t; \t\twget -O python.tar.xz \"https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz\"; \techo \"$PYTHON_SHA256 *python.tar.xz\" | sha256sum -c -; \twget -O python.tar.xz.asc \"https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc\"; \tGNUPGHOME=\"$(mktemp -d)\"; export GNUPGHOME; \tgpg --batch --keyserver hkps://keys.openpgp.org --recv-keys \"$GPG_KEY\"; \tgpg --batch --verify python.tar.xz.asc python.tar.xz; \tgpgconf --kill all; \trm -rf \"$GNUPGHOME\" python.tar.xz.asc; \tmkdir -p /usr/src/python; \ttar --extract --directory /usr/src/python --strip-components=1 --file python.tar.xz; \trm python.tar.xz; \t\tcd /usr/src/python; \tgnuArch=\"$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)\"; \t./configure \t\t--build=\"$gnuArch\" \t\t--enable-loadable-sqlite-extensions \t\t--enable-optimizations \t\t--enable-option-checking=fatal \t\t--enable-shared \t\t$(test \"${gnuArch%%-*}\" != 'riscv64' && echo '--with-lto') \t\t--with-ensurepip \t; \tnproc=\"$(nproc)\"; \tEXTRA_CFLAGS=\"$(dpkg-buildflags --get CFLAGS)\"; \tLDFLAGS=\"$(dpkg-buildflags --get LDFLAGS)\"; \tLDFLAGS=\"${LDFLAGS:-} -Wl,--strip-all\"; \tarch=\"$(dpkg --print-architecture)\"; arch=\"${arch##*-}\"; \tcase \"$arch\" in \t\tamd64|arm64) \t\t\tEXTRA_CFLAGS=\"${EXTRA_CFLAGS:-} -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer\"; \t\t\t;; \t\ti386) \t\t\t;; \t\t*) \t\t\tEXTRA_CFLAGS=\"${EXTRA_CFLAGS:-} -fno-omit-frame-pointer\"; \t\t\t;; \tesac; \tmake -j \"$nproc\" \t\t\"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}\" \t\t\"LDFLAGS=${LDFLAGS:-}\" \t; \trm python; \tmake -j \"$nproc\" \t\t\"EXTRA_CFLAGS=${EXTRA_CFLAGS:-}\" \t\t\"LDFLAGS=${LDFLAGS:-} -Wl,-rpath='\\$\\$ORIGIN/../lib'\" \t\tpython \t; \tmake install; \t\tcd /; \trm -rf /usr/src/python; \t\tfind /usr/local -depth \t\t\\( \t\t\t\\( -type d -a \\( -name test -o -name tests -o -name idle_test \\) \\) \t\t\t-o \\( -type f -a \\( -name '*.pyc' -o -name '*.pyo' -o -name 'libpython*.a' \\) \\) \t\t\\) -exec rm -rf '{}' + \t; \t\tldconfig; \t\tapt-mark auto '.*' > /dev/null; \tapt-mark manual $savedAptMark; \tfind /usr/local -type f -executable -not \\( -name '*tkinter*' \\) -exec ldd '{}' ';' \t\t| awk '/=>/ { so = $(NF-1); if (index(so, \"/usr/local/\") == 1) { next }; gsub(\"^/(usr/)?\", \"\", so); printf \"*%s\\n\", so }' \t\t| sort -u \t\t| xargs -rt dpkg-query --search \t\t| awk 'sub(\":$\", \"\", $1) { print $1 }' \t\t| sort -u \t\t| xargs -r apt-mark manual \t; \tapt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \tapt-get dist-clean; \t\texport PYTHONDONTWRITEBYTECODE=1; \tpython3 --version; \tpip3 --version # buildkit\nRUN RUN /bin/sh -c set -eux; \tfor src in idle3 pip3 pydoc3 python3 python3-config; do \t\tdst=\"$(echo \"$src\" | tr -d 3)\"; \t\t[ -s \"/usr/local/bin/$src\" ]; \t\t[ ! -e \"/usr/local/bin/$dst\" ]; \t\tln -svT \"$src\" \"/usr/local/bin/$dst\"; \tdone # buildkit\nRUN CMD [\"python3\"]\nRUN LABEL org.opencontainers.image.title=regis-cli org.opencontainers.image.description=Container Security & Policy-as-Code Orchestration. Unified analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD. org.opencontainers.image.url=https://github.com/trivoallan/regis-cli org.opencontainers.image.source=https://github.com/trivoallan/regis-cli org.opencontainers.image.documentation=https://trivoallan.github.io/regis-cli/ org.opencontainers.image.vendor=trivoallan org.opencontainers.image.authors=trivoallan org.opencontainers.image.licenses=MIT\nRUN ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 DEBIAN_FRONTEND=noninteractive\nRUN RUN /bin/sh -c apt-get update && apt-get install -y --no-install-recommends     curl     ca-certificates     gnupg     skopeo     && rm -rf /var/lib/apt/lists/* # buildkit\nRUN RUN /bin/sh -c groupadd -g 1001 regis &&     useradd -u 1001 -g regis -m -d /home/regis regis &&     chmod 755 /home/regis # buildkit\nRUN ENV HOME=/home/regis\nRUN RUN /bin/sh -c curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin # buildkit\nRUN RUN /bin/sh -c arch=$(uname -m) &&     if [ \"$arch\" = \"x86_64\" ]; then hadolint_arch=\"x86_64\"; else hadolint_arch=\"arm64\"; fi &&     curl -sSfL \"https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-${hadolint_arch}\" -o /usr/local/bin/hadolint &&     chmod +x /usr/local/bin/hadolint # buildkit\nRUN ENV DOCKLE_VERSION=0.4.15\nRUN RUN /bin/sh -c arch=$(uname -m) &&     if [ \"$arch\" = \"x86_64\" ]; then dockle_arch=\"64bit\"; else dockle_arch=\"ARM64\"; fi &&     curl -L -o dockle.tar.gz https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-${dockle_arch}.tar.gz &&     tar zxvf dockle.tar.gz dockle &&     mv dockle /usr/local/bin/dockle &&     rm dockle.tar.gz &&     chmod +x /usr/local/bin/dockle # buildkit\nRUN WORKDIR /app\nRUN RUN /bin/sh -c chown regis:regis /app && chmod 777 /app # buildkit\nRUN COPY --chown=regis:regis . . # buildkit\nRUN RUN /bin/sh -c apt-get update && apt-get install -y git # buildkit\nRUN RUN /bin/sh -c pip install --no-cache-dir . # buildkit\nRUN HEALTHCHECK &{[\"CMD-SHELL\" \"regis-cli list || exit 1\"] \"30s\" \"5s\" \"5s\" \"0s\" '\\x03'}\nRUN USER regis\nRUN ENTRYPOINT [\"regis-cli\"]\nRUN CMD [\"--help\"]"
+      "dockerfile": "FROM scratch\nRUN BusyBox 1.37.0 (glibc), Debian 13"
     },
-    "popularity": {
-      "analyzer": "popularity",
-      "repository": "trivoallan/regis-cli",
-      "available": false,
-      "pull_count": null,
-      "star_count": null,
-      "description": null,
-      "last_updated": null,
-      "date_registered": null,
-      "is_official": false
+    "dockle": {
+      "analyzer": "dockle",
+      "repository": "library/busybox",
+      "tag": "latest",
+      "passed": true,
+      "issues_count": 4,
+      "issues_by_level": {
+        "FATAL": 0,
+        "WARN": 2,
+        "INFO": 2,
+        "SKIP": 0,
+        "PASS": 0
+      },
+      "issues": [
+        {
+          "code": "CIS-DI-0001",
+          "level": "WARN",
+          "title": "Create a user for the container",
+          "alerts": ["Last user should not be root"]
+        },
+        {
+          "code": "DKL-DI-0006",
+          "level": "WARN",
+          "title": "Avoid latest tag",
+          "alerts": ["Avoid 'latest' tag"]
+        },
+        {
+          "code": "CIS-DI-0005",
+          "level": "INFO",
+          "title": "Enable Content trust for Docker",
+          "alerts": ["export DOCKER_CONTENT_TRUST=1 before docker pull/build"]
+        },
+        {
+          "code": "CIS-DI-0006",
+          "level": "INFO",
+          "title": "Add HEALTHCHECK instruction to the container image",
+          "alerts": ["not found HEALTHCHECK statement"]
+        }
+      ]
     },
     "provenance": {
       "analyzer": "provenance",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
-      "has_provenance": true,
+      "repository": "library/busybox",
+      "tag": "latest",
+      "has_provenance": false,
       "has_cosign_signature": false,
-      "source_tracked": true,
-      "indicators_count": 4,
-      "indicators": [
-        {
-          "type": "oci-annotation",
-          "key": "org.opencontainers.image.source",
-          "value": "https://github.com/trivoallan/regis-cli"
-        },
-        {
-          "type": "oci-annotation",
-          "key": "org.opencontainers.image.revision",
-          "value": "8596aef162aa416662855a46f12733598484eeaf"
-        },
-        {
-          "type": "oci-annotation",
-          "key": "org.opencontainers.image.created",
-          "value": "2026-03-21T01:34:17.660Z"
-        },
-        {
-          "type": "oci-annotation",
-          "key": "org.opencontainers.image.vendor",
-          "value": "trivoallan"
-        }
-      ]
-    },
-    "sbom": {
-      "analyzer": "sbom",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
-      "has_sbom": true,
-      "sbom_format": "CycloneDX",
-      "sbom_version": "1.6",
-      "total_components": 689,
-      "component_types": {
-        "library": 686,
-        "operating-system": 1,
-        "application": 2
-      },
-      "total_dependencies": 690,
-      "licenses": [
-        "0BSD",
-        "Apache-2.0",
-        "Apache-2.0-and-or-Expat",
-        "Artistic-1",
-        "Artistic-2",
-        "Artistic-2.0",
-        "Artistic-dist",
-        "BSD-2-Clause",
-        "BSD-2-Clause-NetBSD",
-        "BSD-2-clause-author",
-        "BSD-2-clause-verbatim",
-        "BSD-2.2-clause",
-        "BSD-3-Clause",
-        "BSD-3-Clause WITH weird-numbering",
-        "BSD-3-Clause-Attribution",
-        "BSD-3-Clause-Attribution and IBM-as-is",
-        "BSD-3-Clause-Variant",
-        "BSD-3-clause-Aaron-D-Gifford",
-        "BSD-3-clause-Berkeley",
-        "BSD-3-clause-California",
-        "BSD-3-clause-Cambridge WITH BINARY-LIBRARY-LIKE-PACKAGES-exception",
-        "BSD-3-clause-Carnegie",
-        "BSD-3-clause-GENERIC",
-        "BSD-3-clause-JANET",
-        "BSD-3-clause-John-Birrell",
-        "BSD-3-clause-Oracle",
-        "BSD-3-clause-PADL",
-        "BSD-3-clause-Regents",
-        "BSD-3-clause-WIDE",
-        "BSD-3-clause-author",
-        "BSD-3-clause-fjord",
-        "BSD-3-clause-variant",
-        "BSD-4-Clause",
-        "BSD-4-Clause-CMU",
-        "BSD-4-Clause-UC",
-        "BSD-4-clause-California",
-        "BSD-4-clause-POWERDOG",
-        "BSD-5-clause-Peter-Wemm",
-        "BSD-like-Spencer",
-        "BSD-tcp-wrappers",
-        "BSL-1",
-        "BSL-1.0",
-        "BSLA",
-        "BZIP",
-        "Beerware",
-        "CC-BY-3.0",
-        "CC0-1.0",
-        "CORE-MATH",
-        "Carnegie",
-        "Chromium",
-        "DEC",
-        "DONT-CHANGE-THE-GPL",
-        "Expat-ISC",
-        "Expat-UNM",
-        "F5",
-        "FSF-manpages",
-        "FSF-unlimited",
-        "FSFAP",
-        "FSFUL",
-        "FSFULLR",
-        "FSFULLRWD",
-        "FreeSoftware",
-        "GAP",
-        "GFDL-1.2-only",
-        "GFDL-1.2-or-later",
-        "GFDL-1.3--no-invariant",
-        "GFDL-1.3-no-invariants-only",
-        "GFDL-1.3-no-invariants-or-later",
-        "GFDL-1.3-only",
-        "GFDL-1.3-or-later",
-        "GFDL-3",
-        "GPL-1.0-only",
-        "GPL-1.0-or-later",
-        "GPL-2.0-only",
-        "GPL-2.0-only WITH Linux-syscall-note-exception",
-        "GPL-2.0-only WITH autoconf-exception+",
-        "GPL-2.0-only WITH bison-exception+",
-        "GPL-2.0-or-later",
-        "GPL-2.0-or-later WITH Autoconf-data-exception",
-        "GPL-2.0-or-later WITH Autoconf-generic-exception",
-        "GPL-2.0-or-later WITH Libtool-Exception",
-        "GPL-2.0-or-later WITH Libtool-exception",
-        "GPL-2.0-or-later WITH Texinfo-exception",
-        "GPL-2.0-or-later WITH automake-exception",
-        "GPL-2.0-or-later WITH distribution-exception",
-        "GPL-2.0-or-later WITH link-exception",
-        "GPL-2.with.nonstandard.Autoconf-data.exception",
-        "GPL-3.0-only",
-        "GPL-3.0-only WITH autoconf-exception+",
-        "GPL-3.0-or-later",
-        "GPL-3.0-or-later WITH Autoconf-2.0-Archive-exception",
-        "GPL-3.0-or-later WITH Autoconf-data-exception",
-        "GPL-3.0-or-later WITH Autoconf-exception-macro",
-        "GPL-3.0-or-later WITH Autoconf-generic-exception",
-        "GPL-3.0-or-later WITH Bison-2.2-exception",
-        "GPL-3.0-or-later WITH Bison-exception",
-        "GPL-3.0-or-later WITH Libtool-exception",
-        "GPL-3.0-or-later WITH texinfo-exception",
-        "IBM",
-        "IBM-as-is",
-        "ISC",
-        "ISC-Original",
-        "ISC-no-attribution",
-        "Inner-Net",
-        "JCG",
-        "Kazlib",
-        "LGPL-2.0-only",
-        "LGPL-2.0-or-later",
-        "LGPL-2.1-only",
-        "LGPL-2.1-or-later",
-        "LGPL-2.1-or-later WITH link-exception",
-        "LGPL-3.0-only",
-        "LGPL-3.0-or-later",
-        "Latex2e",
-        "Less",
-        "MIT",
-        "MIT WITH advertising-restriction",
-        "MIT-CMU",
-        "MIT-Export",
-        "MIT-OpenVision",
-        "MIT-US-export",
-        "MIT-X11",
-        "MIT-XC",
-        "MIT-like-Lord",
-        "MIT-old",
-        "MPL-1.1",
-        "MPL-2.0",
-        "MS-PL",
-        "Mazieres-BSD-style",
-        "NeoSoft-permissive",
-        "OLDAP-2.8",
-        "OpenLDAP",
-        "OpenLDAP-2.8",
-        "OpenSSH",
-        "PCRE",
-        "PD",
-        "PD-debian",
-        "PSF-2.0",
-        "Powell-BSD-style",
-        "REGCOMP",
-        "RFC-Reference",
-        "RSA-MD",
-        "SDBM-PUBLIC-DOMAIN",
-        "SMAIL-GPL",
-        "Sleepycat",
-        "Spencer-86",
-        "SunPro",
-        "TCL-like",
-        "TEXT-TABS",
-        "TinySCHEME",
-        "UMich",
-        "Unicode",
-        "Unicode-DFS-2016",
-        "Univ-Coimbra",
-        "X11",
-        "Zlib",
-        "all-permissive",
-        "curl",
-        "custom",
-        "customFSFUL",
-        "customFSFULLRWD",
-        "dlmalloc",
-        "g10-permissive",
-        "gnulib",
-        "mingw-runtime",
-        "noderivs",
-        "none",
-        "pcre",
-        "permissive",
-        "permissive-nowarranty",
-        "public-domain",
-        "public-domain-md4",
-        "public-domain-md5",
-        "public-domain-s-s-d",
-        "public-domain-sha1",
-        "verbatim"
-      ],
-      "components": [
-        {
-          "name": "github.com/pmezard/go-difflib",
-          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/objx",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/felixge/httpsnoop",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/yaml.v3",
-          "version": "v3.0.1",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/mountinfo",
-          "version": "v0.7.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/mountinfo@v0.7.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/errwrap",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pkg/errors",
-          "version": "v0.9.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/distribution",
-          "version": "v2.8.3+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/mountinfo",
-          "version": "v0.7.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/mountinfo@v0.7.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/docker-image-spec",
-          "version": "v1.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
-          "licenses": []
-        },
-        {
-          "name": "regis-cli",
-          "version": "0.18.0",
-          "type": "library",
-          "purl": "pkg:pypi/regis-cli@0.18.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "github.com/gogo/protobuf",
-          "version": "v1.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/go-digest",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/go-units",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/go-units@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-logr/stdr",
-          "version": "v1.2.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/concurrent",
-          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/nested",
-          "version": "v0.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/nested@v0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/go-units",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/go-units@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/distribution/reference",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/distribution/reference@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-logr/stdr",
-          "version": "v1.2.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/stdr@v1.2.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/uuid",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/json-iterator/go",
-          "version": "v1.1.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/yaml.v3",
-          "version": "v3.0.1",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-          "licenses": []
-        },
-        {
-          "name": "regis-cli",
-          "version": "0.18.0",
-          "type": "library",
-          "purl": "pkg:pypi/regis-cli@0.18.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "github.com/russross/blackfriday/v2",
-          "version": "v2.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/davecgh/go-spew",
-          "version": "v1.1.2-0.20180830191138-d8f796af33cc",
-          "type": "library",
-          "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
-          "licenses": []
-        },
-        {
-          "name": "github.com/toqueteos/webbrowser",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/toqueteos/webbrowser@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pkg/errors",
-          "version": "v0.9.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/concurrent",
-          "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/distribution",
-          "version": "v2.8.3+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/distribution@v2.8.3%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "debian",
-          "version": "13.4",
-          "type": "operating-system",
-          "purl": null,
-          "licenses": []
-        },
-        {
-          "name": "github.com/davecgh/go-spew",
-          "version": "v1.1.2-0.20180830191138-d8f796af33cc",
-          "type": "library",
-          "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc",
-          "licenses": []
-        },
-        {
-          "name": "github.com/russross/blackfriday/v2",
-          "version": "v2.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/russross/blackfriday/v2@v2.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/uuid",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/objx",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/objx@v0.5.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pmezard/go-difflib",
-          "version": "v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2",
-          "licenses": []
-        },
-        {
-          "name": "usr/local/bin/dockle",
-          "version": null,
-          "type": "application",
-          "purl": null,
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/docker-image-spec",
-          "version": "v1.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/docker-image-spec@v1.3.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/go-digest",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/go-digest@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gogo/protobuf",
-          "version": "v1.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/felixge/httpsnoop",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/felixge/httpsnoop@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/errwrap",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/errwrap@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-multierror",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/toqueteos/webbrowser",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/toqueteos/webbrowser@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/nested",
-          "version": "v0.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/nested@v0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/distribution/reference",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/distribution/reference@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "usr/local/bin/trivy",
-          "version": null,
-          "type": "application",
-          "purl": null,
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-multierror",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-multierror@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/json-iterator/go",
-          "version": "v1.1.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-          "licenses": []
-        },
-        {
-          "name": "adduser",
-          "version": "3.152",
-          "type": "library",
-          "purl": "pkg:deb/debian/adduser@3.152?arch=all&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "apt",
-          "version": "3.0.3",
-          "type": "library",
-          "purl": "pkg:deb/debian/apt@3.0.3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "curl",
-            "BSD-3-Clause",
-            "MIT",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "base-files",
-          "version": "13.8+deb13u4",
-          "type": "library",
-          "purl": "pkg:deb/debian/base-files@13.8%2Bdeb13u4?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "verbatim"]
-        },
-        {
-          "name": "base-passwd",
-          "version": "3.6.7",
-          "type": "library",
-          "purl": "pkg:deb/debian/base-passwd@3.6.7?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only", "public-domain"]
-        },
-        {
-          "name": "bash",
-          "version": "5.2.37-2+b8",
-          "type": "library",
-          "purl": "pkg:deb/debian/bash@5.2.37-2%2Bb8?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GFDL-1.3-no-invariants-only",
-            "GFDL-1.3-only",
-            "Latex2e",
-            "BSD-4-Clause-UC",
-            "MIT",
-            "permissive"
-          ]
-        },
-        {
-          "name": "bsdutils",
-          "version": "1:2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/bsdutils@2.41-5?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "ca-certificates",
-          "version": "20250419",
-          "type": "library",
-          "purl": "pkg:deb/debian/ca-certificates@20250419?arch=all&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "GPL-2.0-only", "MPL-2.0"]
-        },
-        {
-          "name": "containernetworking-plugins",
-          "version": "1.1.1+ds1-3+b17",
-          "type": "library",
-          "purl": "pkg:deb/debian/containernetworking-plugins@1.1.1%2Bds1-3%2Bb17?arch=amd64&distro=debian-13.4",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "coreutils",
-          "version": "9.7-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/coreutils@9.7-3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "BSD-4-Clause-UC",
-            "GPL-3.0-only",
-            "ISC",
-            "FSFULLR",
-            "GFDL-1.3-no-invariants-only",
-            "GFDL-1.3-only"
-          ]
-        },
-        {
-          "name": "curl",
-          "version": "8.14.1-2+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/curl@8.14.1-2%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "curl",
-            "OLDAP-2.8",
-            "ISC",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "GPL-2.0-or-later WITH Libtool-exception",
-            "BSD-3-Clause",
-            "BSD-4-Clause-UC",
-            "FSFULLR",
-            "X11",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "dash",
-          "version": "0.5.12-12",
-          "type": "library",
-          "purl": "pkg:deb/debian/dash@0.5.12-12?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "public-domain",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "debconf",
-          "version": "1.5.91",
-          "type": "library",
-          "purl": "pkg:deb/debian/debconf@1.5.91?arch=all&distro=debian-13.4",
-          "licenses": ["BSD-2-Clause"]
-        },
-        {
-          "name": "debian-archive-keyring",
-          "version": "2025.1",
-          "type": "library",
-          "purl": "pkg:deb/debian/debian-archive-keyring@2025.1?arch=all&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later"]
-        },
-        {
-          "name": "debianutils",
-          "version": "5.23.2",
-          "type": "library",
-          "purl": "pkg:deb/debian/debianutils@5.23.2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "public-domain",
-            "SMAIL-GPL"
-          ]
-        },
-        {
-          "name": "diffutils",
-          "version": "1:3.10-4",
-          "type": "library",
-          "purl": "pkg:deb/debian/diffutils@3.10-4?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "FSFULLR",
-            "LGPL-2.1-or-later",
-            "GPL-3.0-only WITH autoconf-exception+",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH texinfo-exception",
-            "LGPL-2.0-or-later",
-            "GPL-2.0-or-later",
-            "X11",
-            "FSFAP",
-            "GFDL-1.3-no-invariants-only",
-            "LGPL-3.0-or-later",
-            "LGPL-3.0-only",
-            "public-domain",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only",
-            "GFDL-1.3-only"
-          ]
-        },
-        {
-          "name": "dirmngr",
-          "version": "2.4.7-21+deb13u1+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/dirmngr@2.4.7-21%2Bdeb13u1%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "dpkg",
-          "version": "1.22.22",
-          "type": "library",
-          "purl": "pkg:deb/debian/dpkg@1.22.22?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "public-domain-s-s-d",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "findutils",
-          "version": "4.10.0-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/findutils@4.10.0-3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GFDL-1.3-no-invariants-or-later",
-            "GPL-3.0-or-later",
-            "FSFAP",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "FSFULLR",
-            "GPL-2.0-or-later",
-            "X11",
-            "public-domain",
-            "LGPL-2.1-or-later",
-            "GPL-2.0-or-later WITH automake-exception",
-            "LGPL-2.0-or-later",
-            "LGPL-3.0-or-later",
-            "BSD-3-Clause",
-            "GPL-3.0-or-later WITH Bison-2.2-exception",
-            "LGPL-3.0-only",
-            "ISC",
-            "GFDL-1.3-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "gcc-14-base",
-          "version": "14.2.0-19",
-          "type": "library",
-          "purl": "pkg:deb/debian/gcc-14-base@14.2.0-19?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-3.0-only",
-            "GFDL-1.2-only",
-            "Artistic-2.0",
-            "LGPL-2.0-or-later"
-          ]
-        },
-        {
-          "name": "git-man",
-          "version": "1:2.47.3-0+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/git-man@2.47.3-0%2Bdeb13u1?arch=all&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-2.0-only",
-            "BSD-3-Clause",
-            "Zlib",
-            "LGPL-2.1-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "GPL-1.0-or-later",
-            "Artistic-1",
-            "Artistic-2.0",
-            "ISC",
-            "mingw-runtime",
-            "BSL-1.0",
-            "dlmalloc",
-            "Apache-2.0",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "git",
-          "version": "1:2.47.3-0+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/git@2.47.3-0%2Bdeb13u1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-2.0-only",
-            "BSD-3-Clause",
-            "Zlib",
-            "LGPL-2.1-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "GPL-1.0-or-later",
-            "Artistic-1",
-            "Artistic-2.0",
-            "ISC",
-            "mingw-runtime",
-            "BSL-1.0",
-            "dlmalloc",
-            "Apache-2.0",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "gnupg-l10n",
-          "version": "2.4.7-21+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/gnupg-l10n@2.4.7-21%2Bdeb13u1?arch=all&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "gnupg",
-          "version": "2.4.7-21+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/gnupg@2.4.7-21%2Bdeb13u1?arch=all&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "golang-github-containers-common",
-          "version": "0.62.2+ds1-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/golang-github-containers-common@0.62.2%2Bds1-2?arch=all&distro=debian-13.4",
-          "licenses": ["Apache-2.0", "MIT"]
-        },
-        {
-          "name": "golang-github-containers-image",
-          "version": "5.34.2-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/golang-github-containers-image@5.34.2-1?arch=all&distro=debian-13.4",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "gpg-agent",
-          "version": "2.4.7-21+deb13u1+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/gpg-agent@2.4.7-21%2Bdeb13u1%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "gpg",
-          "version": "2.4.7-21+deb13u1+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/gpg@2.4.7-21%2Bdeb13u1%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "gpgconf",
-          "version": "2.4.7-21+deb13u1+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/gpgconf@2.4.7-21%2Bdeb13u1%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "gpgsm",
-          "version": "2.4.7-21+deb13u1+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/gpgsm@2.4.7-21%2Bdeb13u1%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "permissive",
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "BSD-3-Clause",
-            "RFC-Reference",
-            "TinySCHEME",
-            "CC0-1.0",
-            "GPL-3.0-only",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "grep",
-          "version": "3.11-4",
-          "type": "library",
-          "purl": "pkg:deb/debian/grep@3.11-4?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-3.0-or-later", "GPL-3.0-only"]
-        },
-        {
-          "name": "gzip",
-          "version": "1.13-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/gzip@1.13-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GFDL-1.3--no-invariant",
-            "FSF-manpages",
-            "GPL-3.0-only",
-            "GFDL-3"
-          ]
-        },
-        {
-          "name": "hostname",
-          "version": "3.25",
-          "type": "library",
-          "purl": "pkg:deb/debian/hostname@3.25?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "init-system-helpers",
-          "version": "1.69~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/init-system-helpers@1.69~deb13u1?arch=all&distro=debian-13.4",
-          "licenses": ["BSD-3-Clause", "GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "iptables",
-          "version": "1.8.11-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/iptables@1.8.11-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-only",
-            "Artistic-2.0",
-            "GPL-2.0-or-later",
-            "custom"
-          ]
-        },
-        {
-          "name": "less",
-          "version": "668-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/less@668-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "Less",
-            "GPL-3.0-only",
-            "X11",
-            "Spencer-86",
-            "public-domain"
-          ]
-        },
-        {
-          "name": "libacl1",
-          "version": "2.3.2-2+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libacl1@2.3.2-2%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "LGPL-2.0-or-later",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libapt-pkg7.0",
-          "version": "3.0.3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libapt-pkg7.0@3.0.3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "curl",
-            "BSD-3-Clause",
-            "MIT",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libassuan9",
-          "version": "3.0.2-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libassuan9@3.0.2-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "FSFULLR",
-            "FSFULLRWD",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "X11",
-            "GPL-2.0-or-later WITH Libtool-exception",
-            "GPL-3.0-or-later",
-            "LGPL-3.0-or-later",
-            "LGPL-2.1-only",
-            "GPL-2.with.nonstandard.Autoconf-data.exception",
-            "GPL-3.0-or-later WITH Autoconf-2.0-Archive-exception",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libattr1",
-          "version": "1:2.5.2-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libattr1@2.5.2-3?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "LGPL-2.0-or-later",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libaudit-common",
-          "version": "1:4.0.2-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libaudit-common@4.0.2-2?arch=all&distro=debian-13.4&epoch=1",
-          "licenses": ["GPL-2.0-only", "LGPL-2.1-only", "GPL-1.0-only"]
-        },
-        {
-          "name": "libaudit1",
-          "version": "1:4.0.2-2+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libaudit1@4.0.2-2%2Bb2?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": ["GPL-2.0-only", "LGPL-2.1-only", "GPL-1.0-only"]
-        },
-        {
-          "name": "libblkid1",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libblkid1@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libbrotli1",
-          "version": "1.1.0-2+b7",
-          "type": "library",
-          "purl": "pkg:deb/debian/libbrotli1@1.1.0-2%2Bb7?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "libbsd0",
-          "version": "0.12.2-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libbsd0@0.12.2-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "BSD-3-clause-Regents",
-            "BSD-2-Clause-NetBSD",
-            "BSD-3-clause-author",
-            "BSD-3-clause-John-Birrell",
-            "BSD-5-clause-Peter-Wemm",
-            "BSD-2-Clause",
-            "BSD-2-clause-verbatim",
-            "BSD-2-clause-author",
-            "ISC",
-            "ISC-Original",
-            "MIT",
-            "public-domain",
-            "Beerware"
-          ]
-        },
-        {
-          "name": "libbz2-1.0",
-          "version": "1.0.8-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/libbz2-1.0@1.0.8-6?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-3-Clause", "GPL-2.0-only"]
-        },
-        {
-          "name": "libc-bin",
-          "version": "2.41-12+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libc-bin@2.41-12%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "LGPL-2.0-or-later",
-            "LGPL-2.1-or-later WITH link-exception",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "GPL-2.0-or-later WITH link-exception",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "FSFAP",
-            "Carnegie",
-            "Inner-Net",
-            "MIT-like-Lord",
-            "BSD-like-Spencer",
-            "PCRE",
-            "BSD-3-clause-Carnegie",
-            "Unicode-DFS-2016",
-            "BSL-1.0",
-            "SunPro",
-            "CORE-MATH",
-            "BSD-3-clause-Berkeley",
-            "BSD-3-clause-WIDE",
-            "BSD-2-Clause",
-            "BSD-3-clause-Oracle",
-            "DEC",
-            "IBM",
-            "ISC",
-            "Univ-Coimbra",
-            "public-domain",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libc6",
-          "version": "2.41-12+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libc6@2.41-12%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "LGPL-2.0-or-later",
-            "LGPL-2.1-or-later WITH link-exception",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "GPL-2.0-or-later WITH link-exception",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "FSFAP",
-            "Carnegie",
-            "Inner-Net",
-            "MIT-like-Lord",
-            "BSD-like-Spencer",
-            "PCRE",
-            "BSD-3-clause-Carnegie",
-            "Unicode-DFS-2016",
-            "BSL-1.0",
-            "SunPro",
-            "CORE-MATH",
-            "BSD-3-clause-Berkeley",
-            "BSD-3-clause-WIDE",
-            "BSD-2-Clause",
-            "BSD-3-clause-Oracle",
-            "DEC",
-            "IBM",
-            "ISC",
-            "Univ-Coimbra",
-            "public-domain",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libcap-ng0",
-          "version": "0.8.5-4+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcap-ng0@0.8.5-4%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "GPL-2.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.1-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libcap2",
-          "version": "1:2.75-10+b8",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcap2@2.75-10%2Bb8?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": ["BSD-3-Clause", "GPL-2.0-only", "GPL-2.0-or-later"]
-        },
-        {
-          "name": "libcbor0.10",
-          "version": "0.10.2-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcbor0.10@0.10.2-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "libcom-err2",
-          "version": "1.47.2-3+b10",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcom-err2@1.47.2-3%2Bb10?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-only",
-            "GPL-2.0-or-later",
-            "0BSD",
-            "MIT",
-            "BSD-3-Clause-Variant",
-            "BSD-3-Clause",
-            "BSD-4-Clause-CMU",
-            "LGPL-2.0-only",
-            "Apache-2.0",
-            "ISC",
-            "MIT-US-export",
-            "Kazlib",
-            "Latex2e",
-            "GPL-2.0-or-later WITH Texinfo-exception"
-          ]
-        },
-        {
-          "name": "libcrypt1",
-          "version": "1:4.4.38-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcrypt1@4.4.38-1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": []
-        },
-        {
-          "name": "libcurl3t64-gnutls",
-          "version": "8.14.1-2+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcurl3t64-gnutls@8.14.1-2%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "curl",
-            "OLDAP-2.8",
-            "ISC",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "GPL-2.0-or-later WITH Libtool-exception",
-            "BSD-3-Clause",
-            "BSD-4-Clause-UC",
-            "FSFULLR",
-            "X11",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libcurl4t64",
-          "version": "8.14.1-2+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libcurl4t64@8.14.1-2%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "curl",
-            "OLDAP-2.8",
-            "ISC",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "GPL-2.0-or-later WITH Libtool-exception",
-            "BSD-3-Clause",
-            "BSD-4-Clause-UC",
-            "FSFULLR",
-            "X11",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libdb5.3t64",
-          "version": "5.3.28+dfsg2-9",
-          "type": "library",
-          "purl": "pkg:deb/debian/libdb5.3t64@5.3.28%2Bdfsg2-9?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "Sleepycat",
-            "BSD-3-Clause",
-            "MS-PL",
-            "GPL-2.0-or-later",
-            "Artistic-2.0",
-            "X11",
-            "MIT-old",
-            "TCL-like",
-            "BSD-3-clause-fjord",
-            "GPL-3.0-only",
-            "Zlib"
-          ]
-        },
-        {
-          "name": "libdebconfclient0",
-          "version": "0.280",
-          "type": "library",
-          "purl": "pkg:deb/debian/libdebconfclient0@0.280?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-2-Clause", "GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libedit2",
-          "version": "3.1-20250104-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libedit2@3.1-20250104-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "liberror-perl",
-          "version": "0.17030-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/liberror-perl@0.17030-1?arch=all&distro=debian-13.4",
-          "licenses": [
-            "Artistic-2.0",
-            "GPL-1.0-or-later",
-            "MIT-X11",
-            "GPL-1.0-only"
-          ]
-        },
-        {
-          "name": "libexpat1",
-          "version": "2.7.1-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libexpat1@2.7.1-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "libffi8",
-          "version": "3.4.8-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libffi8@3.4.8-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "MIT",
-            "X11",
-            "GPL-2.0-or-later",
-            "GPL-3.0-or-later",
-            "MPL-1.1",
-            "LGPL-2.1-or-later",
-            "public-domain"
-          ]
-        },
-        {
-          "name": "libfido2-1",
-          "version": "1.15.0-1+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libfido2-1@1.15.0-1%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-2-Clause", "ISC", "public-domain"]
-        },
-        {
-          "name": "libgcc-s1",
-          "version": "14.2.0-19",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgcc-s1@14.2.0-19?arch=amd64&distro=debian-13.4",
-          "licenses": []
-        },
-        {
-          "name": "libgcrypt20",
-          "version": "1.11.0-7",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgcrypt20@1.11.0-7?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libgdbm-compat4t64",
-          "version": "1.24-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgdbm-compat4t64@1.24-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "GFDL-1.3-no-invariants-or-later",
-            "GPL-3.0-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libgdbm6t64",
-          "version": "1.24-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgdbm6t64@1.24-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "GFDL-1.3-no-invariants-or-later",
-            "GPL-3.0-only",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libgmp10",
-          "version": "2:6.3.0+dfsg-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgmp10@6.3.0%2Bdfsg-3?arch=amd64&distro=debian-13.4&epoch=2",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-or-later",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libgnutls30t64",
-          "version": "3.8.9-3+deb13u2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgnutls30t64@3.8.9-3%2Bdeb13u2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-only",
-            "LGPL-2.0-or-later",
-            "LGPL-3.0-only",
-            "GPL-2.0-or-later",
-            "GPL-3.0-only",
-            "GFDL-1.3-only",
-            "CC0-1.0",
-            "MIT",
-            "Apache-2.0",
-            "LGPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "GPL-3.0-or-later",
-            "BSD-3-Clause",
-            "FSFAP"
-          ]
-        },
-        {
-          "name": "libgpg-error0",
-          "version": "1.51-4",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgpg-error0@1.51-4?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "BSD-3-Clause",
-            "g10-permissive",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libgpgme11t64",
-          "version": "1.24.2-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgpgme11t64@1.24.2-3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "GPL-3.0-or-later",
-            "LGPL-2.0-or-later",
-            "LGPL-3.0-only",
-            "LGPL-2.1-only",
-            "LGPL-2.0-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libgssapi-krb5-2",
-          "version": "1.21.3-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libgssapi-krb5-2@1.21.3-5?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "libhogweed6t64",
-          "version": "3.10.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libhogweed6t64@3.10.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "MIT",
-            "GPL-3.0-only WITH autoconf-exception+",
-            "public-domain",
-            "GPL-2.0-only",
-            "GAP"
-          ]
-        },
-        {
-          "name": "libidn2-0",
-          "version": "2.3.8-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libidn2-0@2.3.8-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "MIT",
-            "Unicode",
-            "GPL-3.0-only",
-            "GPL-2.0-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libip4tc2",
-          "version": "1.8.11-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libip4tc2@1.8.11-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-only",
-            "Artistic-2.0",
-            "GPL-2.0-or-later",
-            "custom"
-          ]
-        },
-        {
-          "name": "libip6tc2",
-          "version": "1.8.11-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libip6tc2@1.8.11-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-only",
-            "Artistic-2.0",
-            "GPL-2.0-or-later",
-            "custom"
-          ]
-        },
-        {
-          "name": "libk5crypto3",
-          "version": "1.21.3-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libk5crypto3@1.21.3-5?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "libkeyutils1",
-          "version": "1.6.3-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/libkeyutils1@1.6.3-6?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "LGPL-2.0-or-later",
-            "GPL-2.0-only",
-            "LGPL-2.0-only"
-          ]
-        },
-        {
-          "name": "libkrb5-3",
-          "version": "1.21.3-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libkrb5-3@1.21.3-5?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "libkrb5support0",
-          "version": "1.21.3-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libkrb5support0@1.21.3-5?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "libksba8",
-          "version": "1.6.7-2+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libksba8@1.6.7-2%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-3.0-only", "FSFUL", "LGPL-2.1-or-later"]
-        },
-        {
-          "name": "liblastlog2-2",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/liblastlog2-2@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libldap2",
-          "version": "2.6.10+dfsg-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libldap2@2.6.10%2Bdfsg-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "OpenLDAP-2.8",
-            "FSF-unlimited",
-            "GPL-2.0-only WITH autoconf-exception+",
-            "GPL-3.0-only WITH autoconf-exception+",
-            "GPL-2.0-or-later WITH Libtool-exception",
-            "GPL-3.0-or-later WITH Libtool-exception",
-            "GPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "UMich",
-            "F5",
-            "JCG",
-            "MIT-XC",
-            "NeoSoft-permissive",
-            "BSD-3-Clause",
-            "Beerware",
-            "public-domain",
-            "BSD-4-clause-California",
-            "BSD-3-clause-variant",
-            "Expat-ISC",
-            "Expat-UNM",
-            "MIT",
-            "BSD-3-clause-California",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "liblz4-1",
-          "version": "1.10.0-4",
-          "type": "library",
-          "purl": "pkg:deb/debian/liblz4-1@1.10.0-4?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "BSD-2-Clause", "GPL-2.0-only"]
-        },
-        {
-          "name": "liblzma5",
-          "version": "5.8.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/liblzma5@5.8.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "0BSD",
-            "GPL-2.0-or-later",
-            "LGPL-2.1-or-later",
-            "FSFULLR",
-            "GPL-3.0-or-later WITH Autoconf-exception-macro",
-            "none",
-            "PD",
-            "permissive-nowarranty",
-            "FSFUL",
-            "noderivs",
-            "PD-debian",
-            "LGPL-2.1-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libmd0",
-          "version": "1.1.0-2+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libmd0@1.1.0-2%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "BSD-3-clause-Aaron-D-Gifford",
-            "BSD-2-Clause",
-            "BSD-2-Clause-NetBSD",
-            "ISC",
-            "Beerware",
-            "public-domain-md4",
-            "public-domain-md5",
-            "public-domain-sha1"
-          ]
-        },
-        {
-          "name": "libmnl0",
-          "version": "1.0.5-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libmnl0@1.0.5-3?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.1-only", "GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libmount1",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libmount1@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libncursesw6",
-          "version": "6.5+20250216-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libncursesw6@6.5%2B20250216-2?arch=amd64&distro=debian-13.4",
-          "licenses": []
-        },
-        {
-          "name": "libnetfilter-conntrack3",
-          "version": "1.1.0-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnetfilter-conntrack3@1.1.0-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libnettle8t64",
-          "version": "3.10.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnettle8t64@3.10.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-3.0-or-later",
-            "GPL-2.0-or-later",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "MIT",
-            "GPL-3.0-only WITH autoconf-exception+",
-            "public-domain",
-            "GPL-2.0-only",
-            "GAP"
-          ]
-        },
-        {
-          "name": "libnfnetlink0",
-          "version": "1.0.2-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnfnetlink0@1.0.2-3?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libnftnl11",
-          "version": "1.2.9-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnftnl11@1.2.9-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libnghttp2-14",
-          "version": "1.64.0-1.1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnghttp2-14@1.64.0-1.1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "MIT",
-            "all-permissive",
-            "GPL-3.0-only WITH autoconf-exception+",
-            "BSD-2-Clause",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libnghttp3-9",
-          "version": "1.8.0-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnghttp3-9@1.8.0-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "MIT",
-            "FSFULLR",
-            "GPL-3.0-or-later WITH Autoconf-generic-exception",
-            "FSFUL",
-            "GPL-2.0-or-later WITH Autoconf-generic-exception",
-            "FSFAP",
-            "GPL-2.0-or-later WITH Libtool-Exception",
-            "GPL-3.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libngtcp2-16",
-          "version": "1.11.0-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libngtcp2-16@1.11.0-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "MIT",
-            "FSFULLR",
-            "GPL-3.0-or-later WITH Autoconf-generic-exception",
-            "FSFUL",
-            "GPL-2.0-or-later WITH Autoconf-generic-exception",
-            "FSFAP",
-            "GPL-2.0-or-later WITH Libtool-Exception",
-            "GPL-3.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libngtcp2-crypto-gnutls8",
-          "version": "1.11.0-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libngtcp2-crypto-gnutls8@1.11.0-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "MIT",
-            "FSFULLR",
-            "GPL-3.0-or-later WITH Autoconf-generic-exception",
-            "FSFUL",
-            "GPL-2.0-or-later WITH Autoconf-generic-exception",
-            "FSFAP",
-            "GPL-2.0-or-later WITH Libtool-Exception",
-            "GPL-3.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libnpth0t64",
-          "version": "1.8-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libnpth0t64@1.8-3?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.1-or-later", "LGPL-2.1-only"]
-        },
-        {
-          "name": "libp11-kit0",
-          "version": "0.25.5-3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libp11-kit0@0.25.5-3?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "FSFULLR",
-            "GPL-2.0-or-later WITH Autoconf-data-exception",
-            "GPL-3.0-or-later WITH Autoconf-data-exception",
-            "X11",
-            "ISC",
-            "customFSFULLRWD",
-            "LGPL-2.1-or-later",
-            "Apache-2.0",
-            "customFSFUL",
-            "FSFAP",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libpam-modules-bin",
-          "version": "1.7.0-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpam-modules-bin@1.7.0-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-2.0-or-later",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "BSD-tcp-wrappers",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "public-domain",
-            "Beerware"
-          ]
-        },
-        {
-          "name": "libpam-modules",
-          "version": "1.7.0-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpam-modules@1.7.0-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-2.0-or-later",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "BSD-tcp-wrappers",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "public-domain",
-            "Beerware"
-          ]
-        },
-        {
-          "name": "libpam-runtime",
-          "version": "1.7.0-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpam-runtime@1.7.0-5?arch=all&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-2.0-or-later",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "BSD-tcp-wrappers",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "public-domain",
-            "Beerware"
-          ]
-        },
-        {
-          "name": "libpam0g",
-          "version": "1.7.0-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpam0g@1.7.0-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-2.0-or-later",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "BSD-tcp-wrappers",
-            "LGPL-2.0-or-later",
-            "LGPL-2.0-only",
-            "public-domain",
-            "Beerware"
-          ]
-        },
-        {
-          "name": "libpcre2-8-0",
-          "version": "10.46-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpcre2-8-0@10.46-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-clause-Cambridge WITH BINARY-LIBRARY-LIKE-PACKAGES-exception",
-            "BSD-3-Clause",
-            "X11",
-            "BSD-2-Clause",
-            "public-domain"
-          ]
-        },
-        {
-          "name": "libperl5.40",
-          "version": "5.40.1-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/libperl5.40@5.40.1-6?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-1.0-or-later",
-            "Artistic-2.0",
-            "MIT",
-            "REGCOMP",
-            "GPL-2.0-only WITH bison-exception+",
-            "Unicode",
-            "BZIP",
-            "Zlib",
-            "GPL-2.0-or-later",
-            "FSFAP",
-            "BSD-3-Clause WITH weird-numbering",
-            "CC0-1.0",
-            "TEXT-TABS",
-            "BSD-4-clause-POWERDOG",
-            "BSD-3-clause-GENERIC",
-            "BSD-3-Clause",
-            "SDBM-PUBLIC-DOMAIN",
-            "DONT-CHANGE-THE-GPL",
-            "Artistic-dist",
-            "LGPL-2.1-only",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "Artistic-2"
-          ]
-        },
-        {
-          "name": "libpsl5t64",
-          "version": "0.21.2-1.1+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libpsl5t64@0.21.2-1.1%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT", "gnulib", "Chromium"]
-        },
-        {
-          "name": "libreadline8t64",
-          "version": "8.2-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/libreadline8t64@8.2-6?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GFDL-1.3-no-invariants-or-later",
-            "GFDL-1.3-or-later",
-            "ISC-no-attribution"
-          ]
-        },
-        {
-          "name": "librtmp1",
-          "version": "2.4+20151223.gitfa8646d.1-2+b5",
-          "type": "library",
-          "purl": "pkg:deb/debian/librtmp1@2.4%2B20151223.gitfa8646d.1-2%2Bb5?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only", "LGPL-2.1-only"]
-        },
-        {
-          "name": "libsasl2-2",
-          "version": "2.1.28+dfsg1-9",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsasl2-2@2.1.28%2Bdfsg1-9?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause-Attribution",
-            "BSD-3-Clause",
-            "BSD-2-Clause",
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "BSD-4-Clause-UC",
-            "RSA-MD",
-            "BSD-3-Clause-Attribution and IBM-as-is",
-            "BSD-3-clause-JANET",
-            "BSD-3-clause-PADL",
-            "MIT-OpenVision",
-            "OpenLDAP",
-            "FSFULLR",
-            "MIT-CMU",
-            "MIT-Export",
-            "BSD-2.2-clause",
-            "IBM-as-is"
-          ]
-        },
-        {
-          "name": "libsasl2-modules-db",
-          "version": "2.1.28+dfsg1-9",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsasl2-modules-db@2.1.28%2Bdfsg1-9?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "BSD-3-Clause-Attribution",
-            "BSD-3-Clause",
-            "BSD-2-Clause",
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "BSD-4-Clause-UC",
-            "RSA-MD",
-            "BSD-3-Clause-Attribution and IBM-as-is",
-            "BSD-3-clause-JANET",
-            "BSD-3-clause-PADL",
-            "MIT-OpenVision",
-            "OpenLDAP",
-            "FSFULLR",
-            "MIT-CMU",
-            "MIT-Export",
-            "BSD-2.2-clause",
-            "IBM-as-is"
-          ]
-        },
-        {
-          "name": "libseccomp2",
-          "version": "2.6.0-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libseccomp2@2.6.0-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.1-only"]
-        },
-        {
-          "name": "libselinux1",
-          "version": "3.8.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libselinux1@3.8.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["public-domain", "GPL-2.0-only"]
-        },
-        {
-          "name": "libsemanage-common",
-          "version": "3.8.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsemanage-common@3.8.1-1?arch=all&distro=debian-13.4",
-          "licenses": ["LGPL-2.1-or-later", "LGPL-2.1-only", "GPL-2.0-only"]
-        },
-        {
-          "name": "libsemanage2",
-          "version": "3.8.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsemanage2@3.8.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.1-or-later", "LGPL-2.1-only", "GPL-2.0-only"]
-        },
-        {
-          "name": "libsepol2",
-          "version": "3.8.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsepol2@3.8.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "LGPL-2.1-only",
-            "Zlib",
-            "GPL-2.0-only",
-            "GPL-2.0-or-later"
-          ]
-        },
-        {
-          "name": "libsmartcols1",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsmartcols1@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libsqlite3-0",
-          "version": "3.46.1-7+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsqlite3-0@3.46.1-7%2Bdeb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": ["public-domain", "GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libssh2-1t64",
-          "version": "1.11.1-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libssh2-1t64@1.11.1-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-3-Clause", "ISC"]
-        },
-        {
-          "name": "libssl3t64",
-          "version": "3.5.5-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libssl3t64@3.5.5-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "Apache-2.0",
-            "Artistic-2.0",
-            "GPL-1.0-or-later",
-            "GPL-1.0-only"
-          ]
-        },
-        {
-          "name": "libstdc++6",
-          "version": "14.2.0-19",
-          "type": "library",
-          "purl": "pkg:deb/debian/libstdc%2B%2B6@14.2.0-19?arch=amd64&distro=debian-13.4",
-          "licenses": []
-        },
-        {
-          "name": "libsystemd0",
-          "version": "257.9-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libsystemd0@257.9-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "CC0-1.0",
-            "GPL-2.0-only WITH Linux-syscall-note-exception",
-            "MIT",
-            "public-domain",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libtasn1-6",
-          "version": "4.20.0-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libtasn1-6@4.20.0-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.0-or-later",
-            "LGPL-2.1-only",
-            "GPL-3.0-only",
-            "GFDL-1.3-only"
-          ]
-        },
-        {
-          "name": "libtinfo6",
-          "version": "6.5+20250216-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libtinfo6@6.5%2B20250216-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT-X11", "X11", "BSD-3-Clause"]
-        },
-        {
-          "name": "libudev1",
-          "version": "257.9-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libudev1@257.9-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "LGPL-2.1-or-later",
-            "CC0-1.0",
-            "GPL-2.0-only WITH Linux-syscall-note-exception",
-            "MIT",
-            "public-domain",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libunistring5",
-          "version": "1.3-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libunistring5@1.3-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "LGPL-3.0-or-later",
-            "LGPL-2.0-or-later",
-            "GFDL-1.3-or-later",
-            "GFDL-1.2-or-later",
-            "LGPL-3.0-only",
-            "LGPL-2.1-or-later",
-            "BSD-3-Clause",
-            "ISC",
-            "Unicode-DFS-2016",
-            "public-domain",
-            "FreeSoftware",
-            "GPL-2.0-or-later",
-            "GPL-2.0-or-later WITH distribution-exception",
-            "MIT",
-            "X11",
-            "GPL-3.0-only",
-            "GPL-2.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "libuuid1",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/libuuid1@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "libx11-6",
-          "version": "2:1.8.12-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libx11-6@1.8.12-1?arch=amd64&distro=debian-13.4&epoch=2",
-          "licenses": []
-        },
-        {
-          "name": "libx11-data",
-          "version": "2:1.8.12-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libx11-data@1.8.12-1?arch=all&distro=debian-13.4&epoch=2",
-          "licenses": []
-        },
-        {
-          "name": "libxau6",
-          "version": "1:1.0.11-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxau6@1.0.11-1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": []
-        },
-        {
-          "name": "libxcb1",
-          "version": "1.17.0-2+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxcb1@1.17.0-2%2Bb1?arch=amd64&distro=debian-13.4",
-          "licenses": []
-        },
-        {
-          "name": "libxdmcp6",
-          "version": "1:1.1.5-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxdmcp6@1.1.5-1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": []
-        },
-        {
-          "name": "libxext6",
-          "version": "2:1.3.4-1+b3",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxext6@1.3.4-1%2Bb3?arch=amd64&distro=debian-13.4&epoch=2",
-          "licenses": []
-        },
-        {
-          "name": "libxmuu1",
-          "version": "2:1.1.3-3+b4",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxmuu1@1.1.3-3%2Bb4?arch=amd64&distro=debian-13.4&epoch=2",
-          "licenses": []
-        },
-        {
-          "name": "libxtables12",
-          "version": "1.8.11-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxtables12@1.8.11-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-only",
-            "Artistic-2.0",
-            "GPL-2.0-or-later",
-            "custom"
-          ]
-        },
-        {
-          "name": "libxxhash0",
-          "version": "0.8.3-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/libxxhash0@0.8.3-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-2-Clause", "GPL-2.0-or-later", "GPL-2.0-only"]
-        },
-        {
-          "name": "libzstd1",
-          "version": "1.5.7+dfsg-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/libzstd1@1.5.7%2Bdfsg-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["BSD-3-Clause", "GPL-2.0-only", "Zlib", "MIT"]
-        },
-        {
-          "name": "login.defs",
-          "version": "1:4.17.4-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/login.defs@4.17.4-2?arch=all&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-1.0-only",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "login",
-          "version": "1:4.16.0-2+really2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/login@4.16.0-2%2Breally2.41-5?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "mawk",
-          "version": "1.3.4.20250131-1",
-          "type": "library",
-          "purl": "pkg:deb/debian/mawk@1.3.4.20250131-1?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only", "X11", "CC-BY-3.0"]
-        },
-        {
-          "name": "mount",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/mount@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "ncurses-base",
-          "version": "6.5+20250216-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/ncurses-base@6.5%2B20250216-2?arch=all&distro=debian-13.4",
-          "licenses": ["MIT-X11", "X11", "BSD-3-Clause"]
-        },
-        {
-          "name": "ncurses-bin",
-          "version": "6.5+20250216-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/ncurses-bin@6.5%2B20250216-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["MIT-X11", "X11", "BSD-3-Clause"]
-        },
-        {
-          "name": "netbase",
-          "version": "6.5",
-          "type": "library",
-          "purl": "pkg:deb/debian/netbase@6.5?arch=all&distro=debian-13.4",
-          "licenses": ["GPL-2.0-only"]
-        },
-        {
-          "name": "openssh-client",
-          "version": "1:10.0p1-7+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/openssh-client@10.0p1-7%2Bdeb13u1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "OpenSSH",
-            "Mazieres-BSD-style",
-            "public-domain",
-            "BSD-3-Clause",
-            "Powell-BSD-style",
-            "MIT WITH advertising-restriction",
-            "BSD-2-Clause"
-          ]
-        },
-        {
-          "name": "openssl-provider-legacy",
-          "version": "3.5.5-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/openssl-provider-legacy@3.5.5-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "Apache-2.0",
-            "Artistic-2.0",
-            "GPL-1.0-or-later",
-            "GPL-1.0-only"
-          ]
-        },
-        {
-          "name": "openssl",
-          "version": "3.5.5-1~deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/openssl@3.5.5-1~deb13u1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "Apache-2.0",
-            "Artistic-2.0",
-            "GPL-1.0-or-later",
-            "GPL-1.0-only"
-          ]
-        },
-        {
-          "name": "passwd",
-          "version": "1:4.17.4-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/passwd@4.17.4-2?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": [
-            "BSD-3-Clause",
-            "GPL-1.0-only",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "patch",
-          "version": "2.8-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/patch@2.8-2?arch=amd64&distro=debian-13.4",
-          "licenses": ["GPL-3.0-or-later", "GPL-3.0-only"]
-        },
-        {
-          "name": "perl-base",
-          "version": "5.40.1-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/perl-base@5.40.1-6?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-1.0-or-later",
-            "Artistic-2.0",
-            "MIT",
-            "REGCOMP",
-            "GPL-2.0-only WITH bison-exception+",
-            "Unicode",
-            "BZIP",
-            "Zlib",
-            "GPL-2.0-or-later",
-            "FSFAP",
-            "BSD-3-Clause WITH weird-numbering",
-            "CC0-1.0",
-            "TEXT-TABS",
-            "BSD-4-clause-POWERDOG",
-            "BSD-3-clause-GENERIC",
-            "BSD-3-Clause",
-            "SDBM-PUBLIC-DOMAIN",
-            "DONT-CHANGE-THE-GPL",
-            "Artistic-dist",
-            "LGPL-2.1-only",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "Artistic-2"
-          ]
-        },
-        {
-          "name": "perl-modules-5.40",
-          "version": "5.40.1-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/perl-modules-5.40@5.40.1-6?arch=all&distro=debian-13.4",
-          "licenses": [
-            "GPL-1.0-or-later",
-            "Artistic-2.0",
-            "MIT",
-            "REGCOMP",
-            "GPL-2.0-only WITH bison-exception+",
-            "Unicode",
-            "BZIP",
-            "Zlib",
-            "GPL-2.0-or-later",
-            "FSFAP",
-            "BSD-3-Clause WITH weird-numbering",
-            "CC0-1.0",
-            "TEXT-TABS",
-            "BSD-4-clause-POWERDOG",
-            "BSD-3-clause-GENERIC",
-            "BSD-3-Clause",
-            "SDBM-PUBLIC-DOMAIN",
-            "DONT-CHANGE-THE-GPL",
-            "Artistic-dist",
-            "LGPL-2.1-only",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "Artistic-2"
-          ]
-        },
-        {
-          "name": "perl",
-          "version": "5.40.1-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/perl@5.40.1-6?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-1.0-or-later",
-            "Artistic-2.0",
-            "MIT",
-            "REGCOMP",
-            "GPL-2.0-only WITH bison-exception+",
-            "Unicode",
-            "BZIP",
-            "Zlib",
-            "GPL-2.0-or-later",
-            "FSFAP",
-            "BSD-3-Clause WITH weird-numbering",
-            "CC0-1.0",
-            "TEXT-TABS",
-            "BSD-4-clause-POWERDOG",
-            "BSD-3-clause-GENERIC",
-            "BSD-3-Clause",
-            "SDBM-PUBLIC-DOMAIN",
-            "DONT-CHANGE-THE-GPL",
-            "Artistic-dist",
-            "LGPL-2.1-only",
-            "GPL-1.0-only",
-            "GPL-2.0-only",
-            "Artistic-2"
-          ]
-        },
-        {
-          "name": "pinentry-curses",
-          "version": "1.3.1-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/pinentry-curses@1.3.1-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "X11",
-            "LGPL-3.0-or-later",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "readline-common",
-          "version": "8.2-6",
-          "type": "library",
-          "purl": "pkg:deb/debian/readline-common@8.2-6?arch=all&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GFDL-1.3-no-invariants-or-later",
-            "GFDL-1.3-or-later",
-            "ISC-no-attribution"
-          ]
-        },
-        {
-          "name": "sed",
-          "version": "4.9-2",
-          "type": "library",
-          "purl": "pkg:deb/debian/sed@4.9-2?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "X11",
-            "GFDL-1.3-no-invariants-or-later",
-            "GFDL-1.3-only",
-            "ISC",
-            "BSD-4-Clause-UC",
-            "BSL-1",
-            "pcre"
-          ]
-        },
-        {
-          "name": "skopeo",
-          "version": "1.18.0+ds1-1+b5",
-          "type": "library",
-          "purl": "pkg:deb/debian/skopeo@1.18.0%2Bds1-1%2Bb5?arch=amd64&distro=debian-13.4",
-          "licenses": ["Apache-2.0-and-or-Expat", "Apache-2.0", "MIT"]
-        },
-        {
-          "name": "sqv",
-          "version": "1.3.0-3+b2",
-          "type": "library",
-          "purl": "pkg:deb/debian/sqv@1.3.0-3%2Bb2?arch=amd64&distro=debian-13.4",
-          "licenses": ["LGPL-2.0-or-later", "LGPL-2.0-only"]
-        },
-        {
-          "name": "sysvinit-utils",
-          "version": "3.14-4",
-          "type": "library",
-          "purl": "pkg:deb/debian/sysvinit-utils@3.14-4?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "LGPL-2.1-or-later",
-            "GPL-3.0-only",
-            "GPL-2.0-only",
-            "LGPL-2.1-only"
-          ]
-        },
-        {
-          "name": "tar",
-          "version": "1.35+dfsg-3.1",
-          "type": "library",
-          "purl": "pkg:deb/debian/tar@1.35%2Bdfsg-3.1?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-3.0-or-later",
-            "GPL-3.0-only",
-            "GPL-3.0-or-later WITH Bison-exception",
-            "LGPL-2.1-or-later",
-            "LGPL-2.1-only",
-            "LGPL-3.0-or-later",
-            "LGPL-3.0-only",
-            "GPL-2.0-or-later",
-            "GPL-2.0-only"
-          ]
-        },
-        {
-          "name": "tzdata",
-          "version": "2026a-0+deb13u1",
-          "type": "library",
-          "purl": "pkg:deb/debian/tzdata@2026a-0%2Bdeb13u1?arch=all&distro=debian-13.4",
-          "licenses": ["public-domain"]
-        },
-        {
-          "name": "util-linux",
-          "version": "2.41-5",
-          "type": "library",
-          "purl": "pkg:deb/debian/util-linux@2.41-5?arch=amd64&distro=debian-13.4",
-          "licenses": [
-            "GPL-2.0-or-later",
-            "GPL-2.0-only",
-            "GPL-3.0-or-later",
-            "LGPL-2.1-or-later",
-            "public-domain",
-            "BSD-4-Clause",
-            "MIT",
-            "ISC",
-            "BSD-3-Clause",
-            "BSLA",
-            "LGPL-2.0-or-later",
-            "BSD-2-Clause",
-            "LGPL-3.0-or-later",
-            "GPL-3.0-only",
-            "LGPL-2.0-only",
-            "LGPL-2.1-only",
-            "LGPL-3.0-only"
-          ]
-        },
-        {
-          "name": "xauth",
-          "version": "1:1.1.2-1.1",
-          "type": "library",
-          "purl": "pkg:deb/debian/xauth@1.1.2-1.1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": []
-        },
-        {
-          "name": "zlib1g",
-          "version": "1:1.3.dfsg+really1.3.1-1+b1",
-          "type": "library",
-          "purl": "pkg:deb/debian/zlib1g@1.3.dfsg%2Breally1.3.1-1%2Bb1?arch=amd64&distro=debian-13.4&epoch=1",
-          "licenses": ["Zlib"]
-        },
-        {
-          "name": "cel.dev/expr",
-          "version": "v0.24.0",
-          "type": "library",
-          "purl": "pkg:golang/cel.dev/expr@v0.24.0",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/auth/oauth2adapt",
-          "version": "v0.2.8",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/auth/oauth2adapt@v0.2.8",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/auth",
-          "version": "v0.10.0",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/auth@v0.10.0",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/auth",
-          "version": "v0.18.0",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/auth@v0.18.0",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/compute/metadata",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/compute/metadata@v0.5.2",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/compute/metadata",
-          "version": "v0.9.0",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/compute/metadata@v0.9.0",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/iam",
-          "version": "v1.5.3",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/iam@v1.5.3",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/monitoring",
-          "version": "v1.24.3",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/monitoring@v1.24.3",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go/storage",
-          "version": "v1.57.1",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go/storage@v1.57.1",
-          "licenses": []
-        },
-        {
-          "name": "cloud.google.com/go",
-          "version": "v0.121.6",
-          "type": "library",
-          "purl": "pkg:golang/cloud.google.com/go@v0.121.6",
-          "licenses": []
-        },
-        {
-          "name": "dario.cat/mergo",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/dario.cat/mergo@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "dario.cat/mergo",
-          "version": "v1.0.2",
-          "type": "library",
-          "purl": "pkg:golang/dario.cat/mergo@v1.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/agext/levenshtein",
-          "version": "v1.2.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/agext/levenshtein@v1.2.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/agnivade/levenshtein",
-          "version": "v1.2.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/agnivade/levenshtein@v1.2.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/alecthomas/chroma",
-          "version": "v0.10.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/alecthomas/chroma@v0.10.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/anchore/go-struct-converter",
-          "version": "v0.0.0-20221118182256-c68fdcfa2092",
-          "type": "library",
-          "purl": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20221118182256-c68fdcfa2092",
-          "licenses": []
-        },
-        {
-          "name": "github.com/apparentlymart/go-cidr",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/apparentlymart/go-cidr@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/apparentlymart/go-textseg/v15",
-          "version": "v15.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/apparentlymart/go-textseg/v15@v15.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/go-gem-version",
-          "version": "v0.0.0-20201115065557-8eed6fe000ce",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/go-gem-version@v0.0.0-20201115065557-8eed6fe000ce",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/go-npm-version",
-          "version": "v0.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/go-npm-version@v0.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/go-pep440-version",
-          "version": "v0.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/go-pep440-version@v0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/go-version",
-          "version": "v0.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/go-version@v0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/iamgo",
-          "version": "v0.0.10",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/iamgo@v0.0.10",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/jfather",
-          "version": "v0.0.8",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/jfather@v0.0.8",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/table",
-          "version": "v1.11.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/table@v1.11.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/tml",
-          "version": "v0.6.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/tml@v0.6.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/trivy-checks",
-          "version": "v1.12.2-0.20251219190323-79d27547baf5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/trivy-checks@v1.12.2-0.20251219190323-79d27547baf5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/trivy-db",
-          "version": "v0.0.0-20251222105351-a833f47f8f0d",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/trivy-db@v0.0.0-20251222105351-a833f47f8f0d",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/trivy-java-db",
-          "version": "v0.0.0-20240109071736-184bd7481d48",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/trivy-java-db@v0.0.0-20240109071736-184bd7481d48",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/trivy-kubernetes",
-          "version": "v0.9.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/trivy-kubernetes@v0.9.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aquasecurity/trivy",
-          "version": "v0.69.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aquasecurity/trivy@v0.69.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/asaskevich/govalidator",
-          "version": "v0.0.0-20230301143203-a9d515a09cc2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/asaskevich/govalidator@v0.0.0-20230301143203-a9d515a09cc2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream",
-          "version": "v1.7.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream@v1.7.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/config",
-          "version": "v1.32.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/config@v1.32.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/credentials",
-          "version": "v1.19.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/credentials@v1.19.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/feature/ec2/imds",
-          "version": "v1.18.16",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/feature/ec2/imds@v1.18.16",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/internal/configsources",
-          "version": "v1.4.16",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/internal/configsources@v1.4.16",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/internal/endpoints/v2",
-          "version": "v2.7.16",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/internal/endpoints/v2@v2.7.16",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/internal/ini",
-          "version": "v1.8.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/internal/ini@v1.8.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/internal/v4a",
-          "version": "v1.4.14",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/internal/v4a@v1.4.14",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/ebs",
-          "version": "v1.22.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/ebs@v1.22.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/ec2",
-          "version": "v1.273.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/ec2@v1.273.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/ecr",
-          "version": "v1.53.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/ecr@v1.53.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding",
-          "version": "v1.13.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding@v1.13.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/internal/checksum",
-          "version": "v1.9.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/internal/checksum@v1.9.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/internal/presigned-url",
-          "version": "v1.13.16",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/internal/presigned-url@v1.13.16",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/internal/s3shared",
-          "version": "v1.19.14",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/internal/s3shared@v1.19.14",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/s3",
-          "version": "v1.92.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/s3@v1.92.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/signin",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/signin@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/sso",
-          "version": "v1.30.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/sso@v1.30.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/ssooidc",
-          "version": "v1.35.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/ssooidc@v1.35.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2/service/sts",
-          "version": "v1.41.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2/service/sts@v1.41.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go-v2",
-          "version": "v1.41.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go-v2@v1.41.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/aws-sdk-go",
-          "version": "v1.55.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.55.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/aws/smithy-go",
-          "version": "v1.24.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/aws/smithy-go@v1.24.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
-          "version": "v1.20.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/azure/azure-sdk-for-go/sdk/azcore@v1.20.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-          "version": "v1.13.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/azure/azure-sdk-for-go/sdk/azidentity@v1.13.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry",
-          "version": "v0.2.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/azure/azure-sdk-for-go/sdk/containers/azcontainerregistry@v0.2.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Azure/azure-sdk-for-go/sdk/internal",
-          "version": "v1.11.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/azure/azure-sdk-for-go/sdk/internal@v1.11.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/AzureAD/microsoft-authentication-library-for-go",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/azuread/microsoft-authentication-library-for-go@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/beorn7/perks",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/bgentry/go-netrc",
-          "version": "v0.0.0-20140422174119-9fd32a8b3d3d",
-          "type": "library",
-          "purl": "pkg:golang/github.com/bgentry/go-netrc@v0.0.0-20140422174119-9fd32a8b3d3d",
-          "licenses": []
-        },
-        {
-          "name": "github.com/bitnami/go-version",
-          "version": "v0.0.0-20231130084017-bb00604d650c",
-          "type": "library",
-          "purl": "pkg:golang/github.com/bitnami/go-version@v0.0.0-20231130084017-bb00604d650c",
-          "licenses": []
-        },
-        {
-          "name": "github.com/blang/semver/v4",
-          "version": "v4.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/blang/semver/v4@v4.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/blang/semver",
-          "version": "v3.5.1+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/blang/semver@v3.5.1%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/bmatcuk/doublestar/v4",
-          "version": "v4.9.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/bmatcuk/doublestar/v4@v4.9.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/briandowns/spinner",
-          "version": "v1.23.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/briandowns/spinner@v1.23.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/BurntSushi/toml",
-          "version": "v1.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/burntsushi/toml@v1.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/BurntSushi/toml",
-          "version": "v1.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/burntsushi/toml@v1.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cenkalti/backoff/v4",
-          "version": "v4.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cenkalti/backoff/v4@v4.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cenkalti/backoff/v5",
-          "version": "v5.0.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cenkalti/backoff/v5@v5.0.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cespare/xxhash/v2",
-          "version": "v2.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cespare/xxhash/v2@v2.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/chai2010/gettext-go",
-          "version": "v1.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/chai2010/gettext-go@v1.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cheggaaa/pb/v3",
-          "version": "v3.1.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cheggaaa/pb/v3@v3.1.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cloudflare/circl",
-          "version": "v1.6.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cloudflare/circl@v1.6.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cncf/xds/go",
-          "version": "v0.0.0-20251022180443-0feb69152e9f",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20251022180443-0feb69152e9f",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/containerd/api",
-          "version": "v1.10.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/containerd/api@v1.10.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/containerd/v2",
-          "version": "v2.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/containerd/v2@v2.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/containerd",
-          "version": "v1.7.29",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/containerd@v1.7.29",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/continuity",
-          "version": "v0.4.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/continuity@v0.4.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/errdefs/pkg",
-          "version": "v0.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/errdefs/pkg@v0.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/errdefs",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/errdefs@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/fifo",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/fifo@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/log",
-          "version": "v0.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/log@v0.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/platforms",
-          "version": "v1.0.0-rc.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/platforms@v1.0.0-rc.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/plugin",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/plugin@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/stargz-snapshotter/estargz",
-          "version": "v0.15.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/stargz-snapshotter/estargz@v0.15.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/stargz-snapshotter/estargz",
-          "version": "v0.18.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/stargz-snapshotter/estargz@v0.18.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/ttrpc",
-          "version": "v1.2.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/ttrpc@v1.2.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containerd/typeurl/v2",
-          "version": "v2.2.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containerd/typeurl/v2@v2.2.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containers/image/v5",
-          "version": "v5.33.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containers/image/v5@v5.33.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containers/libtrust",
-          "version": "v0.0.0-20230121012942-c1716e8a8d01",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containers/libtrust@v0.0.0-20230121012942-c1716e8a8d01",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containers/ocicrypt",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containers/ocicrypt@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/containers/storage",
-          "version": "v1.56.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/containers/storage@v1.56.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/coreos/go-oidc/v3",
-          "version": "v3.17.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/coreos/go-oidc/v3@v3.17.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cpuguy83/go-md2man/v2",
-          "version": "v2.0.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cpuguy83/go-md2man/v2@v2.0.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cyberphone/json-canonicalization",
-          "version": "v0.0.0-20241213102144-19d51d7fe467",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cyberphone/json-canonicalization@v0.0.0-20241213102144-19d51d7fe467",
-          "licenses": []
-        },
-        {
-          "name": "github.com/CycloneDX/cyclonedx-go",
-          "version": "v0.9.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cyphar/filepath-securejoin",
-          "version": "v0.3.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.3.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/cyphar/filepath-securejoin",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/cyphar/filepath-securejoin@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/dgryski/go-rendezvous",
-          "version": "v0.0.0-20200823014737-9f7001d12a5f",
-          "type": "library",
-          "purl": "pkg:golang/github.com/dgryski/go-rendezvous@v0.0.0-20200823014737-9f7001d12a5f",
-          "licenses": []
-        },
-        {
-          "name": "github.com/digitorus/pkcs7",
-          "version": "v0.0.0-20230818184609-3a137a874352",
-          "type": "library",
-          "purl": "pkg:golang/github.com/digitorus/pkcs7@v0.0.0-20230818184609-3a137a874352",
-          "licenses": []
-        },
-        {
-          "name": "github.com/digitorus/timestamp",
-          "version": "v0.0.0-20231217203849-220c5c2851b7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/digitorus/timestamp@v0.0.0-20231217203849-220c5c2851b7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/dlclark/regexp2",
-          "version": "v1.11.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/dlclark/regexp2@v1.11.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/cli",
-          "version": "v29.1.1+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/cli@v29.1.1%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/docker-credential-helpers",
-          "version": "v0.8.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/docker-credential-helpers@v0.8.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/docker-credential-helpers",
-          "version": "v0.9.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/docker-credential-helpers@v0.9.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/docker",
-          "version": "v27.3.1+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/docker@v27.3.1%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/docker",
-          "version": "v28.5.2+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/docker@v28.5.2%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/go-connections",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/go-connections@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/docker/go-connections",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/docker/go-connections@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/dsnet/compress",
-          "version": "v0.0.2-0.20230904184137-39efe44ab707",
-          "type": "library",
-          "purl": "pkg:golang/github.com/dsnet/compress@v0.0.2-0.20230904184137-39efe44ab707",
-          "licenses": []
-        },
-        {
-          "name": "github.com/dustin/go-humanize",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/emicklei/go-restful/v3",
-          "version": "v3.13.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.13.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/emirpasic/gods",
-          "version": "v1.18.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/emirpasic/gods@v1.18.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/envoyproxy/go-control-plane/envoy",
-          "version": "v1.35.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/envoyproxy/go-control-plane/envoy@v1.35.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/envoyproxy/protoc-gen-validate",
-          "version": "v1.2.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v1.2.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/evanphx/json-patch",
-          "version": "v5.9.11+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/evanphx/json-patch@v5.9.11%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/exponent-io/jsonpath",
-          "version": "v0.0.0-20210407135951-1de76d718b3f",
-          "type": "library",
-          "purl": "pkg:golang/github.com/exponent-io/jsonpath@v0.0.0-20210407135951-1de76d718b3f",
-          "licenses": []
-        },
-        {
-          "name": "github.com/fatih/color",
-          "version": "v1.18.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/fatih/color@v1.18.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/fsnotify/fsnotify",
-          "version": "v1.9.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.9.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/fvbommel/sortorder",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/fvbommel/sortorder@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/fxamacker/cbor/v2",
-          "version": "v2.9.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/fxamacker/cbor/v2@v2.9.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-chi/chi/v5",
-          "version": "v5.2.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-chi/chi/v5@v5.2.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-errors/errors",
-          "version": "v1.4.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-errors/errors@v1.4.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-git/gcfg",
-          "version": "v1.5.1-0.20230307220236-3a3c6141e376",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-git/gcfg@v1.5.1-0.20230307220236-3a3c6141e376",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-git/go-billy/v5",
-          "version": "v5.6.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-git/go-git/v5",
-          "version": "v5.16.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-git/go-git/v5@v5.16.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-gorp/gorp/v3",
-          "version": "v3.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-gorp/gorp/v3@v3.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-ini/ini",
-          "version": "v1.67.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-ini/ini@v1.67.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-jose/go-jose/v4",
-          "version": "v4.1.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-jose/go-jose/v4@v4.1.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-logr/logr",
-          "version": "v1.4.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/logr@v1.4.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-logr/logr",
-          "version": "v1.4.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-logr/logr@v1.4.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/analysis",
-          "version": "v0.24.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/analysis@v0.24.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/errors",
-          "version": "v0.22.6",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/errors@v0.22.6",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/jsonpointer",
-          "version": "v0.22.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.22.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/jsonreference",
-          "version": "v0.21.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.21.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/loads",
-          "version": "v0.23.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/loads@v0.23.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/runtime",
-          "version": "v0.29.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/runtime@v0.29.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/spec",
-          "version": "v0.22.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/spec@v0.22.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/strfmt",
-          "version": "v0.25.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/strfmt@v0.25.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/cmdutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/cmdutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/conv",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/conv@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/fileutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/fileutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/jsonname",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/jsonname@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/jsonutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/jsonutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/loading",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/loading@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/mangling",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/mangling@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/netutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/netutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/stringutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/stringutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/typeutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/typeutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag/yamlutils",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag/yamlutils@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/swag",
-          "version": "v0.25.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/swag@v0.25.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-openapi/validate",
-          "version": "v0.25.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-openapi/validate@v0.25.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-redis/redis/v8",
-          "version": "v8.11.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-redis/redis/v8@v8.11.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/go-viper/mapstructure/v2",
-          "version": "v2.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/go-viper/mapstructure/v2@v2.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gobwas/glob",
-          "version": "v0.2.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gobwas/glob@v0.2.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gocsaf/csaf/v3",
-          "version": "v3.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gocsaf/csaf/v3@v3.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/golang-jwt/jwt/v5",
-          "version": "v5.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/golang-jwt/jwt/v5@v5.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/golang/groupcache",
-          "version": "v0.0.0-20241129210726-2c02b8208cf8",
-          "type": "library",
-          "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20241129210726-2c02b8208cf8",
-          "licenses": []
-        },
-        {
-          "name": "github.com/golang/snappy",
-          "version": "v0.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/golang/snappy@v0.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/goodwithtech/deckoder",
-          "version": "v0.0.6",
-          "type": "library",
-          "purl": "pkg:golang/github.com/goodwithtech/deckoder@v0.0.6",
-          "licenses": []
-        },
-        {
-          "name": "github.com/goodwithtech/dockle",
-          "version": "0.4.15",
-          "type": "library",
-          "purl": "pkg:golang/github.com/goodwithtech/dockle@0.4.15",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/btree",
-          "version": "v1.1.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/btree@v1.1.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/certificate-transparency-go",
-          "version": "v1.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/certificate-transparency-go@v1.3.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/gnostic-models",
-          "version": "v0.7.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/gnostic-models@v0.7.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-cmp",
-          "version": "v0.7.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-cmp@v0.7.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-containerregistry",
-          "version": "v0.20.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-containerregistry@v0.20.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-containerregistry",
-          "version": "v0.20.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-containerregistry@v0.20.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-github/v62",
-          "version": "v62.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-github/v62@v62.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-intervals",
-          "version": "v0.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-intervals@v0.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/go-querystring",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/go-querystring@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/licenseclassifier/v2",
-          "version": "v2.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/licenseclassifier/v2@v2.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/s2a-go",
-          "version": "v0.1.9",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/s2a-go@v0.1.9",
-          "licenses": []
-        },
-        {
-          "name": "github.com/google/shlex",
-          "version": "v0.0.0-20191202100458-e7afc7fbc510",
-          "type": "library",
-          "purl": "pkg:golang/github.com/google/shlex@v0.0.0-20191202100458-e7afc7fbc510",
-          "licenses": []
-        },
-        {
-          "name": "github.com/googleapis/enterprise-certificate-proxy",
-          "version": "v0.3.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googleapis/enterprise-certificate-proxy@v0.3.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/googleapis/enterprise-certificate-proxy",
-          "version": "v0.3.9",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googleapis/enterprise-certificate-proxy@v0.3.9",
-          "licenses": []
-        },
-        {
-          "name": "github.com/googleapis/gax-go/v2",
-          "version": "v2.16.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.16.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/GoogleCloudPlatform/docker-credential-gcr/v2",
-          "version": "v2.1.26",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googlecloudplatform/docker-credential-gcr/v2@v2.1.26",
-          "licenses": []
-        },
-        {
-          "name": "github.com/GoogleCloudPlatform/docker-credential-gcr/v2",
-          "version": "v2.1.30",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googlecloudplatform/docker-credential-gcr/v2@v2.1.30",
-          "licenses": []
-        },
-        {
-          "name": "github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp",
-          "version": "v1.30.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googlecloudplatform/opentelemetry-operations-go/detectors/gcp@v1.30.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric",
-          "version": "v0.54.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googlecloudplatform/opentelemetry-operations-go/exporter/metric@v0.54.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping",
-          "version": "v0.54.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/googlecloudplatform/opentelemetry-operations-go/internal/resourcemapping@v0.54.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gorilla/mux",
-          "version": "v1.8.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gorilla/mux@v1.8.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gorilla/websocket",
-          "version": "v1.5.4-0.20250319132907-e064f32e3674",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gorilla/websocket@v1.5.4-0.20250319132907-e064f32e3674",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gosuri/uitable",
-          "version": "v0.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gosuri/uitable@v0.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/gregjones/httpcache",
-          "version": "v0.0.0-20190611155906-901d90724c79",
-          "type": "library",
-          "purl": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79",
-          "licenses": []
-        },
-        {
-          "name": "github.com/grpc-ecosystem/grpc-gateway/v2",
-          "version": "v2.27.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/grpc-ecosystem/grpc-gateway/v2@v2.27.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/aws-sdk-go-base/v2",
-          "version": "v2.0.0-beta.65",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.65",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-cleanhttp",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-cleanhttp@v0.5.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-getter",
-          "version": "v1.8.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-getter@v1.8.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-retryablehttp",
-          "version": "v0.7.8",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-retryablehttp@v0.7.8",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-uuid",
-          "version": "v1.0.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-uuid@v1.0.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/go-version",
-          "version": "v1.8.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/go-version@v1.8.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/golang-lru/v2",
-          "version": "v2.0.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/golang-lru/v2@v2.0.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/hashicorp/hcl/v2",
-          "version": "v2.24.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/hashicorp/hcl/v2@v2.24.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/huandu/xstrings",
-          "version": "v1.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/huandu/xstrings@v1.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/in-toto/attestation",
-          "version": "v1.1.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/in-toto/attestation@v1.1.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/in-toto/in-toto-golang",
-          "version": "v0.9.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/in-toto/in-toto-golang@v0.9.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Intevation/gval",
-          "version": "v1.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/intevation/gval@v1.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Intevation/jsonpath",
-          "version": "v0.2.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/intevation/jsonpath@v0.2.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/jbenet/go-context",
-          "version": "v0.0.0-20150711004518-d14ea06fba99",
-          "type": "library",
-          "purl": "pkg:golang/github.com/jbenet/go-context@v0.0.0-20150711004518-d14ea06fba99",
-          "licenses": []
-        },
-        {
-          "name": "github.com/jedisct1/go-minisign",
-          "version": "v0.0.0-20230811132847-661be99b8267",
-          "type": "library",
-          "purl": "pkg:golang/github.com/jedisct1/go-minisign@v0.0.0-20230811132847-661be99b8267",
-          "licenses": []
-        },
-        {
-          "name": "github.com/jmespath/go-jmespath",
-          "version": "v0.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/jmoiron/sqlx",
-          "version": "v1.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/jmoiron/sqlx@v1.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/josephburnett/jd/v2",
-          "version": "v2.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/josephburnett/jd/v2@v2.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/kevinburke/ssh_config",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/kevinburke/ssh_config@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/klauspost/compress",
-          "version": "v1.17.11",
-          "type": "library",
-          "purl": "pkg:golang/github.com/klauspost/compress@v1.17.11",
-          "licenses": []
-        },
-        {
-          "name": "github.com/klauspost/compress",
-          "version": "v1.18.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/klauspost/compress@v1.18.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/klauspost/pgzip",
-          "version": "v1.2.6",
-          "type": "library",
-          "purl": "pkg:golang/github.com/klauspost/pgzip@v1.2.6",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/go-apk-version",
-          "version": "v0.0.0-20200609155635-041fdbb8563f",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/go-apk-version@v0.0.0-20200609155635-041fdbb8563f",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/go-deb-version",
-          "version": "v0.0.0-20241115132648-6f4aee6ccd23",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/go-deb-version@v0.0.0-20241115132648-6f4aee6ccd23",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/go-rpm-version",
-          "version": "v0.0.0-20220614171824-631e686d1075",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/go-rpm-version@v0.0.0-20220614171824-631e686d1075",
-          "licenses": []
-        },
-        {
-          "name": "github.com/knqyf263/go-rpmdb",
-          "version": "v0.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/knqyf263/go-rpmdb@v0.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/kylelemons/godebug",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/kylelemons/godebug@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lann/builder",
-          "version": "v0.0.0-20180802200727-47ae307949d0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lann/builder@v0.0.0-20180802200727-47ae307949d0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lann/ps",
-          "version": "v0.0.0-20150810152359-62de8c46ede0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lann/ps@v0.0.0-20150810152359-62de8c46ede0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/blackmagic",
-          "version": "v1.0.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/blackmagic@v1.0.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/dsig",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/dsig@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/httpcc",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/httpcc@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/httprc/v3",
-          "version": "v3.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/httprc/v3@v3.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/jwx/v3",
-          "version": "v3.0.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/jwx/v3@v3.0.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/option/v2",
-          "version": "v2.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/option/v2@v2.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lestrrat-go/option",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lestrrat-go/option@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/letsencrypt/boulder",
-          "version": "v0.20251110.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/letsencrypt/boulder@v0.20251110.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lib/pq",
-          "version": "v1.10.9",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lib/pq@v1.10.9",
-          "licenses": []
-        },
-        {
-          "name": "github.com/liggitt/tabwriter",
-          "version": "v0.0.0-20181228230101-89fcab3d43de",
-          "type": "library",
-          "purl": "pkg:golang/github.com/liggitt/tabwriter@v0.0.0-20181228230101-89fcab3d43de",
-          "licenses": []
-        },
-        {
-          "name": "github.com/lunixbochs/struc",
-          "version": "v0.0.0-20200707160740-784aaebc1d40",
-          "type": "library",
-          "purl": "pkg:golang/github.com/lunixbochs/struc@v0.0.0-20200707160740-784aaebc1d40",
-          "licenses": []
-        },
-        {
-          "name": "github.com/MakeNowJust/heredoc",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/makenowjust/heredoc@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-disk",
-          "version": "v0.0.0-20240625071113-56c933208fee",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-disk@v0.0.0-20240625071113-56c933208fee",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-ebs-file",
-          "version": "v0.0.0-20240917043618-e6d2bea5c32e",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-ebs-file@v0.0.0-20240917043618-e6d2bea5c32e",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-ext4-filesystem",
-          "version": "v0.0.0-20240620024024-ca14e6327bbd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-ext4-filesystem@v0.0.0-20240620024024-ca14e6327bbd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-mvn-version",
-          "version": "v0.0.0-20250131095131-f4974fa13b8a",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-mvn-version@v0.0.0-20250131095131-f4974fa13b8a",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-vmdk-parser",
-          "version": "v0.0.0-20221225061455-612096e4bbbd",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-vmdk-parser@v0.0.0-20221225061455-612096e4bbbd",
-          "licenses": []
-        },
-        {
-          "name": "github.com/masahiro331/go-xfs-filesystem",
-          "version": "v0.0.0-20231205045356-1b22259a6c44",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masahiro331/go-xfs-filesystem@v0.0.0-20231205045356-1b22259a6c44",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Masterminds/goutils",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masterminds/goutils@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Masterminds/semver/v3",
-          "version": "v3.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masterminds/semver/v3@v3.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Masterminds/sprig/v3",
-          "version": "v3.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masterminds/sprig/v3@v3.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/Masterminds/squirrel",
-          "version": "v1.5.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/masterminds/squirrel@v1.5.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mattn/go-colorable",
-          "version": "v0.1.14",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.14",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mattn/go-isatty",
-          "version": "v0.0.20",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.20",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mattn/go-runewidth",
-          "version": "v0.0.16",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.16",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mattn/go-shellwords",
-          "version": "v1.0.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mattn/go-shellwords@v1.0.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mattn/go-sqlite3",
-          "version": "v1.14.24",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mattn/go-sqlite3@v1.14.24",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mistifyio/go-zfs/v3",
-          "version": "v3.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mistifyio/go-zfs/v3@v3.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/copystructure",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/copystructure@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/go-homedir",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/go-homedir@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/go-wordwrap",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/go-wordwrap@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/hashstructure/v2",
-          "version": "v2.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/hashstructure/v2@v2.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/mapstructure",
-          "version": "v1.5.1-0.20231216201459-8508981c8b6c",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/mapstructure@v1.5.1-0.20231216201459-8508981c8b6c",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mitchellh/reflectwalk",
-          "version": "v1.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mitchellh/reflectwalk@v1.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/buildkit",
-          "version": "v0.26.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/buildkit@v0.26.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/locker",
-          "version": "v1.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/locker@v1.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/moby/api",
-          "version": "v1.52.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/moby/api@v1.52.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/moby/client",
-          "version": "v0.2.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/moby/client@v0.2.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/spdystream",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/spdystream@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/atomicwriter",
-          "version": "v0.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/atomicwriter@v0.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/capability",
-          "version": "v0.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/capability@v0.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/sequential",
-          "version": "v0.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/sequential@v0.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/signal",
-          "version": "v0.7.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/signal@v0.7.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/user",
-          "version": "v0.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/user@v0.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/user",
-          "version": "v0.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/user@v0.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/sys/userns",
-          "version": "v0.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/sys/userns@v0.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/moby/term",
-          "version": "v0.5.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/moby/term@v0.5.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/reflect2",
-          "version": "v1.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/modern-go/reflect2",
-          "version": "v1.0.3-0.20250322232337-35a7c28c31ee",
-          "type": "library",
-          "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.3-0.20250322232337-35a7c28c31ee",
-          "licenses": []
-        },
-        {
-          "name": "github.com/monochromegane/go-gitignore",
-          "version": "v0.0.0-20200626010858-205db1a8cc00",
-          "type": "library",
-          "purl": "pkg:golang/github.com/monochromegane/go-gitignore@v0.0.0-20200626010858-205db1a8cc00",
-          "licenses": []
-        },
-        {
-          "name": "github.com/morikuni/aec",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/morikuni/aec@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/munnerz/goautoneg",
-          "version": "v0.0.0-20191010083416-a7dc8b61c822",
-          "type": "library",
-          "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-          "licenses": []
-        },
-        {
-          "name": "github.com/mxk/go-flowrate",
-          "version": "v0.0.0-20140419014527-cca7078d478f",
-          "type": "library",
-          "purl": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-          "licenses": []
-        },
-        {
-          "name": "github.com/nikolalohinski/gonja/v2",
-          "version": "v2.4.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/nikolalohinski/gonja/v2@v2.4.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/nozzle/throttler",
-          "version": "v0.0.0-20180817012639-2ea982251481",
-          "type": "library",
-          "purl": "pkg:golang/github.com/nozzle/throttler@v0.0.0-20180817012639-2ea982251481",
-          "licenses": []
-        },
-        {
-          "name": "github.com/NYTimes/gziphandler",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/nytimes/gziphandler@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/oklog/ulid/v2",
-          "version": "v2.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/oklog/ulid/v2@v2.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/oklog/ulid",
-          "version": "v1.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/oklog/ulid@v1.3.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/open-policy-agent/opa",
-          "version": "v1.11.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/open-policy-agent/opa@v1.11.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/image-spec",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/image-spec",
-          "version": "v1.1.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/image-spec@v1.1.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/runtime-spec",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/runtime-spec",
-          "version": "v1.2.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/runtime-spec@v1.2.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/selinux",
-          "version": "v1.11.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/selinux@v1.11.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/opencontainers/selinux",
-          "version": "v1.13.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/opencontainers/selinux@v1.13.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/openvex/discovery",
-          "version": "v0.1.1-0.20240802171711-7c54efc57553",
-          "type": "library",
-          "purl": "pkg:golang/github.com/openvex/discovery@v0.1.1-0.20240802171711-7c54efc57553",
-          "licenses": []
-        },
-        {
-          "name": "github.com/openvex/go-vex",
-          "version": "v0.2.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/openvex/go-vex@v0.2.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/owenrumney/go-sarif/v2",
-          "version": "v2.0.17",
-          "type": "library",
-          "purl": "pkg:golang/github.com/owenrumney/go-sarif/v2@v2.0.17",
-          "licenses": []
-        },
-        {
-          "name": "github.com/owenrumney/go-sarif/v2",
-          "version": "v2.3.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/owenrumney/go-sarif/v2@v2.3.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/owenrumney/squealer",
-          "version": "v1.2.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/owenrumney/squealer@v1.2.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/package-url/packageurl-go",
-          "version": "v0.1.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/package-url/packageurl-go@v0.1.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pandatix/go-cvss",
-          "version": "v0.6.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pandatix/go-cvss@v0.6.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pelletier/go-toml/v2",
-          "version": "v2.2.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pelletier/go-toml/v2@v2.2.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/peterbourgon/diskv",
-          "version": "v2.0.1+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pjbgf/sha1cd",
-          "version": "v0.3.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pjbgf/sha1cd@v0.3.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/pkg/browser",
-          "version": "v0.0.0-20240102092130-5ac0b6a4141c",
-          "type": "library",
-          "purl": "pkg:golang/github.com/pkg/browser@v0.0.0-20240102092130-5ac0b6a4141c",
-          "licenses": []
-        },
-        {
-          "name": "github.com/planetscale/vtprotobuf",
-          "version": "v0.6.1-0.20240319094008-0393e58bdf10",
-          "type": "library",
-          "purl": "pkg:golang/github.com/planetscale/vtprotobuf@v0.6.1-0.20240319094008-0393e58bdf10",
-          "licenses": []
-        },
-        {
-          "name": "github.com/prometheus/client_golang",
-          "version": "v1.23.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/prometheus/client_golang@v1.23.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/prometheus/client_model",
-          "version": "v0.6.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/prometheus/client_model@v0.6.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/prometheus/common",
-          "version": "v0.67.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/prometheus/common@v0.67.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/prometheus/procfs",
-          "version": "v0.17.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/prometheus/procfs@v0.17.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/ProtonMail/go-crypto",
-          "version": "v1.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/protonmail/go-crypto@v1.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/rcrowley/go-metrics",
-          "version": "v0.0.0-20250401214520-65e299d6c5c9",
-          "type": "library",
-          "purl": "pkg:golang/github.com/rcrowley/go-metrics@v0.0.0-20250401214520-65e299d6c5c9",
-          "licenses": []
-        },
-        {
-          "name": "github.com/remyoudompheng/bigfft",
-          "version": "v0.0.0-20230129092748-24d4a6f8daec",
-          "type": "library",
-          "purl": "pkg:golang/github.com/remyoudompheng/bigfft@v0.0.0-20230129092748-24d4a6f8daec",
-          "licenses": []
-        },
-        {
-          "name": "github.com/rivo/uniseg",
-          "version": "v0.4.7",
-          "type": "library",
-          "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
-          "licenses": []
-        },
-        {
-          "name": "github.com/rubenv/sql-migrate",
-          "version": "v1.8.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/rubenv/sql-migrate@v1.8.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/rust-secure-code/go-rustaudit",
-          "version": "v0.0.0-20250226111315-e20ec32e963c",
-          "type": "library",
-          "purl": "pkg:golang/github.com/rust-secure-code/go-rustaudit@v0.0.0-20250226111315-e20ec32e963c",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sagikazarmark/locafero",
-          "version": "v0.11.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sagikazarmark/locafero@v0.11.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/samber/lo",
-          "version": "v1.52.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/samber/lo@v1.52.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/samber/oops",
-          "version": "v1.18.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/samber/oops@v1.18.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/santhosh-tekuri/jsonschema/v6",
-          "version": "v6.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema/v6@v6.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sassoftware/go-rpmutils",
-          "version": "v0.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sassoftware/go-rpmutils@v0.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sassoftware/relic",
-          "version": "v7.2.1+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sassoftware/relic@v7.2.1%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/secure-systems-lab/go-securesystemslib",
-          "version": "v0.10.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/secure-systems-lab/go-securesystemslib@v0.10.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sergi/go-diff",
-          "version": "v1.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sergi/go-diff@v1.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/shibumi/go-pathspec",
-          "version": "v1.3.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/shibumi/go-pathspec@v1.3.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/shopspring/decimal",
-          "version": "v1.4.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/shopspring/decimal@v1.4.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/cosign/v2",
-          "version": "v2.6.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/cosign/v2@v2.6.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/protobuf-specs",
-          "version": "v0.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/protobuf-specs@v0.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/rekor-tiles/v2",
-          "version": "v2.0.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/rekor-tiles/v2@v2.0.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/rekor",
-          "version": "v1.5.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/rekor@v1.5.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/sigstore-go",
-          "version": "v1.1.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/sigstore-go@v1.1.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/sigstore",
-          "version": "v1.10.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/sigstore@v1.10.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sigstore/timestamp-authority/v2",
-          "version": "v2.0.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sigstore/timestamp-authority/v2@v2.0.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sirupsen/logrus",
-          "version": "v1.9.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sirupsen/logrus",
-          "version": "v1.9.4-0.20230606125235-dd1b4c2e81af",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sirupsen/logrus@v1.9.4-0.20230606125235-dd1b4c2e81af",
-          "licenses": []
-        },
-        {
-          "name": "github.com/skeema/knownhosts",
-          "version": "v1.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/skeema/knownhosts@v1.3.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sourcegraph/conc",
-          "version": "v0.3.1-0.20240121214520-5f936abd7ae8",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sourcegraph/conc@v0.3.1-0.20240121214520-5f936abd7ae8",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spdx/tools-golang",
-          "version": "v0.5.5",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spdx/tools-golang@v0.5.5",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spf13/afero",
-          "version": "v1.15.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spf13/afero@v1.15.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spf13/cast",
-          "version": "v1.10.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spf13/cast@v1.10.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spf13/cobra",
-          "version": "v1.10.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spf13/cobra@v1.10.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spf13/pflag",
-          "version": "v1.0.10",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spf13/pflag@v1.0.10",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spf13/viper",
-          "version": "v1.21.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spf13/viper@v1.21.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/spiffe/go-spiffe/v2",
-          "version": "v2.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/spiffe/go-spiffe/v2@v2.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/testify",
-          "version": "v1.10.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/testify@v1.10.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/stretchr/testify",
-          "version": "v1.11.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/stretchr/testify@v1.11.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/subosito/gotenv",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/subosito/gotenv@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/sylabs/sif/v2",
-          "version": "v2.19.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/sylabs/sif/v2@v2.19.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/syndtr/goleveldb",
-          "version": "v1.0.1-0.20220721030215-126854af5e6d",
-          "type": "library",
-          "purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.1-0.20220721030215-126854af5e6d",
-          "licenses": []
-        },
-        {
-          "name": "github.com/tchap/go-patricia/v2",
-          "version": "v2.3.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/tchap/go-patricia/v2@v2.3.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/tchap/go-patricia/v2",
-          "version": "v2.3.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/tchap/go-patricia/v2@v2.3.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/tetratelabs/wazero",
-          "version": "v1.10.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/tetratelabs/wazero@v1.10.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/theupdateframework/go-tuf/v2",
-          "version": "v2.4.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/theupdateframework/go-tuf/v2@v2.4.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/theupdateframework/go-tuf",
-          "version": "v0.7.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/theupdateframework/go-tuf@v0.7.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/titanous/rocacheck",
-          "version": "v0.0.0-20171023193734-afe73141d399",
-          "type": "library",
-          "purl": "pkg:golang/github.com/titanous/rocacheck@v0.0.0-20171023193734-afe73141d399",
-          "licenses": []
-        },
-        {
-          "name": "github.com/tonistiigi/go-csvvalue",
-          "version": "v0.0.0-20240814133006-030d3b2625d0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/tonistiigi/go-csvvalue@v0.0.0-20240814133006-030d3b2625d0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/transparency-dev/formats",
-          "version": "v0.0.0-20251017110053-404c0d5b696c",
-          "type": "library",
-          "purl": "pkg:golang/github.com/transparency-dev/formats@v0.0.0-20251017110053-404c0d5b696c",
-          "licenses": []
-        },
-        {
-          "name": "github.com/transparency-dev/merkle",
-          "version": "v0.0.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/transparency-dev/merkle@v0.0.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/twitchtv/twirp",
-          "version": "v8.1.3+incompatible",
-          "type": "library",
-          "purl": "pkg:golang/github.com/twitchtv/twirp@v8.1.3%2Bincompatible",
-          "licenses": []
-        },
-        {
-          "name": "github.com/ulikunitz/xz",
-          "version": "v0.5.12",
-          "type": "library",
-          "purl": "pkg:golang/github.com/ulikunitz/xz@v0.5.12",
-          "licenses": []
-        },
-        {
-          "name": "github.com/ulikunitz/xz",
-          "version": "v0.5.15",
-          "type": "library",
-          "purl": "pkg:golang/github.com/ulikunitz/xz@v0.5.15",
-          "licenses": []
-        },
-        {
-          "name": "github.com/urfave/cli",
-          "version": "v1.22.15",
-          "type": "library",
-          "purl": "pkg:golang/github.com/urfave/cli@v1.22.15",
-          "licenses": []
-        },
-        {
-          "name": "github.com/valyala/fastjson",
-          "version": "v1.6.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/valyala/fastjson@v1.6.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/vbatts/tar-split",
-          "version": "v0.11.6",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vbatts/tar-split@v0.11.6",
-          "licenses": []
-        },
-        {
-          "name": "github.com/vbatts/tar-split",
-          "version": "v0.12.2",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vbatts/tar-split@v0.12.2",
-          "licenses": []
-        },
-        {
-          "name": "github.com/vektah/gqlparser/v2",
-          "version": "v2.5.31",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vektah/gqlparser/v2@v2.5.31",
-          "licenses": []
-        },
-        {
-          "name": "github.com/VividCortex/ewma",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vividcortex/ewma@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/vmihailenco/msgpack/v5",
-          "version": "v5.4.1",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vmihailenco/msgpack/v5@v5.4.1",
-          "licenses": []
-        },
-        {
-          "name": "github.com/vmihailenco/tagparser/v2",
-          "version": "v2.0.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/vmihailenco/tagparser/v2@v2.0.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/x448/float16",
-          "version": "v0.8.4",
-          "type": "library",
-          "purl": "pkg:golang/github.com/x448/float16@v0.8.4",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xanzy/ssh-agent",
-          "version": "v0.3.3",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xanzy/ssh-agent@v0.3.3",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xeipuuv/gojsonpointer",
-          "version": "v0.0.0-20190905194746-02993c407bfb",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xeipuuv/gojsonpointer@v0.0.0-20190905194746-02993c407bfb",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xeipuuv/gojsonreference",
-          "version": "v0.0.0-20180127040603-bd5ef7bd5415",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xeipuuv/gojsonreference@v0.0.0-20180127040603-bd5ef7bd5415",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xeipuuv/gojsonschema",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xeipuuv/gojsonschema@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xi2/xz",
-          "version": "v0.0.0-20171230120015-48954b6210f8",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xi2/xz@v0.0.0-20171230120015-48954b6210f8",
-          "licenses": []
-        },
-        {
-          "name": "github.com/xlab/treeprint",
-          "version": "v1.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/xlab/treeprint@v1.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/yashtewari/glob-intersection",
-          "version": "v0.2.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/yashtewari/glob-intersection@v0.2.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/zclconf/go-cty-yaml",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/zclconf/go-cty-yaml@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "github.com/zclconf/go-cty",
-          "version": "v1.17.0",
-          "type": "library",
-          "purl": "pkg:golang/github.com/zclconf/go-cty@v1.17.0",
-          "licenses": []
-        },
-        {
-          "name": "go.etcd.io/bbolt",
-          "version": "v1.4.3",
-          "type": "library",
-          "purl": "pkg:golang/go.etcd.io/bbolt@v1.4.3",
-          "licenses": []
-        },
-        {
-          "name": "go.mongodb.org/mongo-driver",
-          "version": "v1.17.6",
-          "type": "library",
-          "purl": "pkg:golang/go.mongodb.org/mongo-driver@v1.17.6",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/auto/sdk",
-          "version": "v1.1.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/auto/sdk@v1.1.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/auto/sdk",
-          "version": "v1.2.1",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/auto/sdk@v1.2.1",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/contrib/detectors/gcp",
-          "version": "v1.38.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/contrib/detectors/gcp@v1.38.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
-          "version": "v0.63.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.63.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
-          "version": "v0.54.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.54.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
-          "version": "v0.63.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.63.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc",
-          "version": "v1.38.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.38.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc",
-          "version": "v1.38.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.38.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace",
-          "version": "v1.38.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/exporters/otlp/otlptrace@v1.38.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/metric",
-          "version": "v1.33.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/metric@v1.33.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/metric",
-          "version": "v1.40.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/metric@v1.40.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/sdk/metric",
-          "version": "v1.40.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/sdk/metric@v1.40.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/sdk",
-          "version": "v1.40.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.40.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/trace",
-          "version": "v1.33.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/trace@v1.33.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel/trace",
-          "version": "v1.40.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel/trace@v1.40.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel",
-          "version": "v1.33.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel@v1.33.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/otel",
-          "version": "v1.40.0",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/otel@v1.40.0",
-          "licenses": []
-        },
-        {
-          "name": "go.opentelemetry.io/proto/otlp",
-          "version": "v1.7.1",
-          "type": "library",
-          "purl": "pkg:golang/go.opentelemetry.io/proto/otlp@v1.7.1",
-          "licenses": []
-        },
-        {
-          "name": "go.uber.org/atomic",
-          "version": "v1.7.0",
-          "type": "library",
-          "purl": "pkg:golang/go.uber.org/atomic@v1.7.0",
-          "licenses": []
-        },
-        {
-          "name": "go.uber.org/multierr",
-          "version": "v1.11.0",
-          "type": "library",
-          "purl": "pkg:golang/go.uber.org/multierr@v1.11.0",
-          "licenses": []
-        },
-        {
-          "name": "go.uber.org/multierr",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/go.uber.org/multierr@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "go.uber.org/zap",
-          "version": "v1.17.0",
-          "type": "library",
-          "purl": "pkg:golang/go.uber.org/zap@v1.17.0",
-          "licenses": []
-        },
-        {
-          "name": "go.uber.org/zap",
-          "version": "v1.27.1",
-          "type": "library",
-          "purl": "pkg:golang/go.uber.org/zap@v1.27.1",
-          "licenses": []
-        },
-        {
-          "name": "go.yaml.in/yaml/v2",
-          "version": "v2.4.3",
-          "type": "library",
-          "purl": "pkg:golang/go.yaml.in/yaml/v2@v2.4.3",
-          "licenses": []
-        },
-        {
-          "name": "go.yaml.in/yaml/v3",
-          "version": "v3.0.4",
-          "type": "library",
-          "purl": "pkg:golang/go.yaml.in/yaml/v3@v3.0.4",
-          "licenses": []
-        },
-        {
-          "name": "go.yaml.in/yaml/v4",
-          "version": "v4.0.0-rc.3",
-          "type": "library",
-          "purl": "pkg:golang/go.yaml.in/yaml/v4@v4.0.0-rc.3",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/crypto",
-          "version": "v0.46.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/crypto@v0.46.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/exp",
-          "version": "v0.0.0-20241009180824-f66d83c29e7c",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20241009180824-f66d83c29e7c",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/exp",
-          "version": "v0.0.0-20250911091902-df9299821621",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20250911091902-df9299821621",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/mod",
-          "version": "v0.31.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/mod@v0.31.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/net",
-          "version": "v0.48.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/net@v0.48.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/oauth2",
-          "version": "v0.23.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/oauth2@v0.23.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/oauth2",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/oauth2@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/sync",
-          "version": "v0.19.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/sync@v0.19.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/sync",
-          "version": "v0.9.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/sync@v0.9.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/sys",
-          "version": "v0.28.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/sys@v0.28.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/sys",
-          "version": "v0.40.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/sys@v0.40.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/term",
-          "version": "v0.38.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/term@v0.38.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/text",
-          "version": "v0.32.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/text@v0.32.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/time",
-          "version": "v0.14.0",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/time@v0.14.0",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/xerrors",
-          "version": "v0.0.0-20231012003039-104605ab7028",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20231012003039-104605ab7028",
-          "licenses": []
-        },
-        {
-          "name": "golang.org/x/xerrors",
-          "version": "v0.0.0-20240716161551-93cc26a95ae9",
-          "type": "library",
-          "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20240716161551-93cc26a95ae9",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/api",
-          "version": "v0.260.0",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/api@v0.260.0",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/genproto/googleapis/api",
-          "version": "v0.0.0-20251202230838-ff82c1b0f217",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/genproto/googleapis/api@v0.0.0-20251202230838-ff82c1b0f217",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/genproto/googleapis/rpc",
-          "version": "v0.0.0-20251222181119-0a764e51fe1b",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/genproto/googleapis/rpc@v0.0.0-20251222181119-0a764e51fe1b",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/genproto",
-          "version": "v0.0.0-20251202230838-ff82c1b0f217",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20251202230838-ff82c1b0f217",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/grpc",
-          "version": "v1.78.0",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/grpc@v1.78.0",
-          "licenses": []
-        },
-        {
-          "name": "google.golang.org/protobuf",
-          "version": "v1.36.11",
-          "type": "library",
-          "purl": "pkg:golang/google.golang.org/protobuf@v1.36.11",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/evanphx/json-patch.v4",
-          "version": "v4.12.0",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/evanphx/json-patch.v4@v4.12.0",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/inf.v0",
-          "version": "v0.9.1",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-          "licenses": []
-        },
-        {
-          "name": "gopkg.in/warnings.v0",
-          "version": "v0.1.2",
-          "type": "library",
-          "purl": "pkg:golang/gopkg.in/warnings.v0@v0.1.2",
-          "licenses": []
-        },
-        {
-          "name": "helm.sh/helm/v3",
-          "version": "v3.19.2",
-          "type": "library",
-          "purl": "pkg:golang/helm.sh/helm/v3@v3.19.2",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/api",
-          "version": "v0.34.2",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/api@v0.34.2",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/apiextensions-apiserver",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/apimachinery",
-          "version": "v0.34.2",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/apimachinery@v0.34.2",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/apiserver",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/apiserver@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/cli-runtime",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/cli-runtime@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/client-go",
-          "version": "v0.34.1",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/client-go@v0.34.1",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/component-base",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/component-base@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/klog/v2",
-          "version": "v2.130.1",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/klog/v2@v2.130.1",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/kube-openapi",
-          "version": "v0.0.0-20250710124328-f3f2b991d03b",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20250710124328-f3f2b991d03b",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/kubectl",
-          "version": "v0.34.0",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/kubectl@v0.34.0",
-          "licenses": []
-        },
-        {
-          "name": "k8s.io/utils",
-          "version": "v0.0.0-20250820121507-0af2bda4dd1d",
-          "type": "library",
-          "purl": "pkg:golang/k8s.io/utils@v0.0.0-20250820121507-0af2bda4dd1d",
-          "licenses": []
-        },
-        {
-          "name": "modernc.org/libc",
-          "version": "v1.66.10",
-          "type": "library",
-          "purl": "pkg:golang/modernc.org/libc@v1.66.10",
-          "licenses": []
-        },
-        {
-          "name": "modernc.org/mathutil",
-          "version": "v1.7.1",
-          "type": "library",
-          "purl": "pkg:golang/modernc.org/mathutil@v1.7.1",
-          "licenses": []
-        },
-        {
-          "name": "modernc.org/memory",
-          "version": "v1.11.0",
-          "type": "library",
-          "purl": "pkg:golang/modernc.org/memory@v1.11.0",
-          "licenses": []
-        },
-        {
-          "name": "modernc.org/sqlite",
-          "version": "v1.40.1",
-          "type": "library",
-          "purl": "pkg:golang/modernc.org/sqlite@v1.40.1",
-          "licenses": []
-        },
-        {
-          "name": "mvdan.cc/sh/v3",
-          "version": "v3.12.0",
-          "type": "library",
-          "purl": "pkg:golang/mvdan.cc/sh/v3@v3.12.0",
-          "licenses": []
-        },
-        {
-          "name": "oras.land/oras-go/v2",
-          "version": "v2.6.0",
-          "type": "library",
-          "purl": "pkg:golang/oras.land/oras-go/v2@v2.6.0",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/json",
-          "version": "v0.0.0-20241014173422-cfa47c3a1cc8",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20241014173422-cfa47c3a1cc8",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/kustomize/api",
-          "version": "v0.20.1",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/kustomize/api@v0.20.1",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/kustomize/kyaml",
-          "version": "v0.20.1",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/kustomize/kyaml@v0.20.1",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/randfill",
-          "version": "v1.0.0",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/randfill@v1.0.0",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/structured-merge-diff/v6",
-          "version": "v6.3.0",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v6@v6.3.0",
-          "licenses": []
-        },
-        {
-          "name": "sigs.k8s.io/yaml",
-          "version": "v1.6.0",
-          "type": "library",
-          "purl": "pkg:golang/sigs.k8s.io/yaml@v1.6.0",
-          "licenses": []
-        },
-        {
-          "name": "stdlib",
-          "version": "v1.22.10",
-          "type": "library",
-          "purl": "pkg:golang/stdlib@v1.22.10",
-          "licenses": []
-        },
-        {
-          "name": "stdlib",
-          "version": "v1.25.7",
-          "type": "library",
-          "purl": "pkg:golang/stdlib@v1.25.7",
-          "licenses": []
-        },
-        {
-          "name": "report-viewer",
-          "version": "0.0.1",
-          "type": "library",
-          "purl": "pkg:npm/%40regis-cli/report-viewer@0.0.1",
-          "licenses": []
-        },
-        {
-          "name": "docs",
-          "version": "0.18.0",
-          "type": "library",
-          "purl": "pkg:npm/docs@0.18.0",
-          "licenses": []
-        },
-        {
-          "name": "arrow",
-          "version": "1.4.0",
-          "type": "library",
-          "purl": "pkg:pypi/arrow@1.4.0",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "attrs",
-          "version": "26.1.0",
-          "type": "library",
-          "purl": "pkg:pypi/attrs@26.1.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "binaryornot",
-          "version": "0.6.0",
-          "type": "library",
-          "purl": "pkg:pypi/binaryornot@0.6.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "certifi",
-          "version": "2026.2.25",
-          "type": "library",
-          "purl": "pkg:pypi/certifi@2026.2.25",
-          "licenses": ["MPL-2.0"]
-        },
-        {
-          "name": "charset-normalizer",
-          "version": "3.4.6",
-          "type": "library",
-          "purl": "pkg:pypi/charset-normalizer@3.4.6",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "click",
-          "version": "8.3.1",
-          "type": "library",
-          "purl": "pkg:pypi/click@8.3.1",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "cookiecutter",
-          "version": "2.7.1",
-          "type": "library",
-          "purl": "pkg:pypi/cookiecutter@2.7.1",
-          "licenses": []
-        },
-        {
-          "name": "idna",
-          "version": "3.11",
-          "type": "library",
-          "purl": "pkg:pypi/idna@3.11",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "Jinja2",
-          "version": "3.1.6",
-          "type": "library",
-          "purl": "pkg:pypi/jinja2@3.1.6",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "json-logic-qubit",
-          "version": "0.9.1",
-          "type": "library",
-          "purl": "pkg:pypi/json-logic-qubit@0.9.1",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "jsonschema-specifications",
-          "version": "2025.9.1",
-          "type": "library",
-          "purl": "pkg:pypi/jsonschema-specifications@2025.9.1",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "jsonschema",
-          "version": "4.26.0",
-          "type": "library",
-          "purl": "pkg:pypi/jsonschema@4.26.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "markdown-it-py",
-          "version": "4.0.0",
-          "type": "library",
-          "purl": "pkg:pypi/markdown-it-py@4.0.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "MarkupSafe",
-          "version": "3.0.3",
-          "type": "library",
-          "purl": "pkg:pypi/markupsafe@3.0.3",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "mdurl",
-          "version": "0.1.2",
-          "type": "library",
-          "purl": "pkg:pypi/mdurl@0.1.2",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "pip",
-          "version": "25.0.1",
-          "type": "library",
-          "purl": "pkg:pypi/pip@25.0.1",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "Pygments",
-          "version": "2.19.2",
-          "type": "library",
-          "purl": "pkg:pypi/pygments@2.19.2",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "python-dateutil",
-          "version": "2.9.0.post0",
-          "type": "library",
-          "purl": "pkg:pypi/python-dateutil@2.9.0.post0",
-          "licenses": ["BSD-3-Clause", "Apache-2.0"]
-        },
-        {
-          "name": "python-gitlab",
-          "version": "8.1.0",
-          "type": "library",
-          "purl": "pkg:pypi/python-gitlab@8.1.0",
-          "licenses": ["LGPL-3.0-only"]
-        },
-        {
-          "name": "python-slugify",
-          "version": "8.0.4",
-          "type": "library",
-          "purl": "pkg:pypi/python-slugify@8.0.4",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "PyYAML",
-          "version": "6.0.3",
-          "type": "library",
-          "purl": "pkg:pypi/pyyaml@6.0.3",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "referencing",
-          "version": "0.36.2",
-          "type": "library",
-          "purl": "pkg:pypi/referencing@0.36.2",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "requests-toolbelt",
-          "version": "1.0.0",
-          "type": "library",
-          "purl": "pkg:pypi/requests-toolbelt@1.0.0",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "requests",
-          "version": "2.32.5",
-          "type": "library",
-          "purl": "pkg:pypi/requests@2.32.5",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "rich",
-          "version": "14.3.3",
-          "type": "library",
-          "purl": "pkg:pypi/rich@14.3.3",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "rpds-py",
-          "version": "0.30.0",
-          "type": "library",
-          "purl": "pkg:pypi/rpds-py@0.30.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "semver",
-          "version": "3.0.4",
-          "type": "library",
-          "purl": "pkg:pypi/semver@3.0.4",
-          "licenses": ["BSD-3-Clause"]
-        },
-        {
-          "name": "six",
-          "version": "1.17.0",
-          "type": "library",
-          "purl": "pkg:pypi/six@1.17.0",
-          "licenses": ["MIT"]
-        },
-        {
-          "name": "text-unidecode",
-          "version": "1.3",
-          "type": "library",
-          "purl": "pkg:pypi/text-unidecode@1.3",
-          "licenses": ["Artistic-2.0", "GPL-3.0-or-later", "GPL-2.0-or-later"]
-        },
-        {
-          "name": "typing_extensions",
-          "version": "4.15.0",
-          "type": "library",
-          "purl": "pkg:pypi/typing-extensions@4.15.0",
-          "licenses": ["PSF-2.0"]
-        },
-        {
-          "name": "tzdata",
-          "version": "2025.3",
-          "type": "library",
-          "purl": "pkg:pypi/tzdata@2025.3",
-          "licenses": ["Apache-2.0"]
-        },
-        {
-          "name": "urllib3",
-          "version": "2.6.3",
-          "type": "library",
-          "purl": "pkg:pypi/urllib3@2.6.3",
-          "licenses": ["MIT"]
-        }
-      ]
+      "source_tracked": false,
+      "indicators_count": 0,
+      "indicators": []
     },
     "scorecarddev": {
       "analyzer": "scorecarddev",
-      "repository": "trivoallan/regis-cli",
-      "source_repo": "https://github.com/trivoallan/regis-cli",
+      "repository": "library/busybox",
+      "source_repo": "https://github.com/docker-library/busybox",
       "scorecard_available": false,
       "score": null,
       "checks": []
     },
-    "size": {
-      "analyzer": "size",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
-      "multi_arch": true,
-      "total_compressed_bytes": 217241583,
-      "total_compressed_human": "207.2 MB",
-      "layer_count": 14,
-      "config_size_bytes": 0,
-      "layers": [],
-      "platforms": [
+    "sbom": {
+      "analyzer": "sbom",
+      "repository": "library/busybox",
+      "tag": "latest",
+      "has_sbom": false,
+      "sbom_format": "CycloneDX",
+      "sbom_version": "1.6",
+      "total_components": 0,
+      "component_types": {},
+      "total_dependencies": 1,
+      "licenses": [],
+      "copyleft_licenses": [],
+      "components": []
+    },
+    "trivy": {
+      "analyzer": "trivy",
+      "repository": "library/busybox",
+      "tag": "latest",
+      "trivy_version": "2",
+      "vulnerability_count": 0,
+      "critical_count": 0,
+      "high_count": 0,
+      "medium_count": 0,
+      "low_count": 0,
+      "unknown_count": 0,
+      "fixed_count": 0,
+      "secrets_count": 0,
+      "targets": []
+    },
+    "versioning": {
+      "analyzer": "versioning",
+      "repository": "library/busybox",
+      "total_tags": 211,
+      "dominant_pattern": "semver-prerelease",
+      "semver_compliant_percentage": 62.1,
+      "patterns": [
         {
-          "platform": "linux/amd64",
-          "compressed_bytes": 217241583,
-          "compressed_human": "207.2 MB",
-          "layer_count": 14
+          "pattern": "named",
+          "count": 64,
+          "percentage": 30.3,
+          "examples": [
+            "1-glibc",
+            "1-musl",
+            "1-ubuntu",
+            "1-uclibc",
+            "1.21-ubuntu",
+            "1.24-glibc",
+            "1.24-musl",
+            "1.24-uclibc",
+            "1.25-glibc",
+            "1.25-musl"
+          ]
         },
         {
-          "platform": "unknown/unknown",
-          "compressed_bytes": 40970,
-          "compressed_human": "40.0 KB",
-          "layer_count": 1
+          "pattern": "numeric",
+          "count": 16,
+          "percentage": 7.6,
+          "examples": [
+            "1",
+            "1.23",
+            "1.24",
+            "1.25",
+            "1.26",
+            "1.27",
+            "1.28",
+            "1.29",
+            "1.30",
+            "1.31"
+          ]
+        },
+        {
+          "pattern": "semver",
+          "count": 34,
+          "percentage": 16.1,
+          "examples": [
+            "1.23.2",
+            "1.24.0",
+            "1.24.1",
+            "1.24.2",
+            "1.25.0",
+            "1.25.1",
+            "1.26.0",
+            "1.26.1",
+            "1.26.2",
+            "1.27.0"
+          ]
+        },
+        {
+          "pattern": "semver-prerelease",
+          "count": 97,
+          "percentage": 46.0,
+          "examples": [
+            "1.21.0-ubuntu",
+            "1.24.1-glibc",
+            "1.24.1-musl",
+            "1.24.1-uclibc",
+            "1.24.2-glibc",
+            "1.24.2-musl",
+            "1.24.2-uclibc",
+            "1.25.0-glibc",
+            "1.25.0-musl",
+            "1.25.0-uclibc"
+          ]
         }
-      ]
+      ],
+      "variants": [],
+      "release_lines": ["1", "1.37", "1.37.0"]
     },
     "skopeo": {
       "analyzer": "skopeo",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
+      "repository": "library/busybox",
+      "tag": "latest",
       "platforms": [
         {
           "architecture": "amd64",
           "os": "linux",
-          "digest": "sha256:91b474c9c8f3046edb485acc870982f683f5b87b069bc2060448d509491dc729",
-          "created": "2026-03-21T01:34:50.907884378Z",
-          "labels": {
-            "org.opencontainers.image.authors": "trivoallan",
-            "org.opencontainers.image.created": "2026-03-21T01:34:17.660Z",
-            "org.opencontainers.image.description": "Container Security & Policy-as-Code Orchestration. Unified analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD.",
-            "org.opencontainers.image.documentation": "https://trivoallan.github.io/regis-cli/",
-            "org.opencontainers.image.licenses": "",
-            "org.opencontainers.image.revision": "8596aef162aa416662855a46f12733598484eeaf",
-            "org.opencontainers.image.source": "https://github.com/trivoallan/regis-cli",
-            "org.opencontainers.image.title": "regis-cli",
-            "org.opencontainers.image.url": "https://github.com/trivoallan/regis-cli",
-            "org.opencontainers.image.vendor": "trivoallan",
-            "org.opencontainers.image.version": "0.18.0"
-          },
-          "layers_count": 14,
+          "digest": "sha256:b8d1827e38a1d49cd17217efd7b07d689e4ea1744e39c7dcbb95533d175bea65",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
           "size": 0,
           "exposed_ports": [],
           "env": [],
           "variant": null,
-          "user": "regis"
+          "user": ""
         },
         {
           "architecture": "unknown",
           "os": "unknown",
-          "digest": "sha256:9ba185281fb5dc515a6187a3585ac0cfd9774055dc8af5b9df36086c6714095a",
+          "digest": "sha256:85018c50e23d1abd4dddbcfd55c5b7ee6516e956376e882eaa1b6009fbb2cc9b",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "arm",
+          "os": "linux",
+          "digest": "sha256:9c236358041e0978a7d75186dc981e46b9248b87a13fab65ddc2409950bfbe05",
+          "variant": "v5",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:746ece13b4b267510484033c6b612a64e04fc32345321a159148b3894f6c79ef",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "arm",
+          "os": "linux",
+          "digest": "sha256:d1ba3375824b1e605503225e2f42280aea16d388fb2e400b9fe7c4d93b9e8d42",
+          "variant": "v6",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "user": ""
+        },
+        {
+          "architecture": "arm",
+          "os": "linux",
+          "digest": "sha256:4132e5c776cda2f7f1937f5ee9d4c67e894900ac1643470b910ee92096e84de9",
+          "variant": "v7",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:9e3e867b9f5db234dd756639e86d932c3c20f9d73610f80827d51ea73ddd708f",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "arm64",
+          "os": "linux",
+          "digest": "sha256:c4e5b27bf840ba1ebd5568b6b914f6926f3559b2ad4f505b1f37aae483b907d6",
+          "variant": "v8",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:9e51b0919133deba3b661c2c86620db26e01a2cb9f5506de7a2e396181456a5a",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "386",
+          "os": "linux",
+          "digest": "sha256:ea84d3a2fd24875f68dc79b733972acadf9ef707baaf0f2cb605ddb2be403826",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:c3b25931da4710821a73d12d0bfe36aa48bed34d0f21716216cccfd77a40e478",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "ppc64le",
+          "os": "linux",
+          "digest": "sha256:a6fa48de578b85d46db9cbc3d0e7b7cca4ee93b42df39bba065f87ab74d5d091",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:8ea22876e866cb07b3fe62b8649951ffc5d884192b33def4a6c657529000bd8b",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "riscv64",
+          "os": "linux",
+          "digest": "sha256:3a38f165466deaa661f2796c3825b27342c0cb861f9f1e2d6a98d9a6adbb5eb0",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:fefa864756908b3a1c8d2e0f30b20923d181340e2b183f95ae497c831b7a86e5",
+          "created": null,
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "s390x",
+          "os": "linux",
+          "digest": "sha256:b6ed3dc70d0294a3159416179efa3219ab3935bae95db7138dd374c33ff5abb5",
+          "created": "2024-09-26T21:31:42Z",
+          "labels": {},
+          "layers_count": 1,
+          "size": 0,
+          "exposed_ports": [],
+          "env": [],
+          "variant": null,
+          "user": ""
+        },
+        {
+          "architecture": "unknown",
+          "os": "unknown",
+          "digest": "sha256:e8e18974bd05d41857c2c72f0d21288475f082126b771f6ddd40de5d8633f967",
           "created": null,
           "labels": {},
           "layers_count": 1,
@@ -6481,2250 +472,346 @@
       ],
       "inspect": {},
       "tags": [
-        "main",
-        "sha-dfc66c6",
-        "sha-376c16e",
-        "sha-2823f64",
-        "sha-a5d06a6",
-        "sha-391d74f",
-        "sha-9ef6351",
-        "sha-9cf4087",
-        "sha-ddaba2c",
-        "sha-460871b",
-        "sha-5f11d2d",
-        "sha-4113efb",
-        "sha-a02caa3",
-        "sha-4751370",
-        "sha-83c0066",
-        "sha-895c46b",
-        "sha-f3abf1f",
-        "sha-e1faaf9",
-        "sha-6737a68",
-        "sha-6f1d111",
-        "sha-7a6104d",
-        "sha-21b7549",
-        "sha-97a58fd",
-        "sha-ed8a1f2",
-        "0.2.2",
-        "0.2",
-        "sha-6b3a3ee",
+        "1",
+        "1-glibc",
+        "1-musl",
+        "1-ubuntu",
+        "1-uclibc",
+        "1.21-ubuntu",
+        "1.21.0-ubuntu",
+        "1.23",
+        "1.23.2",
+        "1.24",
+        "1.24-glibc",
+        "1.24-musl",
+        "1.24-uclibc",
+        "1.24.0",
+        "1.24.1",
+        "1.24.1-glibc",
+        "1.24.1-musl",
+        "1.24.1-uclibc",
+        "1.24.2",
+        "1.24.2-glibc",
+        "1.24.2-musl",
+        "1.24.2-uclibc",
+        "1.25",
+        "1.25-glibc",
+        "1.25-musl",
+        "1.25-uclibc",
+        "1.25.0",
+        "1.25.0-glibc",
+        "1.25.0-musl",
+        "1.25.0-uclibc",
+        "1.25.1",
+        "1.25.1-glibc",
+        "1.25.1-musl",
+        "1.25.1-uclibc",
+        "1.26",
+        "1.26-glibc",
+        "1.26-musl",
+        "1.26-uclibc",
+        "1.26.0",
+        "1.26.0-glibc",
+        "1.26.0-musl",
+        "1.26.0-uclibc",
+        "1.26.1",
+        "1.26.1-glibc",
+        "1.26.1-musl",
+        "1.26.1-uclibc",
+        "1.26.2",
+        "1.26.2-glibc",
+        "1.26.2-musl",
+        "1.26.2-uclibc",
+        "1.27",
+        "1.27-glibc",
+        "1.27-musl",
+        "1.27-uclibc",
+        "1.27.0",
+        "1.27.0-glibc",
+        "1.27.0-musl",
+        "1.27.0-uclibc",
+        "1.27.1",
+        "1.27.1-glibc",
+        "1.27.1-musl",
+        "1.27.1-uclibc",
+        "1.27.2",
+        "1.27.2-glibc",
+        "1.27.2-musl",
+        "1.27.2-uclibc",
+        "1.28",
+        "1.28-glibc",
+        "1.28-musl",
+        "1.28-uclibc",
+        "1.28.0",
+        "1.28.0-glibc",
+        "1.28.0-musl",
+        "1.28.0-uclibc",
+        "1.28.1",
+        "1.28.1-glibc",
+        "1.28.1-musl",
+        "1.28.1-uclibc",
+        "1.28.2",
+        "1.28.2-glibc",
+        "1.28.2-musl",
+        "1.28.2-uclibc",
+        "1.28.3",
+        "1.28.3-glibc",
+        "1.28.3-musl",
+        "1.28.3-uclibc",
+        "1.28.4",
+        "1.28.4-glibc",
+        "1.28.4-musl",
+        "1.28.4-uclibc",
+        "1.29",
+        "1.29-glibc",
+        "1.29-musl",
+        "1.29-uclibc",
+        "1.29.1",
+        "1.29.1-glibc",
+        "1.29.1-musl",
+        "1.29.1-uclibc",
+        "1.29.2",
+        "1.29.2-glibc",
+        "1.29.2-musl",
+        "1.29.2-uclibc",
+        "1.29.3",
+        "1.29.3-glibc",
+        "1.29.3-musl",
+        "1.29.3-uclibc",
+        "1.30",
+        "1.30-glibc",
+        "1.30-musl",
+        "1.30-uclibc",
+        "1.30.0",
+        "1.30.0-glibc",
+        "1.30.0-musl",
+        "1.30.0-uclibc",
+        "1.30.1",
+        "1.30.1-glibc",
+        "1.30.1-musl",
+        "1.30.1-uclibc",
+        "1.31",
+        "1.31-glibc",
+        "1.31-musl",
+        "1.31-uclibc",
+        "1.31.0",
+        "1.31.0-glibc",
+        "1.31.0-musl",
+        "1.31.0-uclibc",
+        "1.31.1",
+        "1.31.1-glibc",
+        "1.31.1-musl",
+        "1.31.1-uclibc",
+        "1.32",
+        "1.32-glibc",
+        "1.32-musl",
+        "1.32-uclibc",
+        "1.32.0",
+        "1.32.0-glibc",
+        "1.32.0-musl",
+        "1.32.0-uclibc",
+        "1.32.1",
+        "1.32.1-glibc",
+        "1.32.1-musl",
+        "1.32.1-uclibc",
+        "1.33",
+        "1.33-glibc",
+        "1.33-musl",
+        "1.33-uclibc",
+        "1.33.0",
+        "1.33.0-glibc",
+        "1.33.0-musl",
+        "1.33.0-uclibc",
+        "1.33.1",
+        "1.33.1-glibc",
+        "1.33.1-musl",
+        "1.33.1-uclibc",
+        "1.34",
+        "1.34-glibc",
+        "1.34-musl",
+        "1.34-uclibc",
+        "1.34.0",
+        "1.34.0-glibc",
+        "1.34.0-musl",
+        "1.34.0-uclibc",
+        "1.34.1",
+        "1.34.1-glibc",
+        "1.34.1-musl",
+        "1.34.1-uclibc",
+        "1.35",
+        "1.35-glibc",
+        "1.35-musl",
+        "1.35-uclibc",
+        "1.35.0",
+        "1.35.0-glibc",
+        "1.35.0-musl",
+        "1.35.0-uclibc",
+        "1.36",
+        "1.36-glibc",
+        "1.36-musl",
+        "1.36-uclibc",
+        "1.36.0",
+        "1.36.0-glibc",
+        "1.36.0-musl",
+        "1.36.0-uclibc",
+        "1.36.1",
+        "1.36.1-glibc",
+        "1.36.1-musl",
+        "1.36.1-uclibc",
+        "1.37",
+        "1.37-glibc",
+        "1.37-musl",
+        "1.37-uclibc",
+        "1.37.0",
+        "1.37.0-glibc",
+        "1.37.0-musl",
+        "1.37.0-uclibc",
+        "buildroot-2013.08.1",
+        "buildroot-2014.02",
+        "glibc",
         "latest",
-        "sha-dfffabd",
-        "sha-88ccaae",
-        "0.3.0",
-        "0.3",
-        "sha-f86862e",
-        "sha-295db88",
-        "sha-44b8b76",
-        "sha-706e2a7",
-        "sha-e7e71c8",
-        "0.4.0",
-        "0.4",
-        "sha-8368b48",
-        "sha-69ef82f",
-        "sha-c985942",
-        "sha-b03914d",
-        "sha-7de98ad",
-        "sha-e178f38",
-        "sha-44bfdf6",
-        "sha-f2dc6eb",
-        "sha-d508b53",
-        "sha-2bffefd",
-        "sha-e0945f2",
-        "sha-676bb4d",
-        "0.5.0",
-        "0.5",
-        "sha-342d0b8",
-        "sha-d6c065a",
-        "sha-194d574",
-        "0.7.0",
-        "0.7",
-        "sha-e5b0e77",
-        "0.8.0",
-        "0.8",
-        "sha-fd24eb9",
-        "0.9.0",
-        "0.9",
-        "sha-57f48a3",
-        "sha-08211a2",
-        "sha-9393b48",
-        "sha-a48b4b2",
-        "sha-abd95d2",
-        "0.10.0",
-        "0.10",
-        "sha-f04d633",
-        "sha-340f44d",
-        "sha-f18e91b",
-        "sha-ef81c05",
-        "sha-1664655",
-        "sha-9898bd8",
-        "0.11.0",
-        "0.11",
-        "sha-9aaef15",
-        "sha-f865cb0",
-        "sha-9a7914f",
-        "0.12.0",
-        "0.12",
-        "sha-42459a3",
-        "0.13.0",
-        "0.13",
-        "sha-8eef298",
-        "0.14.0",
-        "0.14",
-        "sha-bc504b0",
-        "0.14.1",
-        "sha-15794ab",
-        "0.14.2",
-        "sha-a5bd4e5",
-        "0.15.0",
-        "0.15",
-        "sha-1ee30bb",
-        "0.16.0",
-        "0.16",
-        "sha-7baf724",
-        "0.17.0",
-        "0.17",
-        "sha-e7a1749",
-        "0.17.1",
-        "sha-ac404f4",
-        "sha-3678043",
-        "sha-8fd6186",
-        "0.17.2",
-        "sha-1baea9a",
-        "0.17.3",
-        "sha-ff5b296",
-        "0.17.4",
-        "sha-11fde48",
-        "0.18.0",
-        "0.18",
-        "sha-8596aef"
+        "musl",
+        "stable",
+        "stable-glibc",
+        "stable-musl",
+        "stable-uclibc",
+        "ubuntu",
+        "ubuntu-12.04",
+        "ubuntu-14.04",
+        "uclibc",
+        "unstable",
+        "unstable-glibc",
+        "unstable-musl",
+        "unstable-uclibc"
       ]
     },
-    "trivy": {
-      "analyzer": "trivy",
-      "repository": "trivoallan/regis-cli",
-      "tag": "0.18.0",
-      "trivy_version": "2",
-      "vulnerability_count": 224,
-      "critical_count": 2,
-      "high_count": 19,
-      "medium_count": 54,
-      "low_count": 148,
-      "unknown_count": 1,
-      "fixed_count": 39,
-      "secrets_count": 0,
-      "targets": [
+    "size": {
+      "analyzer": "size",
+      "repository": "library/busybox",
+      "tag": "latest",
+      "multi_arch": true,
+      "total_compressed_bytes": 2211857,
+      "total_compressed_human": "2.1 MB",
+      "layer_count": 1,
+      "config_size_bytes": 0,
+      "layers": [],
+      "platforms": [
         {
-          "Target": "ghcr.io/trivoallan/regis-cli:0.18.0 (debian 13.4)",
-          "Vulnerabilities": [
-            {
-              "VulnerabilityID": "CVE-2011-3374",
-              "PkgName": "apt",
-              "InstalledVersion": "3.0.3",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
-              "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack."
-            },
-            {
-              "VulnerabilityID": "TEMP-0841856-B18BAF",
-              "PkgName": "bash",
-              "InstalledVersion": "5.2.37-2+b8",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "[Privilege escalation possible to other user than root]",
-              "Description": ""
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "bsdutils",
-              "InstalledVersion": "1:2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "bsdutils",
-              "InstalledVersion": "1:2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "bsdutils",
-              "InstalledVersion": "1:2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2017-18018",
-              "PkgName": "coreutils",
-              "InstalledVersion": "9.7-3",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "coreutils: race condition vulnerability in chown and chgrp",
-              "Description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-5278",
-              "PkgName": "coreutils",
-              "InstalledVersion": "9.7-3",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "coreutils: Heap Buffer Under-Read in GNU Coreutils sort via Key Specification",
-              "Description": "A flaw was found in GNU Coreutils. The sort utility's begfield() function is vulnerable to a heap buffer under-read. The program may access memory outside the allocated buffer if a user runs a crafted command using the traditional key format. A malicious input could lead to a crash or leak sensitive data."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-13034",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedp ...",
-              "Description": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedpubkey`\nwith the curl tool,curl should check the public key of the server certificate\nto verify the peer.\n\nThis check was skipped in a certain condition that would then make curl allow\nthe connection without performing the proper check, thus not noticing a\npossible impostor. To skip this check, the connection had to be done with QUIC\nwith ngtcp2 built to use GnuTLS and the user had to explicitly disable the\nstandard certificate verification."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-1965",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Authentication bypass due to incorrect connection reuse with Negotiate authentication",
-              "Description": "libcurl can in some circumstances reuse the wrong connection when asked to do\nan Negotiate-authenticated HTTP or HTTPS request.\n\nlibcurl features a pool of recent connections so that subsequent requests can\nreuse an existing connection to avoid overhead.\n\nWhen reusing a connection a range of criterion must first be met. Due to a\nlogical error in the code, a request that was issued by an application could\nwrongfully reuse an existing connection to the same server that was\nauthenticated using different credentials. One underlying reason being that\nNegotiate sometimes authenticates *connections* and not *requests*, contrary\nto how HTTP is designed to work.\n\nAn application that allows Negotiate authentication to a server (that responds\nwanting Negotiate) with `user1:password1` and then does another operation to\nthe same server also using Negotiate but with `user2:password2` (while the\nprevious connection is still alive) - the second request wrongly reused the\nsame connection and since it then sees that the Negotiate negotiation is\nalready made, it just sends the request over that connection thinking it uses\nthe user2 credentials when it is in fact still using the connection\nauthenticated for user1...\n\nThe set of authentication methods to use is set with  `CURLOPT_HTTPAUTH`.\n\nApplications can disable libcurl's reuse of connections and thus mitigate this\nproblem, by using one of the following libcurl options to alter how\nconnections are or are not reused: `CURLOPT_FRESH_CONNECT`,\n`CURLOPT_MAXCONNECTS` and `CURLMOPT_MAX_HOST_CONNECTIONS` (if using the\ncurl_multi API)."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3783",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Information disclosure via OAuth2 bearer token leakage during HTTP(S) redirect",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a redirect to a second URL, curl could leak that token to the second\nhostname under some circumstances.\n\nIf the hostname that the first request is redirected to has information in the\nused .netrc file, with either of the `machine` or `default` keywords, curl\nwould pass on the bearer token set for the first host also to the second one."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3784",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Unauthorized access due to improper HTTP proxy connection reuse",
-              "Description": "curl would wrongly reuse an existing HTTP proxy connection doing CONNECT to a\nserver, even if the new request uses different credentials for the HTTP proxy.\nThe proper behavior is to create or use a separate connection."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3805",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Arbitrary code execution or Denial of Service via use-after-free in SMB request handling",
-              "Description": "When doing a second SMB request to the same host again, curl would wrongly use\na data pointer pointing into already freed memory."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-10966",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: Curl missing SFTP host verification with wolfSSH backend",
-              "Description": "curl's code for managing SSH connections when SFTP was done using the wolfSSH\npowered backend was flawed and missed host verification mechanisms.\n\nThis prevents curl from detecting MITM attackers and more."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14017",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: curl: Security bypass due to global TLS option changes in multi-threaded LDAPS transfers",
-              "Description": "When doing multi-threaded LDAPS transfers (LDAP over TLS) with libcurl,\nchanging TLS options in one thread would inadvertently change them globally\nand therefore possibly also affect other concurrently setup transfers.\n\nDisabling certificate verification for a specific transfer could\nunintentionally disable the feature for other threads as well."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14524",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that  ...",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a cross-protocol redirect to a second URL that uses an IMAP, LDAP,\nPOP3 or SMTP scheme, curl might wrongly pass on the bearer token to the new\ntarget host."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14819",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing TLS related transfers with reused easy or multi handles and ...",
-              "Description": "When doing TLS related transfers with reused easy or multi handles and\naltering the  `CURLSSLOPT_NO_PARTIALCHAIN` option, libcurl could accidentally\nreuse a CA store cached in memory for which the partial chain option was\nreversed. Contrary to the user's wishes and expectations. This could make\nlibcurl find and accept a trust chain that it otherwise would not."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15079",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and setting t ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and setting the\nknown_hosts file, libcurl could still mistakenly accept connecting to hosts\n*not present* in the specified file if they were added as recognized in the\nlibssh *global* known_hosts file."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15224",
-              "PkgName": "curl",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and asked to  ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and asked to do\npublic key authentication, curl would wrongly still ask and authenticate using\na locally running SSH agent."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "dirmngr",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "dirmngr",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "dirmngr",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-1000021",
-              "PkgName": "git",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: client prints server-sent ANSI escape codes to the terminal, allowing for unverified messages to potentially execute arbitrary commands",
-              "Description": "GIT version 2.15.1 and earlier contains a Input Validation Error vulnerability in Client that can result in problems including messing up terminal configuration to RCE. This attack appear to be exploitable via The user must interact with a malicious git server, (or have their traffic modified in a MITM attack)."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-24975",
-              "PkgName": "git",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: The --mirror option for git leaks secret for deleted content, aka the \"GitBleed\"",
-              "Description": "The --mirror documentation for Git through 2.35.1 does not mention the availability of deleted content, aka the \"GitBleed\" issue. This could present a security risk if information-disclosure auditing processes rely on a clone operation without the --mirror option. Note: This has been disputed by multiple 3rd parties who believe this is an intended feature of the git binary and does not pose a security risk."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-52005",
-              "PkgName": "git",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: The sideband payload is passed unfiltered to the terminal in git",
-              "Description": "Git is a source code management tool. When cloning from a server (or fetching, or pushing), informational or error messages are transported from the remote Git process to the client via the so-called \"sideband channel\". These messages will be prefixed with \"remote:\" and printed directly to the standard error output. Typically, this standard error output is connected to a terminal that understands ANSI escape sequences, which Git did not protect against. Most modern terminals support control sequences that can be used by a malicious actor to hide and misrepresent information, or to mislead the user into executing untrusted scripts. As requested on the git-security mailing list, the patches are under discussion on the public mailing list. Users are advised to update as soon as possible. Users unable to upgrade should avoid recursive clones unless they are from trusted sources."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-1000021",
-              "PkgName": "git-man",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: client prints server-sent ANSI escape codes to the terminal, allowing for unverified messages to potentially execute arbitrary commands",
-              "Description": "GIT version 2.15.1 and earlier contains a Input Validation Error vulnerability in Client that can result in problems including messing up terminal configuration to RCE. This attack appear to be exploitable via The user must interact with a malicious git server, (or have their traffic modified in a MITM attack)."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-24975",
-              "PkgName": "git-man",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: The --mirror option for git leaks secret for deleted content, aka the \"GitBleed\"",
-              "Description": "The --mirror documentation for Git through 2.35.1 does not mention the availability of deleted content, aka the \"GitBleed\" issue. This could present a security risk if information-disclosure auditing processes rely on a clone operation without the --mirror option. Note: This has been disputed by multiple 3rd parties who believe this is an intended feature of the git binary and does not pose a security risk."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-52005",
-              "PkgName": "git-man",
-              "InstalledVersion": "1:2.47.3-0+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "git: The sideband payload is passed unfiltered to the terminal in git",
-              "Description": "Git is a source code management tool. When cloning from a server (or fetching, or pushing), informational or error messages are transported from the remote Git process to the client via the so-called \"sideband channel\". These messages will be prefixed with \"remote:\" and printed directly to the standard error output. Typically, this standard error output is connected to a terminal that understands ANSI escape sequences, which Git did not protect against. Most modern terminals support control sequences that can be used by a malicious actor to hide and misrepresent information, or to mislead the user into executing untrusted scripts. As requested on the git-security mailing list, the patches are under discussion on the public mailing list. Users are advised to update as soon as possible. Users unable to upgrade should avoid recursive clones unless they are from trusted sources."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gnupg",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gnupg",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gnupg",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gnupg-l10n",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gnupg-l10n",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gnupg-l10n",
-              "InstalledVersion": "2.4.7-21+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gpg",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gpg",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gpg",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gpg-agent",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gpg-agent",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gpg-agent",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gpgconf",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gpgconf",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gpgconf",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24882",
-              "PkgName": "gpgsm",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "GnuPG: GnuPG: Stack-based buffer overflow in tpm2daemon allows arbitrary code execution",
-              "Description": "In GnuPG before 2.5.17, a stack-based buffer overflow exists in tpm2daemon during handling of the PKDECRYPT command for TPM-backed RSA and ECC keys."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68972",
-              "PkgName": "gpgsm",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "gnupg: GnuPG: Signature bypass via form feed character in signed messages",
-              "Description": "In GnuPG through 2.4.8, if a signed message has \\f at the end of a plaintext line, an adversary can construct a modified message that places additional text after the signed material, such that signature verification of the modified message succeeds (although an \"invalid armor\" message is printed during verification). This is related to use of \\f as a marker to denote truncation of a long plaintext line."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-3219",
-              "PkgName": "gpgsm",
-              "InstalledVersion": "2.4.7-21+deb13u1+b2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnupg: denial of service issue (resource consumption) using compressed packets",
-              "Description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB."
-            },
-            {
-              "VulnerabilityID": "CVE-2012-2663",
-              "PkgName": "iptables",
-              "InstalledVersion": "1.8.11-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "iptables: --syn flag bypass",
-              "Description": "extensions/libxt_tcp.c in iptables through 1.4.21 does not match TCP SYN+FIN packets in --syn rules, which might allow remote attackers to bypass intended firewall restrictions via crafted packets.  NOTE: the CVE-2012-6638 fix makes this issue less relevant."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-3374",
-              "PkgName": "libapt-pkg7.0",
-              "InstalledVersion": "3.0.3",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
-              "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "libblkid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "libblkid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "libblkid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2010-4756",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: glob implementation can cause excessive CPU and memory consumption due to crafted glob expressions",
-              "Description": "The glob implementation in the GNU C Library (aka glibc or libc6) allows remote authenticated users to cause a denial of service (CPU and memory consumption) via crafted glob expressions that do not match any pathnames, as demonstrated by glob expressions in STAT commands to an FTP daemon, a different vulnerability than CVE-2010-2632."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-20796",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
-              "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(\\227|)(\\\\1\\\\1|t1|\\\\\\2537)+' in grep."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010022",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: stack guard protection bypass",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass stack guard protection. The component is: nptl. The attack vector is: Exploit stack buffer overflow vulnerability and use this bypass vulnerability to bypass stack guard. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010023",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: running ldd on malicious ELF leads to code execution because of wrong size computation",
-              "Description": "GNU Libc current is affected by: Re-mapping current loaded library with malicious ELF file. The impact is: In worst case attacker may evaluate privileges. The component is: libld. The attack vector is: Attacker sends 2 ELF files to victim and asks to run ldd on it. ldd execute code. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010024",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: ASLR bypass using cache of thread stack and heap",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass ASLR using cache of thread stack and heap. The component is: glibc. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010025",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: information disclosure of heap addresses of pthread_created thread",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may guess the heap addresses of pthread_created thread. The component is: glibc. NOTE: the vendor's position is \"ASLR bypass itself is not a vulnerability."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-9192",
-              "PkgName": "libc-bin",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
-              "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(|)(\\\\1\\\\1)*' in grep, a different issue than CVE-2018-20796. NOTE: the software maintainer disputes that this is a vulnerability because the behavior occurs only with a crafted pattern"
-            },
-            {
-              "VulnerabilityID": "CVE-2010-4756",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: glob implementation can cause excessive CPU and memory consumption due to crafted glob expressions",
-              "Description": "The glob implementation in the GNU C Library (aka glibc or libc6) allows remote authenticated users to cause a denial of service (CPU and memory consumption) via crafted glob expressions that do not match any pathnames, as demonstrated by glob expressions in STAT commands to an FTP daemon, a different vulnerability than CVE-2010-2632."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-20796",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
-              "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(\\227|)(\\\\1\\\\1|t1|\\\\\\2537)+' in grep."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010022",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: stack guard protection bypass",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass stack guard protection. The component is: nptl. The attack vector is: Exploit stack buffer overflow vulnerability and use this bypass vulnerability to bypass stack guard. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010023",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: running ldd on malicious ELF leads to code execution because of wrong size computation",
-              "Description": "GNU Libc current is affected by: Re-mapping current loaded library with malicious ELF file. The impact is: In worst case attacker may evaluate privileges. The component is: libld. The attack vector is: Attacker sends 2 ELF files to victim and asks to run ldd on it. ldd execute code. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010024",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: ASLR bypass using cache of thread stack and heap",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may bypass ASLR using cache of thread stack and heap. The component is: glibc. NOTE: Upstream comments indicate \"this is being treated as a non-security bug and no real threat."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-1010025",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: information disclosure of heap addresses of pthread_created thread",
-              "Description": "GNU Libc current is affected by: Mitigation bypass. The impact is: Attacker may guess the heap addresses of pthread_created thread. The component is: glibc. NOTE: the vendor's position is \"ASLR bypass itself is not a vulnerability."
-            },
-            {
-              "VulnerabilityID": "CVE-2019-9192",
-              "PkgName": "libc6",
-              "InstalledVersion": "2.41-12+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "glibc: uncontrolled recursion in function check_dst_limits_calc_pos_1 in posix/regexec.c",
-              "Description": "In the GNU C Library (aka glibc or libc6) through 2.29, check_dst_limits_calc_pos_1 in posix/regexec.c has Uncontrolled Recursion, as demonstrated by '(|)(\\\\1\\\\1)*' in grep, a different issue than CVE-2018-20796. NOTE: the software maintainer disputes that this is a vulnerability because the behavior occurs only with a crafted pattern"
-            },
-            {
-              "VulnerabilityID": "CVE-2025-13034",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedp ...",
-              "Description": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedpubkey`\nwith the curl tool,curl should check the public key of the server certificate\nto verify the peer.\n\nThis check was skipped in a certain condition that would then make curl allow\nthe connection without performing the proper check, thus not noticing a\npossible impostor. To skip this check, the connection had to be done with QUIC\nwith ngtcp2 built to use GnuTLS and the user had to explicitly disable the\nstandard certificate verification."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-1965",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Authentication bypass due to incorrect connection reuse with Negotiate authentication",
-              "Description": "libcurl can in some circumstances reuse the wrong connection when asked to do\nan Negotiate-authenticated HTTP or HTTPS request.\n\nlibcurl features a pool of recent connections so that subsequent requests can\nreuse an existing connection to avoid overhead.\n\nWhen reusing a connection a range of criterion must first be met. Due to a\nlogical error in the code, a request that was issued by an application could\nwrongfully reuse an existing connection to the same server that was\nauthenticated using different credentials. One underlying reason being that\nNegotiate sometimes authenticates *connections* and not *requests*, contrary\nto how HTTP is designed to work.\n\nAn application that allows Negotiate authentication to a server (that responds\nwanting Negotiate) with `user1:password1` and then does another operation to\nthe same server also using Negotiate but with `user2:password2` (while the\nprevious connection is still alive) - the second request wrongly reused the\nsame connection and since it then sees that the Negotiate negotiation is\nalready made, it just sends the request over that connection thinking it uses\nthe user2 credentials when it is in fact still using the connection\nauthenticated for user1...\n\nThe set of authentication methods to use is set with  `CURLOPT_HTTPAUTH`.\n\nApplications can disable libcurl's reuse of connections and thus mitigate this\nproblem, by using one of the following libcurl options to alter how\nconnections are or are not reused: `CURLOPT_FRESH_CONNECT`,\n`CURLOPT_MAXCONNECTS` and `CURLMOPT_MAX_HOST_CONNECTIONS` (if using the\ncurl_multi API)."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3783",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Information disclosure via OAuth2 bearer token leakage during HTTP(S) redirect",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a redirect to a second URL, curl could leak that token to the second\nhostname under some circumstances.\n\nIf the hostname that the first request is redirected to has information in the\nused .netrc file, with either of the `machine` or `default` keywords, curl\nwould pass on the bearer token set for the first host also to the second one."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3784",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Unauthorized access due to improper HTTP proxy connection reuse",
-              "Description": "curl would wrongly reuse an existing HTTP proxy connection doing CONNECT to a\nserver, even if the new request uses different credentials for the HTTP proxy.\nThe proper behavior is to create or use a separate connection."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3805",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Arbitrary code execution or Denial of Service via use-after-free in SMB request handling",
-              "Description": "When doing a second SMB request to the same host again, curl would wrongly use\na data pointer pointing into already freed memory."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-10966",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: Curl missing SFTP host verification with wolfSSH backend",
-              "Description": "curl's code for managing SSH connections when SFTP was done using the wolfSSH\npowered backend was flawed and missed host verification mechanisms.\n\nThis prevents curl from detecting MITM attackers and more."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14017",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: curl: Security bypass due to global TLS option changes in multi-threaded LDAPS transfers",
-              "Description": "When doing multi-threaded LDAPS transfers (LDAP over TLS) with libcurl,\nchanging TLS options in one thread would inadvertently change them globally\nand therefore possibly also affect other concurrently setup transfers.\n\nDisabling certificate verification for a specific transfer could\nunintentionally disable the feature for other threads as well."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14524",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that  ...",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a cross-protocol redirect to a second URL that uses an IMAP, LDAP,\nPOP3 or SMTP scheme, curl might wrongly pass on the bearer token to the new\ntarget host."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14819",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing TLS related transfers with reused easy or multi handles and ...",
-              "Description": "When doing TLS related transfers with reused easy or multi handles and\naltering the  `CURLSSLOPT_NO_PARTIALCHAIN` option, libcurl could accidentally\nreuse a CA store cached in memory for which the partial chain option was\nreversed. Contrary to the user's wishes and expectations. This could make\nlibcurl find and accept a trust chain that it otherwise would not."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15079",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and setting t ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and setting the\nknown_hosts file, libcurl could still mistakenly accept connecting to hosts\n*not present* in the specified file if they were added as recognized in the\nlibssh *global* known_hosts file."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15224",
-              "PkgName": "libcurl3t64-gnutls",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and asked to  ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and asked to do\npublic key authentication, curl would wrongly still ask and authenticate using\na locally running SSH agent."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-13034",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedp ...",
-              "Description": "When using `CURLOPT_PINNEDPUBLICKEY` option with libcurl or `--pinnedpubkey`\nwith the curl tool,curl should check the public key of the server certificate\nto verify the peer.\n\nThis check was skipped in a certain condition that would then make curl allow\nthe connection without performing the proper check, thus not noticing a\npossible impostor. To skip this check, the connection had to be done with QUIC\nwith ngtcp2 built to use GnuTLS and the user had to explicitly disable the\nstandard certificate verification."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-1965",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Authentication bypass due to incorrect connection reuse with Negotiate authentication",
-              "Description": "libcurl can in some circumstances reuse the wrong connection when asked to do\nan Negotiate-authenticated HTTP or HTTPS request.\n\nlibcurl features a pool of recent connections so that subsequent requests can\nreuse an existing connection to avoid overhead.\n\nWhen reusing a connection a range of criterion must first be met. Due to a\nlogical error in the code, a request that was issued by an application could\nwrongfully reuse an existing connection to the same server that was\nauthenticated using different credentials. One underlying reason being that\nNegotiate sometimes authenticates *connections* and not *requests*, contrary\nto how HTTP is designed to work.\n\nAn application that allows Negotiate authentication to a server (that responds\nwanting Negotiate) with `user1:password1` and then does another operation to\nthe same server also using Negotiate but with `user2:password2` (while the\nprevious connection is still alive) - the second request wrongly reused the\nsame connection and since it then sees that the Negotiate negotiation is\nalready made, it just sends the request over that connection thinking it uses\nthe user2 credentials when it is in fact still using the connection\nauthenticated for user1...\n\nThe set of authentication methods to use is set with  `CURLOPT_HTTPAUTH`.\n\nApplications can disable libcurl's reuse of connections and thus mitigate this\nproblem, by using one of the following libcurl options to alter how\nconnections are or are not reused: `CURLOPT_FRESH_CONNECT`,\n`CURLOPT_MAXCONNECTS` and `CURLMOPT_MAX_HOST_CONNECTIONS` (if using the\ncurl_multi API)."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3783",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Information disclosure via OAuth2 bearer token leakage during HTTP(S) redirect",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a redirect to a second URL, curl could leak that token to the second\nhostname under some circumstances.\n\nIf the hostname that the first request is redirected to has information in the\nused .netrc file, with either of the `machine` or `default` keywords, curl\nwould pass on the bearer token set for the first host also to the second one."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3784",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Unauthorized access due to improper HTTP proxy connection reuse",
-              "Description": "curl would wrongly reuse an existing HTTP proxy connection doing CONNECT to a\nserver, even if the new request uses different credentials for the HTTP proxy.\nThe proper behavior is to create or use a separate connection."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3805",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "curl: curl: Arbitrary code execution or Denial of Service via use-after-free in SMB request handling",
-              "Description": "When doing a second SMB request to the same host again, curl would wrongly use\na data pointer pointing into already freed memory."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-10966",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: Curl missing SFTP host verification with wolfSSH backend",
-              "Description": "curl's code for managing SSH connections when SFTP was done using the wolfSSH\npowered backend was flawed and missed host verification mechanisms.\n\nThis prevents curl from detecting MITM attackers and more."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14017",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "curl: curl: Security bypass due to global TLS option changes in multi-threaded LDAPS transfers",
-              "Description": "When doing multi-threaded LDAPS transfers (LDAP over TLS) with libcurl,\nchanging TLS options in one thread would inadvertently change them globally\nand therefore possibly also affect other concurrently setup transfers.\n\nDisabling certificate verification for a specific transfer could\nunintentionally disable the feature for other threads as well."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14524",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that  ...",
-              "Description": "When an OAuth2 bearer token is used for an HTTP(S) transfer, and that transfer\nperforms a cross-protocol redirect to a second URL that uses an IMAP, LDAP,\nPOP3 or SMTP scheme, curl might wrongly pass on the bearer token to the new\ntarget host."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14819",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing TLS related transfers with reused easy or multi handles and ...",
-              "Description": "When doing TLS related transfers with reused easy or multi handles and\naltering the  `CURLSSLOPT_NO_PARTIALCHAIN` option, libcurl could accidentally\nreuse a CA store cached in memory for which the partial chain option was\nreversed. Contrary to the user's wishes and expectations. This could make\nlibcurl find and accept a trust chain that it otherwise would not."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15079",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and setting t ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and setting the\nknown_hosts file, libcurl could still mistakenly accept connecting to hosts\n*not present* in the specified file if they were added as recognized in the\nlibssh *global* known_hosts file."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-15224",
-              "PkgName": "libcurl4t64",
-              "InstalledVersion": "8.14.1-2+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "When doing SSH-based transfers using either SCP or SFTP, and asked to  ...",
-              "Description": "When doing SSH-based transfers using either SCP or SFTP, and asked to do\npublic key authentication, curl would wrongly still ask and authenticate using\na locally running SSH agent."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-25210",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "libexpat: libexpat: Information disclosure and data integrity issues due to integer overflow in buffer reallocation",
-              "Description": "In libexpat before 2.7.4, the doContent function does not properly determine the buffer size bufSize because there is no integer overflow check for tag buffer reallocation."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-59375",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "expat: libexpat in Expat allows attackers to trigger large dynamic memory allocations via a small document that is submitted for parsing",
-              "Description": "libexpat in Expat before 2.7.2 allows attackers to trigger large dynamic memory allocations via a small document that is submitted for parsing."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-66382",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "libexpat: libexpat: Denial of service via crafted file processing",
-              "Description": "In libexpat through 2.7.3, a crafted file with an approximate size of 2 MiB can lead to dozens of seconds of processing time."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-32776",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "libexpat: libexpat: Denial of Service due to NULL pointer dereference",
-              "Description": "libexpat before 2.7.5 allows a NULL pointer dereference with empty external parameter entity content."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-32777",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "libexpat: libexpat: Denial of Service via infinite loop in DTD content parsing",
-              "Description": "libexpat before 2.7.5 allows an infinite loop while parsing DTD content."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-32778",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "libexpat: libexpat: Denial of Service via NULL pointer dereference after out-of-memory condition",
-              "Description": "libexpat before 2.7.5 allows a NULL pointer dereference in the function setContext on retry after an earlier ouf-of-memory condition."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-24515",
-              "PkgName": "libexpat1",
-              "InstalledVersion": "2.7.1-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "libexpat: libexpat null pointer dereference",
-              "Description": "In libexpat before 2.7.4, XML_ExternalEntityParserCreate does not copy unknown encoding handler user data."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-6829",
-              "PkgName": "libgcrypt20",
-              "InstalledVersion": "1.11.0-7",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "libgcrypt: ElGamal implementation doesn't have semantic security due to incorrectly encoded plaintexts possibly allowing to obtain sensitive information",
-              "Description": "cipher/elgamal.c in Libgcrypt through 1.8.2, when used to encrypt messages directly, improperly encodes plaintexts, which allows attackers to obtain sensitive information by reading ciphertext data (i.e., it does not have semantic security in face of a ciphertext-only attack). The Decisional Diffie-Hellman (DDH) assumption does not hold for Libgcrypt's ElGamal implementation."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-2236",
-              "PkgName": "libgcrypt20",
-              "InstalledVersion": "1.11.0-7",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "libgcrypt: vulnerable to Marvin Attack",
-              "Description": "A timing-based side-channel flaw was found in libgcrypt's RSA implementation. This issue may allow a remote attacker to initiate a Bleichenbacher-style attack, which can lead to the decryption of RSA ciphertexts."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-3389",
-              "PkgName": "libgnutls30t64",
-              "InstalledVersion": "3.8.9-3+deb13u2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "HTTPS: block-wise chosen-plaintext attack against SSL/TLS (BEAST)",
-              "Description": "The SSL protocol, as used in certain configurations in Microsoft Windows and Microsoft Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other products, encrypts data by using CBC mode with chained initialization vectors, which allows man-in-the-middle attackers to obtain plaintext HTTP headers via a blockwise chosen-boundary attack (BCBA) on an HTTPS session, in conjunction with JavaScript code that uses (1) the HTML5 WebSocket API, (2) the Java URLConnection API, or (3) the Silverlight WebClient API, aka a \"BEAST\" attack."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-5709",
-              "PkgName": "libgssapi-krb5-2",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: integer overflow in dbentry->n_key_data in kadmin/dbutil/dump.c",
-              "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26458",
-              "PkgName": "libgssapi-krb5-2",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26461",
-              "PkgName": "libgssapi-krb5-2",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2012-2663",
-              "PkgName": "libip4tc2",
-              "InstalledVersion": "1.8.11-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "iptables: --syn flag bypass",
-              "Description": "extensions/libxt_tcp.c in iptables through 1.4.21 does not match TCP SYN+FIN packets in --syn rules, which might allow remote attackers to bypass intended firewall restrictions via crafted packets.  NOTE: the CVE-2012-6638 fix makes this issue less relevant."
-            },
-            {
-              "VulnerabilityID": "CVE-2012-2663",
-              "PkgName": "libip6tc2",
-              "InstalledVersion": "1.8.11-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "iptables: --syn flag bypass",
-              "Description": "extensions/libxt_tcp.c in iptables through 1.4.21 does not match TCP SYN+FIN packets in --syn rules, which might allow remote attackers to bypass intended firewall restrictions via crafted packets.  NOTE: the CVE-2012-6638 fix makes this issue less relevant."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-5709",
-              "PkgName": "libk5crypto3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: integer overflow in dbentry->n_key_data in kadmin/dbutil/dump.c",
-              "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26458",
-              "PkgName": "libk5crypto3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26461",
-              "PkgName": "libk5crypto3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-5709",
-              "PkgName": "libkrb5-3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: integer overflow in dbentry->n_key_data in kadmin/dbutil/dump.c",
-              "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26458",
-              "PkgName": "libkrb5-3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26461",
-              "PkgName": "libkrb5-3",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-5709",
-              "PkgName": "libkrb5support0",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: integer overflow in dbentry->n_key_data in kadmin/dbutil/dump.c",
-              "Description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26458",
-              "PkgName": "libkrb5support0",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/rpc/pmap_rmt.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak in /krb5/src/lib/rpc/pmap_rmt.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-26461",
-              "PkgName": "libkrb5support0",
-              "InstalledVersion": "1.21.3-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "krb5: Memory leak at /krb5/src/lib/gssapi/krb5/k5sealv3.c",
-              "Description": "Kerberos 5 (aka krb5) 1.21.2 contains a memory leak vulnerability in /krb5/src/lib/gssapi/krb5/k5sealv3.c."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "liblastlog2-2",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "liblastlog2-2",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "liblastlog2-2",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2015-3276",
-              "PkgName": "libldap2",
-              "InstalledVersion": "2.6.10+dfsg-1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openldap: incorrect multi-keyword mode cipherstring parsing",
-              "Description": "The nss_parse_ciphers function in libraries/libldap/tls_m.c in OpenLDAP does not properly parse OpenSSL-style multi-keyword mode cipher strings, which might cause a weaker than intended cipher to be used and allow remote attackers to have unspecified impact via unknown vectors."
-            },
-            {
-              "VulnerabilityID": "CVE-2017-14159",
-              "PkgName": "libldap2",
-              "InstalledVersion": "2.6.10+dfsg-1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openldap: Privilege escalation via PID file manipulation",
-              "Description": "slapd in OpenLDAP 2.4.45 and earlier creates a PID file after dropping privileges to a non-root account, which might allow local users to kill arbitrary processes by leveraging access to this non-root account for PID file modification before a root script executes a \"kill `cat /pathname`\" command, as demonstrated by openldap-initscript."
-            },
-            {
-              "VulnerabilityID": "CVE-2017-17740",
-              "PkgName": "libldap2",
-              "InstalledVersion": "2.6.10+dfsg-1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openldap: contrib/slapd-modules/nops/nops.c attempts to free stack buffer allowing remote attackers to cause a denial of service",
-              "Description": "contrib/slapd-modules/nops/nops.c in OpenLDAP through 2.4.45, when both the nops module and the memberof overlay are enabled, attempts to free a buffer that was allocated on the stack, which allows remote attackers to cause a denial of service (slapd crash) via a member MODDN operation."
-            },
-            {
-              "VulnerabilityID": "CVE-2020-15719",
-              "PkgName": "libldap2",
-              "InstalledVersion": "2.6.10+dfsg-1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openldap: Certificate validation incorrectly matches name against CN-ID",
-              "Description": "libldap in certain third-party OpenLDAP packages has a certificate-validation flaw when the third-party package is asserting RFC6125 support. It considers CN even when there is a non-matching subjectAltName (SAN). This is fixed in, for example, openldap-2.4.46-10.el8 in Red Hat Enterprise Linux."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-22185",
-              "PkgName": "libldap2",
-              "InstalledVersion": "2.6.10+dfsg-1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "OpenLDAP: OpenLDAP LMDB: Denial of Service and Information Disclosure via Heap Buffer Underflow",
-              "Description": "OpenLDAP Lightning Memory-Mapped Database (LMDB) versions up to and including 0.9.14, prior to commit 8e1fda8, contain a heap buffer underflow in the readline() function of mdb_load. When processing malformed input containing an embedded NUL byte, an unsigned offset calculation can underflow and cause an out-of-bounds read of one byte before the allocated heap buffer. This can cause mdb_load to crash, leading to a limited denial-of-service condition."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "libmount1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "libmount1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "libmount1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-6141",
-              "PkgName": "libncursesw6",
-              "InstalledVersion": "6.5+20250216-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
-              "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27135",
-              "PkgName": "libnghttp2-14",
-              "InstalledVersion": "1.64.0-1.1",
-              "FixedVersion": "",
-              "Severity": "UNKNOWN",
-              "Title": "nghttp2 is an implementation of the Hypertext Transfer Protocol versio ...",
-              "Description": "nghttp2 is an implementation of the Hypertext Transfer Protocol version 2 in C. Prior to version 1.68.1, the nghttp2 library stops reading the incoming data when user facing public API `nghttp2_session_terminate_session` or `nghttp2_session_terminate_session2` is called by the application. They might be called internally by the library when it detects the situation that is subject to connection error. Due to the missing internal state validation, the library keeps reading the rest of the data after one of those APIs is called. Then receiving a malformed frame that causes FRAME_SIZE_ERROR causes assertion failure. nghttp2 v1.68.1 adds missing state validation to avoid assertion failure. No known workarounds are available."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-4116",
-              "PkgName": "libperl5.40",
-              "InstalledVersion": "5.40.1-6",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "perl: File:: Temp insecure temporary file handling",
-              "Description": "_is_safe in the File::Temp module for Perl does not properly handle symlinks."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "libsmartcols1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "libsmartcols1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "libsmartcols1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2021-45346",
-              "PkgName": "libsqlite3-0",
-              "InstalledVersion": "3.46.1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "sqlite: crafted SQL query allows a malicious user to obtain sensitive information",
-              "Description": "A Memory Leak vulnerability exists in SQLite Project SQLite3 3.35.1 and 3.37.0 via maliciously crafted SQL Queries (made via editing the Database File), it is possible to query a record, and leak subsequent bytes of memory that extend beyond the record, which could let a malicious user obtain sensitive information. NOTE: The developer disputes this as a vulnerability stating that If you give SQLite a corrupted database file and submit a query against the database, it might read parts of the database that you did not intend or expect."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-70873",
-              "PkgName": "libsqlite3-0",
-              "InstalledVersion": "3.46.1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "sqlite: SQLite: Information Disclosure via Crafted ZIP File",
-              "Description": "An information disclosure issue in the zipfileInflate function in the zipfile extension in SQLite v3.51.1 and earlier allows attackers to obtain heap memory via supplying a crafted ZIP file."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-2673",
-              "PkgName": "libssl3t64",
-              "InstalledVersion": "3.5.5-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssl: OpenSSL TLS 1.3 server may choose unexpected key agreement group",
-              "Description": "Issue summary: An OpenSSL TLS 1.3 server may fail to negotiate the expected\npreferred key exchange group when its key exchange group configuration includes\nthe default by using the 'DEFAULT' keyword.\n\nImpact summary: A less preferred key exchange may be used even when a more\npreferred group is supported by both client and server, if the group\nwas not included among the client's initial predicated keyshares.\nThis will sometimes be the case with the new hybrid post-quantum groups,\nif the client chooses to defer their use until specifically requested by\nthe server.\n\nIf an OpenSSL TLS 1.3 server's configuration uses the 'DEFAULT' keyword to\ninterpolate the built-in default group list into its own configuration, perhaps\nadding or removing specific elements, then an implementation defect causes the\n'DEFAULT' list to lose its 'tuple' structure, and all server-supported groups\nwere treated as a single sufficiently secure 'tuple', with the server not\nsending a Hello Retry Request (HRR) even when a group in a more preferred tuple\nwas mutually supported.\n\nAs a result, the client and server might fail to negotiate a mutually supported\npost-quantum key agreement group, such as 'X25519MLKEM768', if the client's\nconfiguration results in only 'classical' groups (such as 'X25519' being the\nonly ones in the client's initial keyshare prediction).\n\nOpenSSL 3.5 and later support a new syntax for selecting the most preferred TLS\n1.3 key agreement group on TLS servers.  The old syntax had a single 'flat'\nlist of groups, and treated all the supported groups as sufficiently secure.\nIf any of the keyshares predicted by the client were supported by the server\nthe most preferred among these was selected, even if other groups supported by\nthe client, but not included in the list of predicted keyshares would have been\nmore preferred, if included.\n\nThe new syntax partitions the groups into distinct 'tuples' of roughly\nequivalent security.  Within each tuple the most preferred group included among\nthe client's predicted keyshares is chosen, but if the client supports a group\nfrom a more preferred tuple, but did not predict any corresponding keyshares,\nthe server will ask the client to retry the ClientHello (by issuing a Hello\nRetry Request or HRR) with the most preferred mutually supported group.\n\nThe above works as expected when the server's configuration uses the built-in\ndefault group list, or explicitly defines its own list by directly defining the\nvarious desired groups and group 'tuples'.\n\nNo OpenSSL FIPS modules are affected by this issue, the code in question lies\noutside the FIPS boundary.\n\nOpenSSL 3.6 and 3.5 are vulnerable to this issue.\n\nOpenSSL 3.6 users should upgrade to OpenSSL 3.6.2 once it is released.\nOpenSSL 3.5 users should upgrade to OpenSSL 3.5.6 once it is released.\n\nOpenSSL 3.4, 3.3, 3.0, 1.0.2 and 1.1.1 are not affected by this issue."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-4105",
-              "PkgName": "libsystemd0",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "systemd: systemd: Privilege escalation via improper access control in RegisterMachine D-Bus method",
-              "Description": "A flaw was found in systemd. The systemd-machined service contains an Improper Access Control vulnerability due to insufficient validation of the class parameter in the RegisterMachine D-Bus (Desktop Bus) method. A local unprivileged user can exploit this by attempting to register a machine with a specific class value, which may leave behind a usable, attacker-controlled machine object. This allows the attacker to invoke methods on the privileged object, leading to the execution of arbitrary commands with root privileges on the host system."
-            },
-            {
-              "VulnerabilityID": "CVE-2013-4392",
-              "PkgName": "libsystemd0",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "systemd: TOCTOU race condition when updating file permissions and SELinux security contexts",
-              "Description": "systemd, when updating file permissions, allows local users to change the permissions and SELinux security contexts for arbitrary files via a symlink attack on unspecified files."
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31437",
-              "PkgName": "libsystemd0",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can modify a seale ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can modify a sealed log file such that, in some views, not all existing and sealed log messages are displayed. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31438",
-              "PkgName": "libsystemd0",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can truncate a sea ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can truncate a sealed log file and then resume log sealing such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31439",
-              "PkgName": "libsystemd0",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can modify the con ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can modify the contents of past events in a sealed log file and then adjust the file such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2025-13151",
-              "PkgName": "libtasn1-6",
-              "InstalledVersion": "4.20.0-2",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "libtasn1: libtasn1: Denial of Service via stack-based buffer overflow in asn1_expend_octet_string",
-              "Description": "Stack-based buffer overflow in libtasn1 version: v4.20.0. The function fails to validate the size of input data resulting in a buffer overflow in asn1_expend_octet_string."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-6141",
-              "PkgName": "libtinfo6",
-              "InstalledVersion": "6.5+20250216-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
-              "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-4105",
-              "PkgName": "libudev1",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "systemd: systemd: Privilege escalation via improper access control in RegisterMachine D-Bus method",
-              "Description": "A flaw was found in systemd. The systemd-machined service contains an Improper Access Control vulnerability due to insufficient validation of the class parameter in the RegisterMachine D-Bus (Desktop Bus) method. A local unprivileged user can exploit this by attempting to register a machine with a specific class value, which may leave behind a usable, attacker-controlled machine object. This allows the attacker to invoke methods on the privileged object, leading to the execution of arbitrary commands with root privileges on the host system."
-            },
-            {
-              "VulnerabilityID": "CVE-2013-4392",
-              "PkgName": "libudev1",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "systemd: TOCTOU race condition when updating file permissions and SELinux security contexts",
-              "Description": "systemd, when updating file permissions, allows local users to change the permissions and SELinux security contexts for arbitrary files via a symlink attack on unspecified files."
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31437",
-              "PkgName": "libudev1",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can modify a seale ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can modify a sealed log file such that, in some views, not all existing and sealed log messages are displayed. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31438",
-              "PkgName": "libudev1",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can truncate a sea ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can truncate a sealed log file and then resume log sealing such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2023-31439",
-              "PkgName": "libudev1",
-              "InstalledVersion": "257.9-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "An issue was discovered in systemd 253. An attacker can modify the con ...",
-              "Description": "An issue was discovered in systemd 253. An attacker can modify the contents of past events in a sealed log file and then adjust the file such that checking the integrity shows no error, despite modifications. NOTE: the vendor reportedly sent \"a reply denying that any of the finding was a security vulnerability.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "libuuid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "libuuid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "libuuid1",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2012-2663",
-              "PkgName": "libxtables12",
-              "InstalledVersion": "1.8.11-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "iptables: --syn flag bypass",
-              "Description": "extensions/libxt_tcp.c in iptables through 1.4.21 does not match TCP SYN+FIN packets in --syn rules, which might allow remote attackers to bypass intended firewall restrictions via crafted packets.  NOTE: the CVE-2012-6638 fix makes this issue less relevant."
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "login",
-              "InstalledVersion": "1:4.16.0-2+really2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "login",
-              "InstalledVersion": "1:4.16.0-2+really2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "login",
-              "InstalledVersion": "1:4.16.0-2+really2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2007-5686",
-              "PkgName": "login.defs",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "initscripts in rPath Linux 1 sets insecure permissions for the /var/lo ...",
-              "Description": "initscripts in rPath Linux 1 sets insecure permissions for the /var/log/btmp file, which allows local users to obtain sensitive information regarding authentication attempts.  NOTE: because sshd detects the insecure permissions and does not log certain events, this also prevents sshd from logging failed authentication attempts by remote attackers."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-56433",
-              "PkgName": "login.defs",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "shadow-utils: Default subordinate ID configuration in /etc/login.defs could lead to compromise",
-              "Description": "shadow-utils (aka shadow) 4.4 through 4.17.0 establishes a default /etc/subuid behavior (e.g., uid 100000 through 165535 for the first user account) that can realistically conflict with the uids of users defined on locally administered networks, potentially leading to account takeover, e.g., by leveraging newuidmap for access to an NFS home directory (or same-host resources in the case of remote logins by these local network users). NOTE: it may also be argued that system administrators should not have assigned uids, within local networks, that are within the range that can occur in /etc/subuid."
-            },
-            {
-              "VulnerabilityID": "TEMP-0628843-DBAD28",
-              "PkgName": "login.defs",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "[more related to CVE-2005-4890]",
-              "Description": ""
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "mount",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "mount",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "mount",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-6141",
-              "PkgName": "ncurses-base",
-              "InstalledVersion": "6.5+20250216-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
-              "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-6141",
-              "PkgName": "ncurses-bin",
-              "InstalledVersion": "6.5+20250216-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "gnu-ncurses: ncurses Stack Buffer Overflow",
-              "Description": "A vulnerability has been found in GNU ncurses up to 6.5-20250322 and classified as problematic. This vulnerability affects the function postprocess_termcap of the file tinfo/parse_entry.c. The manipulation leads to stack-based buffer overflow. The attack needs to be approached locally. Upgrading to version 6.5-20250329 is able to address this issue. It is recommended to upgrade the affected component."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3497",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "HIGH",
-              "Title": "openssh: OpenSSH GSSAPI: Information disclosure or denial of service due to uninitialized variables",
-              "Description": "Vulnerability in the OpenSSH GSSAPI delta included in various Linux distributions. This vulnerability affects the GSSAPI patches added by various Linux distributions and does not affect the OpenSSH upstream project itself. The usage of sshpkt_disconnect() on an error, which does not terminate the process, allows an attacker to send an unexpected GSSAPI message type during the GSSAPI key exchange to the server, which will call the underlying function and continue the execution of the program without setting the related connection variables. As the variables are not initialized to NULL the code later accesses those uninitialized variables, accessing random memory, which could lead to undefined behavior. The recommended workaround is to use ssh_packet_disconnect() instead, which does terminate the process. The impact of the vulnerability depends heavily on the compiler flag hardening configuration."
-            },
-            {
-              "VulnerabilityID": "CVE-2007-2243",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "OpenSSH 4.6 and earlier, when ChallengeResponseAuthentication is enabl ...",
-              "Description": "OpenSSH 4.6 and earlier, when ChallengeResponseAuthentication is enabled, allows remote attackers to determine the existence of user accounts by attempting to authenticate via S/KEY, which displays a different response if the user account exists, a similar issue to CVE-2001-1483."
-            },
-            {
-              "VulnerabilityID": "CVE-2007-2768",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "OpenSSH, when using OPIE (One-Time Passwords in Everything) for PAM, a ...",
-              "Description": "OpenSSH, when using OPIE (One-Time Passwords in Everything) for PAM, allows remote attackers to determine the existence of certain user accounts, which displays a different response if the user account exists and is configured to use one-time passwords (OTP), a similar issue to CVE-2007-2243."
-            },
-            {
-              "VulnerabilityID": "CVE-2008-3234",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "sshd in OpenSSH 4 on Debian GNU/Linux, and the 20070303 OpenSSH snapsh ...",
-              "Description": "sshd in OpenSSH 4 on Debian GNU/Linux, and the 20070303 OpenSSH snapshot, allows remote authenticated users to obtain access to arbitrary SELinux roles by appending a :/ (colon slash) sequence, followed by the role name, to the username."
-            },
-            {
-              "VulnerabilityID": "CVE-2016-20012",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssh: Public key information leak",
-              "Description": "OpenSSH through 8.7 allows remote attackers, who have a suspicion that a certain combination of username and public key is known to an SSH server, to test whether this suspicion is correct. This occurs because a challenge is sent only when that combination could be valid for a login session. NOTE: the vendor does not recognize user enumeration as a vulnerability for this product"
-            },
-            {
-              "VulnerabilityID": "CVE-2018-15919",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssh: User enumeration via malformed packets in authentication requests",
-              "Description": "Remotely observable behaviour in auth-gss2.c in OpenSSH through 7.8 could be used by remote attackers to detect existence of users on a target system when GSS2 is in use. NOTE: the discoverer states 'We understand that the OpenSSH developers do not want to treat such a username enumeration (or \"oracle\") as a vulnerability.'"
-            },
-            {
-              "VulnerabilityID": "CVE-2019-6110",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssh: Acceptance and display of arbitrary stderr allows for spoofing of scp client output",
-              "Description": "In OpenSSH 7.9, due to accepting and displaying arbitrary stderr output from the server, a malicious server (or Man-in-The-Middle attacker) can manipulate the client output, for example to use ANSI control codes to hide additional files being transferred."
-            },
-            {
-              "VulnerabilityID": "CVE-2020-14145",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssh: Observable discrepancy leading to an information leak in the algorithm negotiation",
-              "Description": "The client side in OpenSSH 5.7 through 8.4 has an Observable Discrepancy leading to an information leak in the algorithm negotiation. This allows man-in-the-middle attackers to target initial connection attempts (where no host key for the server has been cached by the client). NOTE: some reports state that 8.5 and 8.6 are also affected."
-            },
-            {
-              "VulnerabilityID": "CVE-2020-15778",
-              "PkgName": "openssh-client",
-              "InstalledVersion": "1:10.0p1-7+deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssh: scp allows command injection when using backtick characters in the destination argument",
-              "Description": "scp in OpenSSH through 8.3p1 allows command injection in the scp.c toremote function, as demonstrated by backtick characters in the destination argument. NOTE: the vendor reportedly has stated that they intentionally omit validation of \"anomalous argument transfers\" because that could \"stand a great chance of breaking existing workflows.\""
-            },
-            {
-              "VulnerabilityID": "CVE-2026-2673",
-              "PkgName": "openssl",
-              "InstalledVersion": "3.5.5-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssl: OpenSSL TLS 1.3 server may choose unexpected key agreement group",
-              "Description": "Issue summary: An OpenSSL TLS 1.3 server may fail to negotiate the expected\npreferred key exchange group when its key exchange group configuration includes\nthe default by using the 'DEFAULT' keyword.\n\nImpact summary: A less preferred key exchange may be used even when a more\npreferred group is supported by both client and server, if the group\nwas not included among the client's initial predicated keyshares.\nThis will sometimes be the case with the new hybrid post-quantum groups,\nif the client chooses to defer their use until specifically requested by\nthe server.\n\nIf an OpenSSL TLS 1.3 server's configuration uses the 'DEFAULT' keyword to\ninterpolate the built-in default group list into its own configuration, perhaps\nadding or removing specific elements, then an implementation defect causes the\n'DEFAULT' list to lose its 'tuple' structure, and all server-supported groups\nwere treated as a single sufficiently secure 'tuple', with the server not\nsending a Hello Retry Request (HRR) even when a group in a more preferred tuple\nwas mutually supported.\n\nAs a result, the client and server might fail to negotiate a mutually supported\npost-quantum key agreement group, such as 'X25519MLKEM768', if the client's\nconfiguration results in only 'classical' groups (such as 'X25519' being the\nonly ones in the client's initial keyshare prediction).\n\nOpenSSL 3.5 and later support a new syntax for selecting the most preferred TLS\n1.3 key agreement group on TLS servers.  The old syntax had a single 'flat'\nlist of groups, and treated all the supported groups as sufficiently secure.\nIf any of the keyshares predicted by the client were supported by the server\nthe most preferred among these was selected, even if other groups supported by\nthe client, but not included in the list of predicted keyshares would have been\nmore preferred, if included.\n\nThe new syntax partitions the groups into distinct 'tuples' of roughly\nequivalent security.  Within each tuple the most preferred group included among\nthe client's predicted keyshares is chosen, but if the client supports a group\nfrom a more preferred tuple, but did not predict any corresponding keyshares,\nthe server will ask the client to retry the ClientHello (by issuing a Hello\nRetry Request or HRR) with the most preferred mutually supported group.\n\nThe above works as expected when the server's configuration uses the built-in\ndefault group list, or explicitly defines its own list by directly defining the\nvarious desired groups and group 'tuples'.\n\nNo OpenSSL FIPS modules are affected by this issue, the code in question lies\noutside the FIPS boundary.\n\nOpenSSL 3.6 and 3.5 are vulnerable to this issue.\n\nOpenSSL 3.6 users should upgrade to OpenSSL 3.6.2 once it is released.\nOpenSSL 3.5 users should upgrade to OpenSSL 3.5.6 once it is released.\n\nOpenSSL 3.4, 3.3, 3.0, 1.0.2 and 1.1.1 are not affected by this issue."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-2673",
-              "PkgName": "openssl-provider-legacy",
-              "InstalledVersion": "3.5.5-1~deb13u1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "openssl: OpenSSL TLS 1.3 server may choose unexpected key agreement group",
-              "Description": "Issue summary: An OpenSSL TLS 1.3 server may fail to negotiate the expected\npreferred key exchange group when its key exchange group configuration includes\nthe default by using the 'DEFAULT' keyword.\n\nImpact summary: A less preferred key exchange may be used even when a more\npreferred group is supported by both client and server, if the group\nwas not included among the client's initial predicated keyshares.\nThis will sometimes be the case with the new hybrid post-quantum groups,\nif the client chooses to defer their use until specifically requested by\nthe server.\n\nIf an OpenSSL TLS 1.3 server's configuration uses the 'DEFAULT' keyword to\ninterpolate the built-in default group list into its own configuration, perhaps\nadding or removing specific elements, then an implementation defect causes the\n'DEFAULT' list to lose its 'tuple' structure, and all server-supported groups\nwere treated as a single sufficiently secure 'tuple', with the server not\nsending a Hello Retry Request (HRR) even when a group in a more preferred tuple\nwas mutually supported.\n\nAs a result, the client and server might fail to negotiate a mutually supported\npost-quantum key agreement group, such as 'X25519MLKEM768', if the client's\nconfiguration results in only 'classical' groups (such as 'X25519' being the\nonly ones in the client's initial keyshare prediction).\n\nOpenSSL 3.5 and later support a new syntax for selecting the most preferred TLS\n1.3 key agreement group on TLS servers.  The old syntax had a single 'flat'\nlist of groups, and treated all the supported groups as sufficiently secure.\nIf any of the keyshares predicted by the client were supported by the server\nthe most preferred among these was selected, even if other groups supported by\nthe client, but not included in the list of predicted keyshares would have been\nmore preferred, if included.\n\nThe new syntax partitions the groups into distinct 'tuples' of roughly\nequivalent security.  Within each tuple the most preferred group included among\nthe client's predicted keyshares is chosen, but if the client supports a group\nfrom a more preferred tuple, but did not predict any corresponding keyshares,\nthe server will ask the client to retry the ClientHello (by issuing a Hello\nRetry Request or HRR) with the most preferred mutually supported group.\n\nThe above works as expected when the server's configuration uses the built-in\ndefault group list, or explicitly defines its own list by directly defining the\nvarious desired groups and group 'tuples'.\n\nNo OpenSSL FIPS modules are affected by this issue, the code in question lies\noutside the FIPS boundary.\n\nOpenSSL 3.6 and 3.5 are vulnerable to this issue.\n\nOpenSSL 3.6 users should upgrade to OpenSSL 3.6.2 once it is released.\nOpenSSL 3.5 users should upgrade to OpenSSL 3.5.6 once it is released.\n\nOpenSSL 3.4, 3.3, 3.0, 1.0.2 and 1.1.1 are not affected by this issue."
-            },
-            {
-              "VulnerabilityID": "CVE-2007-5686",
-              "PkgName": "passwd",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "initscripts in rPath Linux 1 sets insecure permissions for the /var/lo ...",
-              "Description": "initscripts in rPath Linux 1 sets insecure permissions for the /var/log/btmp file, which allows local users to obtain sensitive information regarding authentication attempts.  NOTE: because sshd detects the insecure permissions and does not log certain events, this also prevents sshd from logging failed authentication attempts by remote attackers."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-56433",
-              "PkgName": "passwd",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "shadow-utils: Default subordinate ID configuration in /etc/login.defs could lead to compromise",
-              "Description": "shadow-utils (aka shadow) 4.4 through 4.17.0 establishes a default /etc/subuid behavior (e.g., uid 100000 through 165535 for the first user account) that can realistically conflict with the uids of users defined on locally administered networks, potentially leading to account takeover, e.g., by leveraging newuidmap for access to an NFS home directory (or same-host resources in the case of remote logins by these local network users). NOTE: it may also be argued that system administrators should not have assigned uids, within local networks, that are within the range that can occur in /etc/subuid."
-            },
-            {
-              "VulnerabilityID": "TEMP-0628843-DBAD28",
-              "PkgName": "passwd",
-              "InstalledVersion": "1:4.17.4-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "[more related to CVE-2005-4890]",
-              "Description": ""
-            },
-            {
-              "VulnerabilityID": "CVE-2010-4651",
-              "PkgName": "patch",
-              "InstalledVersion": "2.8-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "patch: directory traversal flaw allows for arbitrary file creation",
-              "Description": "Directory traversal vulnerability in util.c in GNU patch 2.6.1 and earlier allows user-assisted remote attackers to create or overwrite arbitrary files via a filename that is specified with a .. (dot dot) or full pathname, a related issue to CVE-2010-1679."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-6951",
-              "PkgName": "patch",
-              "InstalledVersion": "2.8-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "patch: NULL pointer dereference in pch.c:intuit_diff_type() causes a crash",
-              "Description": "An issue was discovered in GNU patch through 2.7.6. There is a segmentation fault, associated with a NULL pointer dereference, leading to a denial of service in the intuit_diff_type function in pch.c, aka a \"mangled rename\" issue."
-            },
-            {
-              "VulnerabilityID": "CVE-2018-6952",
-              "PkgName": "patch",
-              "InstalledVersion": "2.8-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "patch: Double free of memory in pch.c:another_hunk() causes a crash",
-              "Description": "A double free exists in the another_hunk function in pch.c in GNU patch through 2.7.6."
-            },
-            {
-              "VulnerabilityID": "CVE-2021-45261",
-              "PkgName": "patch",
-              "InstalledVersion": "2.8-2",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "patch: Invalid Pointer via another_hunk function",
-              "Description": "An Invalid Pointer vulnerability exists in GNU patch 2.7 via the another_hunk function, which causes a Denial of Service."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-4116",
-              "PkgName": "perl",
-              "InstalledVersion": "5.40.1-6",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "perl: File:: Temp insecure temporary file handling",
-              "Description": "_is_safe in the File::Temp module for Perl does not properly handle symlinks."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-4116",
-              "PkgName": "perl-base",
-              "InstalledVersion": "5.40.1-6",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "perl: File:: Temp insecure temporary file handling",
-              "Description": "_is_safe in the File::Temp module for Perl does not properly handle symlinks."
-            },
-            {
-              "VulnerabilityID": "CVE-2011-4116",
-              "PkgName": "perl-modules-5.40",
-              "InstalledVersion": "5.40.1-6",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "perl: File:: Temp insecure temporary file handling",
-              "Description": "_is_safe in the File::Temp module for Perl does not properly handle symlinks."
-            },
-            {
-              "VulnerabilityID": "TEMP-0517018-A83CE6",
-              "PkgName": "sysvinit-utils",
-              "InstalledVersion": "3.14-4",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "[sysvinit: no-root option in expert installer exposes locally exploitable security flaw]",
-              "Description": ""
-            },
-            {
-              "VulnerabilityID": "CVE-2005-2541",
-              "PkgName": "tar",
-              "InstalledVersion": "1.35+dfsg-3.1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "tar: does not properly warn the user when extracting setuid or setgid files",
-              "Description": "Tar 1.15.1 does not properly warn the user when extracting setuid or setgid files, which may allow local users or remote attackers to gain privileges."
-            },
-            {
-              "VulnerabilityID": "TEMP-0290435-0B57B5",
-              "PkgName": "tar",
-              "InstalledVersion": "1.35+dfsg-3.1",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "[tar's rmt command may have undesired side effects]",
-              "Description": ""
-            },
-            {
-              "VulnerabilityID": "CVE-2022-0563",
-              "PkgName": "util-linux",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: partial disclosure of arbitrary files in chfn and chsh when compiled with libreadline",
-              "Description": "A flaw was found in the util-linux chfn and chsh utilities when compiled with Readline support. The Readline library uses an \"INPUTRC\" environment variable to get a path to the library config file. When the library cannot parse the specified file, it prints an error message containing data from the file. This flaw allows an unprivileged user to read root-owned files, potentially leading to privilege escalation. This flaw affects util-linux versions prior to 2.37.4."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-14104",
-              "PkgName": "util-linux",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Heap buffer overread in setpwnam() when processing 256-byte usernames",
-              "Description": "A flaw was found in util-linux. This vulnerability allows a heap buffer overread when processing 256-byte usernames, specifically within the `setpwnam()` function, affecting SUID (Set User ID) login-utils utilities writing to the password database."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-3184",
-              "PkgName": "util-linux",
-              "InstalledVersion": "2.41-5",
-              "FixedVersion": "",
-              "Severity": "LOW",
-              "Title": "util-linux: util-linux: Access control bypass due to improper hostname canonicalization",
-              "Description": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27171",
-              "PkgName": "zlib1g",
-              "InstalledVersion": "1:1.3.dfsg+really1.3.1-1+b1",
-              "FixedVersion": "",
-              "Severity": "MEDIUM",
-              "Title": "zlib: zlib: Denial of Service via infinite loop in CRC32 combine functions",
-              "Description": "zlib before 1.3.2 allows CPU consumption via crc32_combine64 and crc32_combine_gen64 because x2nmodp can do right shifts within a loop that has no termination condition."
-            }
-          ],
-          "Secrets": null
+          "platform": "linux/amd64",
+          "compressed_bytes": 2211857,
+          "compressed_human": "2.1 MB",
+          "layer_count": 1
         },
         {
-          "Target": "Node.js",
-          "Vulnerabilities": null,
-          "Secrets": null
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
         },
         {
-          "Target": "Python",
-          "Vulnerabilities": [
-            {
-              "VulnerabilityID": "CVE-2025-8869",
-              "PkgName": "pip",
-              "InstalledVersion": "25.0.1",
-              "FixedVersion": "25.3",
-              "Severity": "MEDIUM",
-              "Title": "pip: pip missing checks on symbolic link extraction",
-              "Description": "When extracting a tar archive pip may not check symbolic links point into the extraction directory if the tarfile module doesn't implement PEP 706.\nNote that upgrading pip to a \"fixed\" version for this vulnerability doesn't fix all known vulnerabilities that are remediated by using a Python version that implements PEP 706.\n\nNote that this is a vulnerability in pip's fallback implementation of tar extraction for Python versions that don't implement PEP 706\nand therefore are not secure to all vulnerabilities in the Python 'tarfile' module. If you're using a Python version that implements PEP 706\nthen pip doesn't use the \"vulnerable\" fallback code.\n\nMitigations include upgrading to a version of pip that includes the fix, upgrading to a Python version that implements PEP 706 (Python >=3.9.17, >=3.10.12, >=3.11.4, or >=3.12),\napplying the linked patch, or inspecting source distributions (sdists) before installation as is already a best-practice."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-1703",
-              "PkgName": "pip",
-              "InstalledVersion": "25.0.1",
-              "FixedVersion": "26.0",
-              "Severity": "LOW",
-              "Title": "pip: pip: Information disclosure via path traversal when installing crafted wheel archives",
-              "Description": "When pip is installing and extracting a maliciously crafted wheel archive, files may be extracted outside the installation directory. The path traversal is limited to prefixes of the installation directory, thus isn't able to inject or overwrite executable files in typical situations."
-            }
-          ],
-          "Secrets": null
+          "platform": "linux/arm/v5",
+          "compressed_bytes": 1824951,
+          "compressed_human": "1.7 MB",
+          "layer_count": 1
         },
         {
-          "Target": "usr/local/bin/dockle",
-          "Vulnerabilities": [
-            {
-              "VulnerabilityID": "CVE-2025-54410",
-              "PkgName": "github.com/docker/docker",
-              "InstalledVersion": "v27.3.1+incompatible",
-              "FixedVersion": "28.0.0",
-              "Severity": "LOW",
-              "Title": "github.com/moby/moby: Moby's Firewalld reload removes bridge network isolation",
-              "Description": "Moby is an open source container framework developed by Docker Inc. that is distributed as Docker Engine, Mirantis Container Runtime, and various other downstream projects/products. A firewalld vulnerability affects Moby releases before 28.0.0. When firewalld reloads, Docker fails to re-create iptables rules that isolate bridge networks, allowing any container to access all ports on any other container across different bridge networks on the same host. This breaks network segmentation between containers that should be isolated, creating significant risk in multi-tenant environments. Only containers in --internal networks remain protected.\nWorkarounds include reloading firewalld and either restarting the docker daemon, re-creating bridge networks, or using rootless mode. Maintainers anticipate a fix for this issue in version 25.0.13."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-52881",
-              "PkgName": "github.com/opencontainers/selinux",
-              "InstalledVersion": "v1.11.1",
-              "FixedVersion": "1.13.0",
-              "Severity": "HIGH",
-              "Title": "runc: opencontainers/selinux: container escape and denial of service due to arbitrary write gadgets and procfs write redirects",
-              "Description": "runc is a CLI tool for spawning and running containers according to the OCI specification. In versions 1.2.7, 1.3.2 and 1.4.0-rc.2, an attacker can trick runc into misdirecting writes to /proc to other procfs files through the use of a racing container with shared mounts (we have also verified this attack is possible to exploit using a standard Dockerfile with docker buildx build as that also permits triggering parallel execution of containers with custom shared mounts configured). This redirect could be through symbolic links in a tmpfs or theoretically other methods such as regular bind-mounts. While similar, the mitigation applied for the related CVE, CVE-2019-19921, was fairly limited and effectively only caused runc to verify that when LSM labels are written they are actually procfs files. This issue is fixed in versions 1.2.8, 1.3.3, and 1.4.0-rc.3."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58058",
-              "PkgName": "github.com/ulikunitz/xz",
-              "InstalledVersion": "v0.5.12",
-              "FixedVersion": "0.5.15",
-              "Severity": "MEDIUM",
-              "Title": "github.com/ulikunitz/xz: github.com/ulikunitz/xz leaks memory",
-              "Description": "xz is a pure golang package for reading and writing xz-compressed files. Prior to version 0.5.14, it is possible to put data in front of an LZMA-encoded byte stream without detecting the situation while reading the header. This can lead to increased memory consumption because the current implementation allocates the full decoding buffer directly after reading the header. The LZMA header doesn't include a magic number or has a checksum to detect such an issue according to the specification. Note that the code recognizes the issue later while reading the stream, but at this time the memory allocation has already been done. This issue has been patched in version 0.5.14."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-22868",
-              "PkgName": "golang.org/x/oauth2",
-              "InstalledVersion": "v0.23.0",
-              "FixedVersion": "0.27.0",
-              "Severity": "HIGH",
-              "Title": "golang.org/x/oauth2/jws: Unexpected memory consumption during token parsing in golang.org/x/oauth2/jws",
-              "Description": "An attacker can pass a malicious malformed token which causes unexpected memory to be consumed during parsing."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-68121",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.13, 1.25.7, 1.26.0-rc.3",
-              "Severity": "CRITICAL",
-              "Title": "crypto/tls: Unexpected session resumption in crypto/tls",
-              "Description": "During session resumption in crypto/tls, if the underlying Config has its ClientCAs or RootCAs fields mutated between the initial handshake and the resumed handshake, the resumed handshake may succeed when it should have failed. This may happen when a user calls Config.Clone and mutates the returned Config, or uses Config.GetConfigForClient. This can cause a client to resume a session with a server that it would not have resumed with during the initial handshake, or cause a server to resume a session with a client that it would not have resumed with during the initial handshake."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-47907",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.12, 1.24.6",
-              "Severity": "HIGH",
-              "Title": "database/sql: Postgres Scan Race Condition",
-              "Description": "Cancelling a query (e.g. by cancelling the context passed to one of the query methods) during a call to the Scan method of the returned Rows can result in unexpected results if other queries are being made in parallel. This can result in a race condition that may overwrite the expected results with those of another query, causing the call to Scan to return either unexpected results from the other query or an error."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58183",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "HIGH",
-              "Title": "golang: archive/tar: Unbounded allocation when parsing GNU sparse map",
-              "Description": "tar.Reader does not set a maximum size on the number of sparse region data blocks in GNU tar pax 1.0 sparse files. A maliciously-crafted archive containing a large number of sparse regions can cause a Reader to read an unbounded amount of data from the archive into memory. When reading from a compressed source, a small compressed input can result in large allocations."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61726",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.12, 1.25.6",
-              "Severity": "HIGH",
-              "Title": "golang: net/url: Memory exhaustion in query parameter parsing in net/url",
-              "Description": "The net/url package does not set a limit on the number of query parameters in a query. While the maximum size of query parameters in URLs is generally limited by the maximum request header size, the net/http.Request.ParseForm method can parse large URL-encoded forms. Parsing a large form containing many unique query parameters can cause excessive memory consumption."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61728",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.12, 1.25.6",
-              "Severity": "HIGH",
-              "Title": "golang: archive/zip: Excessive CPU consumption when building archive index in archive/zip",
-              "Description": "archive/zip uses a super-linear file name indexing algorithm that is invoked the first time a file in an archive is opened. This can lead to a denial of service when consuming a maliciously constructed ZIP archive."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61729",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.11, 1.25.5",
-              "Severity": "HIGH",
-              "Title": "crypto/x509: golang: Denial of Service due to excessive resource consumption via crafted certificate",
-              "Description": "Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out. Furthermore, the error string is constructed by repeated string concatenation, leading to quadratic runtime. Therefore, a certificate provided by a malicious actor can result in excessive resource consumption."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-25679",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "HIGH",
-              "Title": "net/url: Incorrect parsing of IPv6 host literals in net/url",
-              "Description": "url.Parse insufficiently validated the host/authority component and accepted some invalid URLs."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-45336",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2",
-              "Severity": "MEDIUM",
-              "Title": "golang: net/http: net/http: sensitive headers incorrectly sent after cross-domain redirect",
-              "Description": "The HTTP client drops sensitive headers after following a cross-domain redirect. For example, a request to a.com/ containing an Authorization header which is redirected to b.com/ will not send that header to b.com. In the event that the client received a subsequent same-domain redirect, however, the sensitive headers would be restored. For example, a chain of redirects from a.com/, to b.com/1, and finally to b.com/2 would incorrectly send the Authorization header to b.com/2."
-            },
-            {
-              "VulnerabilityID": "CVE-2024-45341",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.22.11, 1.23.5, 1.24.0-rc.2",
-              "Severity": "MEDIUM",
-              "Title": "golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can bypass URI name constraints",
-              "Description": "A certificate with a URI which has a IPv6 address with a zone ID may incorrectly satisfy a URI name constraint that applies to the certificate chain. Certificates containing URIs are not permitted in the web PKI, so this only affects users of private PKIs which make use of URIs."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-0913",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.10, 1.24.4",
-              "Severity": "MEDIUM",
-              "Title": "Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall",
-              "Description": "os.OpenFile(path, os.O_CREATE|O_EXCL) behaved differently on Unix and Windows systems when the target path was a dangling symlink. On Unix systems, OpenFile with O_CREATE and O_EXCL flags never follows symlinks. On Windows, when the target path was a symlink to a nonexistent location, OpenFile would create a file in that location. OpenFile now always returns an error when the O_CREATE and O_EXCL flags are both set and the target path is a symlink."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-22866",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.22.12, 1.23.6, 1.24.0-rc.3",
-              "Severity": "MEDIUM",
-              "Title": "crypto/internal/nistec: golang: Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec",
-              "Description": "Due to the usage of a variable time instruction in the assembly implementation of an internal function, a small number of bits of secret scalars are leaked on the ppc64le architecture. Due to the way this function is used, we do not believe this leakage is enough to allow recovery of the private key when P-256 is used in any well known protocols."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-22871",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.8, 1.24.2",
-              "Severity": "MEDIUM",
-              "Title": "net/http: Request smuggling due to acceptance of invalid chunked data in net/http",
-              "Description": "The net/http package improperly accepts a bare LF as a line terminator in chunked data chunk-size lines. This can permit request smuggling if a net/http server is used in conjunction with a server that incorrectly accepts a bare LF as part of a chunk-ext."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-22873",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.9, 1.24.3",
-              "Severity": "MEDIUM",
-              "Title": "os: os: Information disclosure via path traversal using specially crafted filenames",
-              "Description": "It was possible to improperly access the parent directory of an os.Root by opening a filename ending in \"../\". For example, Root.Open(\"../\") would open the parent directory of the Root. This escape only permits opening the parent directory itself, not ancestors of the parent or files contained within the parent."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-4673",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.10, 1.24.4",
-              "Severity": "MEDIUM",
-              "Title": "net/http: Sensitive headers not cleared on cross-origin redirect in net/http",
-              "Description": "Proxy-Authorization and Proxy-Authenticate headers persisted on cross-origin redirects potentially leaking sensitive information."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-47906",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.23.12, 1.24.6",
-              "Severity": "MEDIUM",
-              "Title": "os/exec: Unexpected paths returned from LookPath in os/exec",
-              "Description": "If the PATH environment variable contains paths which are executables (rather than just directories), passing certain strings to LookPath (\"\", \".\", and \"..\"), can result in the binaries listed in the PATH being unexpectedly returned."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-47912",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "net/url: Insufficient validation of bracketed IPv6 hostnames in net/url",
-              "Description": "The Parse function permits values other than IPv6 addresses to be included in square brackets within the host component of a URL. RFC 3986 permits IPv6 addresses to be included within the host component, enclosed within square brackets. For example: \"http://[::1]/\". IPv4 addresses and hostnames must not appear within square brackets. Parse did not enforce this requirement."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58185",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "encoding/asn1: Parsing DER payload can cause memory exhaustion in encoding/asn1",
-              "Description": "Parsing a maliciously crafted DER payload could allocate large amounts of memory, causing memory exhaustion."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58186",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "golang.org/net/http: Lack of limit when parsing cookies can cause memory exhaustion in net/http",
-              "Description": "Despite HTTP headers having a default limit of 1MB, the number of cookies that can be parsed does not have a limit. By sending a lot of very small cookies such as \"a=;\", an attacker can make an HTTP server allocate a large amount of structs, causing large memory consumption."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58187",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.9, 1.25.3",
-              "Severity": "MEDIUM",
-              "Title": "crypto/x509: Quadratic complexity when checking name constraints in crypto/x509",
-              "Description": "Due to the design of the name constraint checking algorithm, the processing time of some inputs scale non-linearly with respect to the size of the certificate. This affects programs which validate arbitrary certificate chains."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58188",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "crypto/x509: golang: Panic when validating certificates with DSA public keys in crypto/x509",
-              "Description": "Validating certificate chains which contain DSA public keys can cause programs to panic, due to a interface cast that assumes they implement the Equal method. This affects programs which validate arbitrary certificate chains."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-58189",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "crypto/tls: go crypto/tls ALPN negotiation error contains attacker controlled information",
-              "Description": "When Conn.Handshake fails during ALPN negotiation the error contains attacker controlled information (the ALPN protocols sent by the client) which is not escaped."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61723",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "encoding/pem: Quadratic complexity when parsing some invalid inputs in encoding/pem",
-              "Description": "The processing time for parsing some invalid inputs scales non-linearly with respect to the size of the input. This affects programs which parse untrusted PEM inputs."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61724",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "net/textproto: Excessive CPU consumption in Reader.ReadResponse in net/textproto",
-              "Description": "The Reader.ReadResponse function constructs a response string through repeated string concatenation of lines. When the number of lines in a response is large, this can cause excessive CPU consumption."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61725",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.8, 1.25.2",
-              "Severity": "MEDIUM",
-              "Title": "net/mail: Excessive CPU consumption in ParseAddress in net/mail",
-              "Description": "The ParseAddress function constructs domain-literal address components through repeated string concatenation. When parsing large domain-literal components, this can cause excessive CPU consumption."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61727",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.11, 1.25.5",
-              "Severity": "MEDIUM",
-              "Title": "golang: crypto/x509: excluded subdomain constraint does not restrict wildcard SANs",
-              "Description": "An excluded subdomain constraint in a certificate chain does not restrict the usage of wildcard SANs in the leaf certificate. For example a constraint that excludes the subdomain test.example.com does not prevent a leaf certificate from claiming the SAN *.example.com."
-            },
-            {
-              "VulnerabilityID": "CVE-2025-61730",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.24.12, 1.25.6",
-              "Severity": "MEDIUM",
-              "Title": "During the TLS 1.3 handshake if multiple messages are sent in records  ...",
-              "Description": "During the TLS 1.3 handshake if multiple messages are sent in records that span encryption level boundaries (for instance the Client Hello and Encrypted Extensions messages), the subsequent messages may be processed before the encryption level changes. This can cause some minor information disclosure if a network-local attacker can inject messages during the handshake."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27142",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "MEDIUM",
-              "Title": "html/template: URLs in meta content attribute actions are not escaped in html/template",
-              "Description": "Actions which insert URLs into the content attribute of HTML meta tags are not escaped. This can allow XSS if the meta tag also has an http-equiv attribute with the value \"refresh\". A new GODEBUG setting has been added, htmlmetacontenturlescape, which can be used to disable escaping URLs in actions in the meta content attribute which follow \"url=\" by setting htmlmetacontenturlescape=0."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27139",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.22.10",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "LOW",
-              "Title": "os: FileInfo can escape from a Root in golang os module",
-              "Description": "On Unix platforms, when listing the contents of a directory using File.ReadDir or File.Readdir the returned FileInfo could reference a file outside of the Root in which the File was opened. The impact of this escape is limited to reading metadata provided by lstat from arbitrary locations on the filesystem without permitting reading or writing files outside the root."
-            }
-          ],
-          "Secrets": null
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
         },
         {
-          "Target": "usr/local/bin/trivy",
-          "Vulnerabilities": [
-            {
-              "VulnerabilityID": "CVE-2025-15558",
-              "PkgName": "github.com/docker/cli",
-              "InstalledVersion": "v29.1.1+incompatible",
-              "FixedVersion": "29.2.0",
-              "Severity": "HIGH",
-              "Title": "docker/cli: Docker CLI for Windows: Privilege escalation via malicious plugin binaries",
-              "Description": "Docker CLI for Windows searches for plugin binaries in C:\\ProgramData\\Docker\\cli-plugins, a directory that does not exist by default. A low-privileged attacker can create this directory and place malicious CLI plugin binaries (docker-compose.exe, docker-buildx.exe, etc.) that are executed when a victim user opens Docker Desktop or invokes Docker CLI plugin features, and allow privilege-escalation if the docker CLI is executed as a privileged user.\n\nThis issue affects Docker CLI: through 29.1.5 and Windows binaries acting as a CLI-plugin manager using the  github.com/docker/cli/cli-plugins/manager https://pkg.go.dev/github.com/docker/cli@v29.1.5+incompatible/cli-plugins/manager  package, such as Docker Compose.\n\nThis issue does not impact non-Windows binaries, and projects not using the plugin-manager code."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-33186",
-              "PkgName": "google.golang.org/grpc",
-              "InstalledVersion": "v1.78.0",
-              "FixedVersion": "1.79.3",
-              "Severity": "CRITICAL",
-              "Title": "gRPC-Go has an authorization bypass via missing leading slash in :path",
-              "Description": "### Impact\n_What kind of vulnerability is it? Who is impacted?_\n\nIt is an **Authorization Bypass** resulting from **Improper Input Validation** of the HTTP/2 `:path` pseudo-header.\n\nThe gRPC-Go server was too lenient in its routing logic, accepting requests where the `:path` omitted the mandatory leading slash (e.g., `Service/Method` instead of `/Service/Method`). While the server successfully routed these requests to the correct handler, authorization interceptors (including the official `grpc/authz` package) evaluated the raw, non-canonical path string. Consequently, \"deny\" rules defined using canonical paths (starting with `/`) failed to match the incoming request, allowing it to bypass the policy if a fallback \"allow\" rule was present.\n\n**Who is impacted?**\nThis affects gRPC-Go servers that meet both of the following criteria:\n1. They use path-based authorization interceptors, such as the official RBAC implementation in `google.golang.org/grpc/authz` or custom interceptors relying on `info.FullMethod` or `grpc.Method(ctx)`.\n2. Their security policy contains specific \"deny\" rules for canonical paths but allows other requests by default (a fallback \"allow\" rule).\n\nThe vulnerability is exploitable by an attacker who can send raw HTTP/2 frames with malformed `:path` headers directly to the gRPC server.\n\n### Patches\n_Has the problem been patched? What versions should users upgrade to?_\n\nYes, the issue has been patched. The fix ensures that any request with a `:path` that does not start with a leading slash is immediately rejected with a `codes.Unimplemented` error, preventing it from reaching authorization interceptors or handlers with a non-canonical path string.\n\nUsers should upgrade to the following versions (or newer):\n* **v1.79.3**\n* The latest **master** branch.\n\nIt is recommended that all users employing path-based authorization (especially `grpc/authz`) upgrade as soon as the patch is available in a tagged release.\n\n### Workarounds\n_Is there a way for users to fix or remediate the vulnerability without upgrading?_\n\nWhile upgrading is the most secure and recommended path, users can mitigate the vulnerability using one of the following methods:\n\n#### 1. Use a Validating Interceptor (Recommended Mitigation)\nAdd an \"outermost\" interceptor to your server that validates the path before any other authorization logic runs:\n\n```go\nfunc pathValidationInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {\n    if info.FullMethod == \"\" || info.FullMethod[0] != '/' {\n        return nil, status.Errorf(codes.Unimplemented, \"malformed method name\")\n    }   \n    return handler(ctx, req)\n}\n\n// Ensure this is the FIRST interceptor in your chain\ns := grpc.NewServer(\n    grpc.ChainUnaryInterceptor(pathValidationInterceptor, authzInterceptor),\n)\n```\n\n#### 2. Infrastructure-Level Normalization\nIf your gRPC server is behind a reverse proxy or load balancer (such as Envoy, NGINX, or an L7 Cloud Load Balancer), ensure it is configured to enforce strict HTTP/2 compliance for pseudo-headers and reject or normalize requests where the `:path` header does not start with a leading slash.\n\n#### 3. Policy Hardening\nSwitch to a \"default deny\" posture in your authorization policies (explicitly listing all allowed paths and denying everything else) to reduce the risk of bypasses via malformed inputs."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-25679",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.25.7",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "HIGH",
-              "Title": "net/url: Incorrect parsing of IPv6 host literals in net/url",
-              "Description": "url.Parse insufficiently validated the host/authority component and accepted some invalid URLs."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27142",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.25.7",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "MEDIUM",
-              "Title": "html/template: URLs in meta content attribute actions are not escaped in html/template",
-              "Description": "Actions which insert URLs into the content attribute of HTML meta tags are not escaped. This can allow XSS if the meta tag also has an http-equiv attribute with the value \"refresh\". A new GODEBUG setting has been added, htmlmetacontenturlescape, which can be used to disable escaping URLs in actions in the meta content attribute which follow \"url=\" by setting htmlmetacontenturlescape=0."
-            },
-            {
-              "VulnerabilityID": "CVE-2026-27139",
-              "PkgName": "stdlib",
-              "InstalledVersion": "v1.25.7",
-              "FixedVersion": "1.25.8, 1.26.1",
-              "Severity": "LOW",
-              "Title": "os: FileInfo can escape from a Root in golang os module",
-              "Description": "On Unix platforms, when listing the contents of a directory using File.ReadDir or File.Readdir the returned FileInfo could reference a file outside of the Root in which the File was opened. The impact of this escape is limited to reading metadata provided by lstat from arbitrary locations on the filesystem without permitting reading or writing files outside the root."
-            }
-          ],
-          "Secrets": null
+          "platform": "linux/arm/v6",
+          "compressed_bytes": 954372,
+          "compressed_human": "932.0 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/arm/v7",
+          "compressed_bytes": 1593372,
+          "compressed_human": "1.5 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/arm64/v8",
+          "compressed_bytes": 1901182,
+          "compressed_human": "1.8 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/386",
+          "compressed_bytes": 2286260,
+          "compressed_human": "2.2 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/ppc64le",
+          "compressed_bytes": 2526228,
+          "compressed_human": "2.4 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 3371,
+          "compressed_human": "3.3 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/riscv64",
+          "compressed_bytes": 1942635,
+          "compressed_human": "1.9 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
+        },
+        {
+          "platform": "linux/s390x",
+          "compressed_bytes": 2048251,
+          "compressed_human": "2.0 MB",
+          "layer_count": 1
+        },
+        {
+          "platform": "unknown/unknown",
+          "compressed_bytes": 2193,
+          "compressed_human": "2.1 KB",
+          "layer_count": 1
         }
       ]
-    },
-    "versioning": {
-      "analyzer": "versioning",
-      "repository": "trivoallan/regis-cli",
-      "total_tags": 117,
-      "dominant_pattern": "named",
-      "semver_compliant_percentage": 18.8,
-      "patterns": [
-        {
-          "pattern": "named",
-          "count": 79,
-          "percentage": 67.5,
-          "examples": [
-            "latest",
-            "main",
-            "sha-08211a2",
-            "sha-11fde48",
-            "sha-15794ab",
-            "sha-1664655",
-            "sha-194d574",
-            "sha-1baea9a",
-            "sha-1ee30bb",
-            "sha-21b7549"
-          ]
-        },
-        {
-          "pattern": "numeric",
-          "count": 16,
-          "percentage": 13.7,
-          "examples": [
-            "0.10",
-            "0.11",
-            "0.12",
-            "0.13",
-            "0.14",
-            "0.15",
-            "0.16",
-            "0.17",
-            "0.18",
-            "0.2"
-          ]
-        },
-        {
-          "pattern": "semver",
-          "count": 22,
-          "percentage": 18.8,
-          "examples": [
-            "0.10.0",
-            "0.11.0",
-            "0.12.0",
-            "0.13.0",
-            "0.14.0",
-            "0.14.1",
-            "0.14.2",
-            "0.15.0",
-            "0.16.0",
-            "0.17.0"
-          ]
-        }
-      ],
-      "variants": [],
-      "release_lines": []
     }
   },
   "rules": [
+    {
+      "slug": "cve-critical",
+      "description": "Max allowed violations for a given severity level.",
+      "level": "critical",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "Number of critical vulnerabilities is within limits.",
+      "analyzers": ["trivy"]
+    },
     {
       "slug": "env-blacklist",
       "description": "Image must not contain forbidden environment variables.",
@@ -8752,7 +839,7 @@
       "tags": ["security"],
       "passed": true,
       "status": "passed",
-      "message": "Image registry domain 'ghcr.io' is in the domains list.",
+      "message": "Image registry domain 'registry-1.docker.io' is in the domains list.",
       "analyzers": []
     },
     {
@@ -8766,14 +853,24 @@
       "analyzers": ["trivy"]
     },
     {
-      "slug": "user-blacklist",
-      "description": "Image must not run as root.",
-      "level": "critical",
+      "slug": "cve-fixable",
+      "description": "All vulnerabilities should be fixed if a patch exists.",
+      "level": "warning",
       "tags": ["security"],
       "passed": true,
       "status": "passed",
-      "message": "Image does not run as 'root'.",
-      "analyzers": ["skopeo"]
+      "message": "All vulnerabilities with available fixes have been patched.",
+      "analyzers": ["trivy"]
+    },
+    {
+      "slug": "cve-high",
+      "description": "Max allowed violations for a given severity level.",
+      "level": "warning",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "Number of high vulnerabilities is within limits.",
+      "analyzers": ["trivy"]
     },
     {
       "slug": "exposed-ports-whitelist",
@@ -8786,23 +883,13 @@
       "analyzers": ["skopeo"]
     },
     {
-      "slug": "has-sbom",
-      "description": "Image must provide a Software Bill of Materials.",
-      "level": "warning",
-      "tags": ["compliance"],
-      "passed": true,
-      "status": "passed",
-      "message": "SBOM is available for this image.",
-      "analyzers": ["sbom"]
-    },
-    {
       "slug": "layers-count",
       "description": "Image has an acceptable number of layers.",
       "level": "warning",
       "tags": ["performance"],
       "passed": true,
       "status": "passed",
-      "message": "Image has 14 layers.",
+      "message": "Image has 1 layers.",
       "analyzers": ["skopeo"]
     },
     {
@@ -8816,44 +903,14 @@
       "analyzers": ["skopeo"]
     },
     {
-      "slug": "required-labels",
-      "description": "Image must have required OCI labels.",
+      "slug": "severity-count",
+      "description": "Max allowed issues for a given severity level.",
       "level": "warning",
-      "tags": ["metadata"],
+      "tags": ["security"],
       "passed": true,
       "status": "passed",
-      "message": "All required labels are present.",
-      "analyzers": ["skopeo"]
-    },
-    {
-      "slug": "tag-blacklist",
-      "description": "Image tag should not be 'latest'.",
-      "level": "warning",
-      "tags": ["lifecycle"],
-      "passed": true,
-      "status": "passed",
-      "message": "Image tag is not 'latest'.",
-      "analyzers": []
-    },
-    {
-      "slug": "age",
-      "description": "Image should be less than expected days old.",
-      "level": "info",
-      "tags": ["freshness"],
-      "passed": true,
-      "status": "passed",
-      "message": "Image is less than 90 days old (0 days).",
-      "analyzers": ["freshness"]
-    },
-    {
-      "slug": "no-latest",
-      "description": "Image tag should not be 'latest'.",
-      "level": "info",
-      "tags": ["lifecycle"],
-      "passed": true,
-      "status": "passed",
-      "message": "Image tag is not 'latest'.",
-      "analyzers": []
+      "message": "Dockle FATAL issues are within limits.",
+      "analyzers": ["dockle"]
     },
     {
       "slug": "platforms-count",
@@ -8862,68 +919,28 @@
       "tags": ["compatibility"],
       "passed": true,
       "status": "passed",
-      "message": "Image supports 2 platforms.",
+      "message": "Image supports 17 platforms.",
       "analyzers": ["skopeo"]
     },
     {
-      "slug": "cve-critical",
-      "description": "Max allowed violations for a given severity level.",
-      "level": "critical",
-      "tags": ["security"],
+      "slug": "has-sbom",
+      "description": "Image must provide a Software Bill of Materials.",
+      "level": "warning",
+      "tags": ["compliance"],
       "passed": false,
       "status": "failed",
-      "message": "Image has 2 critical CVEs (max allowed: 0).",
-      "analyzers": ["trivy"]
+      "message": "No SBOM could be generated or found for this image.",
+      "analyzers": ["sbom"]
     },
     {
-      "slug": "cve-count",
-      "description": "Max allowed violations for a given severity level.",
+      "slug": "required-labels",
+      "description": "Image must have required OCI labels.",
       "level": "warning",
-      "tags": ["security"],
+      "tags": ["metadata"],
       "passed": false,
       "status": "failed",
-      "message": "Image has 2 critical CVEs (max allowed: 0).",
-      "analyzers": ["trivy"]
-    },
-    {
-      "slug": "cve-fixable",
-      "description": "All vulnerabilities should be fixed if a patch exists.",
-      "level": "warning",
-      "tags": ["security"],
-      "passed": false,
-      "status": "failed",
-      "message": "Image has 39 vulnerabilities with available fixes.",
-      "analyzers": ["trivy"]
-    },
-    {
-      "slug": "cve-high",
-      "description": "Max allowed violations for a given severity level.",
-      "level": "warning",
-      "tags": ["security"],
-      "passed": false,
-      "status": "failed",
-      "message": "Image has 19 high CVEs (max allowed: 10).",
-      "analyzers": ["trivy"]
-    },
-    {
-      "slug": "fix-available",
-      "description": "All vulnerabilities should be fixed if a patch exists.",
-      "level": "warning",
-      "tags": ["security"],
-      "passed": false,
-      "status": "failed",
-      "message": "Image has 39 vulnerabilities with available fixes.",
-      "analyzers": ["trivy"]
-    },
-    {
-      "slug": "min-score",
-      "description": "OpenSSF Scorecard score is above the threshold.",
-      "level": "warning",
-      "tags": ["security"],
-      "passed": false,
-      "status": "incomplete",
-      "message": "Scorecard score is too low: None (min required: 5.0).",
-      "analyzers": ["scorecarddev"]
+      "message": "Image is missing one or more required labels: ['org.opencontainers.image.source'].",
+      "analyzers": ["skopeo"]
     },
     {
       "slug": "scorecard-min",
@@ -8937,16 +954,6 @@
     },
     {
       "slug": "severity-count",
-      "description": "Max allowed issues for a given severity level.",
-      "level": "warning",
-      "tags": ["security"],
-      "passed": false,
-      "status": "incomplete",
-      "message": "Dockle found MISSING FATAL issues (max allowed: 0).",
-      "analyzers": ["dockle"]
-    },
-    {
-      "slug": "severity-count",
       "description": "Max allowed violations for a given severity level.",
       "level": "warning",
       "tags": ["best-practices"],
@@ -8954,83 +961,90 @@
       "status": "failed",
       "message": "Hadolint found 1 error issues (max allowed: 0).",
       "analyzers": ["hadolint"]
+    },
+    {
+      "slug": "age",
+      "description": "Image should be less than expected days old.",
+      "level": "info",
+      "tags": ["freshness"],
+      "passed": false,
+      "status": "failed",
+      "message": "Image is older than 90 days (548 days).",
+      "analyzers": ["freshness"]
+    },
+    {
+      "slug": "no-latest",
+      "description": "Image tag should not be 'latest'.",
+      "level": "info",
+      "tags": ["lifecycle"],
+      "passed": false,
+      "status": "failed",
+      "message": "Image is using the 'latest' tag. Use immutable version tags instead.",
+      "analyzers": []
     }
   ],
   "rules_summary": {
-    "score": 61,
+    "score": 67,
     "total": [
+      "cve-critical",
       "env-blacklist",
       "no-root",
       "registry-domain-whitelist",
       "secret-scan",
-      "user-blacklist",
-      "exposed-ports-whitelist",
-      "has-sbom",
-      "layers-count",
-      "max-size",
-      "required-labels",
-      "tag-blacklist",
-      "age",
-      "no-latest",
-      "platforms-count",
-      "cve-critical",
-      "cve-count",
       "cve-fixable",
       "cve-high",
-      "fix-available",
-      "min-score",
+      "exposed-ports-whitelist",
+      "layers-count",
+      "max-size",
+      "severity-count",
+      "platforms-count",
+      "has-sbom",
+      "required-labels",
       "scorecard-min",
       "severity-count",
-      "severity-count"
+      "age",
+      "no-latest"
     ],
     "passed": [
+      "cve-critical",
       "env-blacklist",
       "no-root",
       "registry-domain-whitelist",
       "secret-scan",
-      "user-blacklist",
+      "cve-fixable",
+      "cve-high",
       "exposed-ports-whitelist",
-      "has-sbom",
       "layers-count",
       "max-size",
-      "required-labels",
-      "tag-blacklist",
-      "age",
-      "no-latest",
+      "severity-count",
       "platforms-count"
     ],
     "by_tag": {
       "security": {
         "rules": [
+          "cve-critical",
           "env-blacklist",
           "no-root",
           "registry-domain-whitelist",
           "secret-scan",
-          "user-blacklist",
-          "exposed-ports-whitelist",
-          "cve-critical",
-          "cve-count",
           "cve-fixable",
           "cve-high",
-          "fix-available",
-          "min-score",
-          "scorecard-min",
-          "severity-count"
+          "exposed-ports-whitelist",
+          "severity-count",
+          "scorecard-min"
         ],
         "passed_rules": [
+          "cve-critical",
           "env-blacklist",
           "no-root",
           "registry-domain-whitelist",
           "secret-scan",
-          "user-blacklist",
-          "exposed-ports-whitelist"
+          "cve-fixable",
+          "cve-high",
+          "exposed-ports-whitelist",
+          "severity-count"
         ],
-        "score": 43
-      },
-      "compliance": {
-        "rules": ["has-sbom"],
-        "passed_rules": ["has-sbom"],
-        "score": 100
+        "score": 90
       },
       "performance": {
         "rules": ["layers-count"],
@@ -9042,28 +1056,33 @@
         "passed_rules": ["max-size"],
         "score": 100
       },
-      "metadata": {
-        "rules": ["required-labels"],
-        "passed_rules": ["required-labels"],
-        "score": 100
-      },
-      "lifecycle": {
-        "rules": ["tag-blacklist", "no-latest"],
-        "passed_rules": ["tag-blacklist", "no-latest"],
-        "score": 100
-      },
-      "freshness": {
-        "rules": ["age"],
-        "passed_rules": ["age"],
-        "score": 100
-      },
       "compatibility": {
         "rules": ["platforms-count"],
         "passed_rules": ["platforms-count"],
         "score": 100
       },
+      "compliance": {
+        "rules": ["has-sbom"],
+        "passed_rules": [],
+        "score": 0
+      },
+      "metadata": {
+        "rules": ["required-labels"],
+        "passed_rules": [],
+        "score": 0
+      },
       "best-practices": {
         "rules": ["severity-count"],
+        "passed_rules": [],
+        "score": 0
+      },
+      "freshness": {
+        "rules": ["age"],
+        "passed_rules": [],
+        "score": 0
+      },
+      "lifecycle": {
+        "rules": ["no-latest"],
         "passed_rules": [],
         "score": 0
       }
@@ -9077,6 +1096,16 @@
       "passed_scorecards": 0,
       "pages": [],
       "rules": [
+        {
+          "slug": "cve-critical",
+          "description": "Max allowed violations for a given severity level.",
+          "level": "critical",
+          "tags": ["security"],
+          "passed": true,
+          "status": "passed",
+          "message": "Number of critical vulnerabilities is within limits.",
+          "analyzers": ["trivy"]
+        },
         {
           "slug": "env-blacklist",
           "description": "Image must not contain forbidden environment variables.",
@@ -9104,7 +1133,7 @@
           "tags": ["security"],
           "passed": true,
           "status": "passed",
-          "message": "Image registry domain 'ghcr.io' is in the domains list.",
+          "message": "Image registry domain 'registry-1.docker.io' is in the domains list.",
           "analyzers": []
         },
         {
@@ -9118,14 +1147,24 @@
           "analyzers": ["trivy"]
         },
         {
-          "slug": "user-blacklist",
-          "description": "Image must not run as root.",
-          "level": "critical",
+          "slug": "cve-fixable",
+          "description": "All vulnerabilities should be fixed if a patch exists.",
+          "level": "warning",
           "tags": ["security"],
           "passed": true,
           "status": "passed",
-          "message": "Image does not run as 'root'.",
-          "analyzers": ["skopeo"]
+          "message": "All vulnerabilities with available fixes have been patched.",
+          "analyzers": ["trivy"]
+        },
+        {
+          "slug": "cve-high",
+          "description": "Max allowed violations for a given severity level.",
+          "level": "warning",
+          "tags": ["security"],
+          "passed": true,
+          "status": "passed",
+          "message": "Number of high vulnerabilities is within limits.",
+          "analyzers": ["trivy"]
         },
         {
           "slug": "exposed-ports-whitelist",
@@ -9138,23 +1177,13 @@
           "analyzers": ["skopeo"]
         },
         {
-          "slug": "has-sbom",
-          "description": "Image must provide a Software Bill of Materials.",
-          "level": "warning",
-          "tags": ["compliance"],
-          "passed": true,
-          "status": "passed",
-          "message": "SBOM is available for this image.",
-          "analyzers": ["sbom"]
-        },
-        {
           "slug": "layers-count",
           "description": "Image has an acceptable number of layers.",
           "level": "warning",
           "tags": ["performance"],
           "passed": true,
           "status": "passed",
-          "message": "Image has 14 layers.",
+          "message": "Image has 1 layers.",
           "analyzers": ["skopeo"]
         },
         {
@@ -9168,44 +1197,14 @@
           "analyzers": ["skopeo"]
         },
         {
-          "slug": "required-labels",
-          "description": "Image must have required OCI labels.",
+          "slug": "severity-count",
+          "description": "Max allowed issues for a given severity level.",
           "level": "warning",
-          "tags": ["metadata"],
+          "tags": ["security"],
           "passed": true,
           "status": "passed",
-          "message": "All required labels are present.",
-          "analyzers": ["skopeo"]
-        },
-        {
-          "slug": "tag-blacklist",
-          "description": "Image tag should not be 'latest'.",
-          "level": "warning",
-          "tags": ["lifecycle"],
-          "passed": true,
-          "status": "passed",
-          "message": "Image tag is not 'latest'.",
-          "analyzers": []
-        },
-        {
-          "slug": "age",
-          "description": "Image should be less than expected days old.",
-          "level": "info",
-          "tags": ["freshness"],
-          "passed": true,
-          "status": "passed",
-          "message": "Image is less than 90 days old (0 days).",
-          "analyzers": ["freshness"]
-        },
-        {
-          "slug": "no-latest",
-          "description": "Image tag should not be 'latest'.",
-          "level": "info",
-          "tags": ["lifecycle"],
-          "passed": true,
-          "status": "passed",
-          "message": "Image tag is not 'latest'.",
-          "analyzers": []
+          "message": "Dockle FATAL issues are within limits.",
+          "analyzers": ["dockle"]
         },
         {
           "slug": "platforms-count",
@@ -9214,68 +1213,28 @@
           "tags": ["compatibility"],
           "passed": true,
           "status": "passed",
-          "message": "Image supports 2 platforms.",
+          "message": "Image supports 17 platforms.",
           "analyzers": ["skopeo"]
         },
         {
-          "slug": "cve-critical",
-          "description": "Max allowed violations for a given severity level.",
-          "level": "critical",
-          "tags": ["security"],
+          "slug": "has-sbom",
+          "description": "Image must provide a Software Bill of Materials.",
+          "level": "warning",
+          "tags": ["compliance"],
           "passed": false,
           "status": "failed",
-          "message": "Image has 2 critical CVEs (max allowed: 0).",
-          "analyzers": ["trivy"]
+          "message": "No SBOM could be generated or found for this image.",
+          "analyzers": ["sbom"]
         },
         {
-          "slug": "cve-count",
-          "description": "Max allowed violations for a given severity level.",
+          "slug": "required-labels",
+          "description": "Image must have required OCI labels.",
           "level": "warning",
-          "tags": ["security"],
+          "tags": ["metadata"],
           "passed": false,
           "status": "failed",
-          "message": "Image has 2 critical CVEs (max allowed: 0).",
-          "analyzers": ["trivy"]
-        },
-        {
-          "slug": "cve-fixable",
-          "description": "All vulnerabilities should be fixed if a patch exists.",
-          "level": "warning",
-          "tags": ["security"],
-          "passed": false,
-          "status": "failed",
-          "message": "Image has 39 vulnerabilities with available fixes.",
-          "analyzers": ["trivy"]
-        },
-        {
-          "slug": "cve-high",
-          "description": "Max allowed violations for a given severity level.",
-          "level": "warning",
-          "tags": ["security"],
-          "passed": false,
-          "status": "failed",
-          "message": "Image has 19 high CVEs (max allowed: 10).",
-          "analyzers": ["trivy"]
-        },
-        {
-          "slug": "fix-available",
-          "description": "All vulnerabilities should be fixed if a patch exists.",
-          "level": "warning",
-          "tags": ["security"],
-          "passed": false,
-          "status": "failed",
-          "message": "Image has 39 vulnerabilities with available fixes.",
-          "analyzers": ["trivy"]
-        },
-        {
-          "slug": "min-score",
-          "description": "OpenSSF Scorecard score is above the threshold.",
-          "level": "warning",
-          "tags": ["security"],
-          "passed": false,
-          "status": "incomplete",
-          "message": "Scorecard score is too low: None (min required: 5.0).",
-          "analyzers": ["scorecarddev"]
+          "message": "Image is missing one or more required labels: ['org.opencontainers.image.source'].",
+          "analyzers": ["skopeo"]
         },
         {
           "slug": "scorecard-min",
@@ -9289,16 +1248,6 @@
         },
         {
           "slug": "severity-count",
-          "description": "Max allowed issues for a given severity level.",
-          "level": "warning",
-          "tags": ["security"],
-          "passed": false,
-          "status": "incomplete",
-          "message": "Dockle found MISSING FATAL issues (max allowed: 0).",
-          "analyzers": ["dockle"]
-        },
-        {
-          "slug": "severity-count",
           "description": "Max allowed violations for a given severity level.",
           "level": "warning",
           "tags": ["best-practices"],
@@ -9306,83 +1255,90 @@
           "status": "failed",
           "message": "Hadolint found 1 error issues (max allowed: 0).",
           "analyzers": ["hadolint"]
+        },
+        {
+          "slug": "age",
+          "description": "Image should be less than expected days old.",
+          "level": "info",
+          "tags": ["freshness"],
+          "passed": false,
+          "status": "failed",
+          "message": "Image is older than 90 days (548 days).",
+          "analyzers": ["freshness"]
+        },
+        {
+          "slug": "no-latest",
+          "description": "Image tag should not be 'latest'.",
+          "level": "info",
+          "tags": ["lifecycle"],
+          "passed": false,
+          "status": "failed",
+          "message": "Image is using the 'latest' tag. Use immutable version tags instead.",
+          "analyzers": []
         }
       ],
       "rules_summary": {
-        "score": 61,
+        "score": 67,
         "total": [
+          "cve-critical",
           "env-blacklist",
           "no-root",
           "registry-domain-whitelist",
           "secret-scan",
-          "user-blacklist",
-          "exposed-ports-whitelist",
-          "has-sbom",
-          "layers-count",
-          "max-size",
-          "required-labels",
-          "tag-blacklist",
-          "age",
-          "no-latest",
-          "platforms-count",
-          "cve-critical",
-          "cve-count",
           "cve-fixable",
           "cve-high",
-          "fix-available",
-          "min-score",
+          "exposed-ports-whitelist",
+          "layers-count",
+          "max-size",
+          "severity-count",
+          "platforms-count",
+          "has-sbom",
+          "required-labels",
           "scorecard-min",
           "severity-count",
-          "severity-count"
+          "age",
+          "no-latest"
         ],
         "passed": [
+          "cve-critical",
           "env-blacklist",
           "no-root",
           "registry-domain-whitelist",
           "secret-scan",
-          "user-blacklist",
+          "cve-fixable",
+          "cve-high",
           "exposed-ports-whitelist",
-          "has-sbom",
           "layers-count",
           "max-size",
-          "required-labels",
-          "tag-blacklist",
-          "age",
-          "no-latest",
+          "severity-count",
           "platforms-count"
         ],
         "by_tag": {
           "security": {
             "rules": [
+              "cve-critical",
               "env-blacklist",
               "no-root",
               "registry-domain-whitelist",
               "secret-scan",
-              "user-blacklist",
-              "exposed-ports-whitelist",
-              "cve-critical",
-              "cve-count",
               "cve-fixable",
               "cve-high",
-              "fix-available",
-              "min-score",
-              "scorecard-min",
-              "severity-count"
+              "exposed-ports-whitelist",
+              "severity-count",
+              "scorecard-min"
             ],
             "passed_rules": [
+              "cve-critical",
               "env-blacklist",
               "no-root",
               "registry-domain-whitelist",
               "secret-scan",
-              "user-blacklist",
-              "exposed-ports-whitelist"
+              "cve-fixable",
+              "cve-high",
+              "exposed-ports-whitelist",
+              "severity-count"
             ],
-            "score": 43
-          },
-          "compliance": {
-            "rules": ["has-sbom"],
-            "passed_rules": ["has-sbom"],
-            "score": 100
+            "score": 90
           },
           "performance": {
             "rules": ["layers-count"],
@@ -9394,28 +1350,33 @@
             "passed_rules": ["max-size"],
             "score": 100
           },
-          "metadata": {
-            "rules": ["required-labels"],
-            "passed_rules": ["required-labels"],
-            "score": 100
-          },
-          "lifecycle": {
-            "rules": ["tag-blacklist", "no-latest"],
-            "passed_rules": ["tag-blacklist", "no-latest"],
-            "score": 100
-          },
-          "freshness": {
-            "rules": ["age"],
-            "passed_rules": ["age"],
-            "score": 100
-          },
           "compatibility": {
             "rules": ["platforms-count"],
             "passed_rules": ["platforms-count"],
             "score": 100
           },
+          "compliance": {
+            "rules": ["has-sbom"],
+            "passed_rules": [],
+            "score": 0
+          },
+          "metadata": {
+            "rules": ["required-labels"],
+            "passed_rules": [],
+            "score": 0
+          },
           "best-practices": {
             "rules": ["severity-count"],
+            "passed_rules": [],
+            "score": 0
+          },
+          "freshness": {
+            "rules": ["age"],
+            "passed_rules": [],
+            "score": 0
+          },
+          "lifecycle": {
+            "rules": ["no-latest"],
             "passed_rules": [],
             "score": 0
           }
@@ -9425,25 +1386,11 @@
       "tier": "Bronze",
       "badges": [
         {
-          "slug": "cve-critical",
-          "scope": "CVE",
-          "value": "Critical",
-          "class": "error",
-          "label": "CVE: Critical"
-        },
-        {
-          "slug": "cve-high",
-          "scope": "CVE",
-          "value": "High",
-          "class": "warning",
-          "label": "CVE: High"
-        },
-        {
-          "slug": "freshness-fresh",
+          "slug": "freshness-stale",
           "scope": "Freshness",
-          "value": "Fresh",
-          "class": "success",
-          "label": "Freshness: Fresh"
+          "value": "Stale",
+          "class": "warning",
+          "label": "Freshness: Stale"
         }
       ],
       "mr_description_checklists": [
@@ -9456,7 +1403,7 @@
             },
             {
               "label": "Aucune vulnérabilité CRITIQUE détectée",
-              "checked": false
+              "checked": true
             },
             {
               "label": "Image issue d'un registre de confiance",
@@ -9488,6 +1435,16 @@
     "pages": [],
     "rules": [
       {
+        "slug": "cve-critical",
+        "description": "Max allowed violations for a given severity level.",
+        "level": "critical",
+        "tags": ["security"],
+        "passed": true,
+        "status": "passed",
+        "message": "Number of critical vulnerabilities is within limits.",
+        "analyzers": ["trivy"]
+      },
+      {
         "slug": "env-blacklist",
         "description": "Image must not contain forbidden environment variables.",
         "level": "critical",
@@ -9514,7 +1471,7 @@
         "tags": ["security"],
         "passed": true,
         "status": "passed",
-        "message": "Image registry domain 'ghcr.io' is in the domains list.",
+        "message": "Image registry domain 'registry-1.docker.io' is in the domains list.",
         "analyzers": []
       },
       {
@@ -9528,14 +1485,24 @@
         "analyzers": ["trivy"]
       },
       {
-        "slug": "user-blacklist",
-        "description": "Image must not run as root.",
-        "level": "critical",
+        "slug": "cve-fixable",
+        "description": "All vulnerabilities should be fixed if a patch exists.",
+        "level": "warning",
         "tags": ["security"],
         "passed": true,
         "status": "passed",
-        "message": "Image does not run as 'root'.",
-        "analyzers": ["skopeo"]
+        "message": "All vulnerabilities with available fixes have been patched.",
+        "analyzers": ["trivy"]
+      },
+      {
+        "slug": "cve-high",
+        "description": "Max allowed violations for a given severity level.",
+        "level": "warning",
+        "tags": ["security"],
+        "passed": true,
+        "status": "passed",
+        "message": "Number of high vulnerabilities is within limits.",
+        "analyzers": ["trivy"]
       },
       {
         "slug": "exposed-ports-whitelist",
@@ -9548,23 +1515,13 @@
         "analyzers": ["skopeo"]
       },
       {
-        "slug": "has-sbom",
-        "description": "Image must provide a Software Bill of Materials.",
-        "level": "warning",
-        "tags": ["compliance"],
-        "passed": true,
-        "status": "passed",
-        "message": "SBOM is available for this image.",
-        "analyzers": ["sbom"]
-      },
-      {
         "slug": "layers-count",
         "description": "Image has an acceptable number of layers.",
         "level": "warning",
         "tags": ["performance"],
         "passed": true,
         "status": "passed",
-        "message": "Image has 14 layers.",
+        "message": "Image has 1 layers.",
         "analyzers": ["skopeo"]
       },
       {
@@ -9578,44 +1535,14 @@
         "analyzers": ["skopeo"]
       },
       {
-        "slug": "required-labels",
-        "description": "Image must have required OCI labels.",
+        "slug": "severity-count",
+        "description": "Max allowed issues for a given severity level.",
         "level": "warning",
-        "tags": ["metadata"],
+        "tags": ["security"],
         "passed": true,
         "status": "passed",
-        "message": "All required labels are present.",
-        "analyzers": ["skopeo"]
-      },
-      {
-        "slug": "tag-blacklist",
-        "description": "Image tag should not be 'latest'.",
-        "level": "warning",
-        "tags": ["lifecycle"],
-        "passed": true,
-        "status": "passed",
-        "message": "Image tag is not 'latest'.",
-        "analyzers": []
-      },
-      {
-        "slug": "age",
-        "description": "Image should be less than expected days old.",
-        "level": "info",
-        "tags": ["freshness"],
-        "passed": true,
-        "status": "passed",
-        "message": "Image is less than 90 days old (0 days).",
-        "analyzers": ["freshness"]
-      },
-      {
-        "slug": "no-latest",
-        "description": "Image tag should not be 'latest'.",
-        "level": "info",
-        "tags": ["lifecycle"],
-        "passed": true,
-        "status": "passed",
-        "message": "Image tag is not 'latest'.",
-        "analyzers": []
+        "message": "Dockle FATAL issues are within limits.",
+        "analyzers": ["dockle"]
       },
       {
         "slug": "platforms-count",
@@ -9624,68 +1551,28 @@
         "tags": ["compatibility"],
         "passed": true,
         "status": "passed",
-        "message": "Image supports 2 platforms.",
+        "message": "Image supports 17 platforms.",
         "analyzers": ["skopeo"]
       },
       {
-        "slug": "cve-critical",
-        "description": "Max allowed violations for a given severity level.",
-        "level": "critical",
-        "tags": ["security"],
+        "slug": "has-sbom",
+        "description": "Image must provide a Software Bill of Materials.",
+        "level": "warning",
+        "tags": ["compliance"],
         "passed": false,
         "status": "failed",
-        "message": "Image has 2 critical CVEs (max allowed: 0).",
-        "analyzers": ["trivy"]
+        "message": "No SBOM could be generated or found for this image.",
+        "analyzers": ["sbom"]
       },
       {
-        "slug": "cve-count",
-        "description": "Max allowed violations for a given severity level.",
+        "slug": "required-labels",
+        "description": "Image must have required OCI labels.",
         "level": "warning",
-        "tags": ["security"],
+        "tags": ["metadata"],
         "passed": false,
         "status": "failed",
-        "message": "Image has 2 critical CVEs (max allowed: 0).",
-        "analyzers": ["trivy"]
-      },
-      {
-        "slug": "cve-fixable",
-        "description": "All vulnerabilities should be fixed if a patch exists.",
-        "level": "warning",
-        "tags": ["security"],
-        "passed": false,
-        "status": "failed",
-        "message": "Image has 39 vulnerabilities with available fixes.",
-        "analyzers": ["trivy"]
-      },
-      {
-        "slug": "cve-high",
-        "description": "Max allowed violations for a given severity level.",
-        "level": "warning",
-        "tags": ["security"],
-        "passed": false,
-        "status": "failed",
-        "message": "Image has 19 high CVEs (max allowed: 10).",
-        "analyzers": ["trivy"]
-      },
-      {
-        "slug": "fix-available",
-        "description": "All vulnerabilities should be fixed if a patch exists.",
-        "level": "warning",
-        "tags": ["security"],
-        "passed": false,
-        "status": "failed",
-        "message": "Image has 39 vulnerabilities with available fixes.",
-        "analyzers": ["trivy"]
-      },
-      {
-        "slug": "min-score",
-        "description": "OpenSSF Scorecard score is above the threshold.",
-        "level": "warning",
-        "tags": ["security"],
-        "passed": false,
-        "status": "incomplete",
-        "message": "Scorecard score is too low: None (min required: 5.0).",
-        "analyzers": ["scorecarddev"]
+        "message": "Image is missing one or more required labels: ['org.opencontainers.image.source'].",
+        "analyzers": ["skopeo"]
       },
       {
         "slug": "scorecard-min",
@@ -9699,16 +1586,6 @@
       },
       {
         "slug": "severity-count",
-        "description": "Max allowed issues for a given severity level.",
-        "level": "warning",
-        "tags": ["security"],
-        "passed": false,
-        "status": "incomplete",
-        "message": "Dockle found MISSING FATAL issues (max allowed: 0).",
-        "analyzers": ["dockle"]
-      },
-      {
-        "slug": "severity-count",
         "description": "Max allowed violations for a given severity level.",
         "level": "warning",
         "tags": ["best-practices"],
@@ -9716,83 +1593,90 @@
         "status": "failed",
         "message": "Hadolint found 1 error issues (max allowed: 0).",
         "analyzers": ["hadolint"]
+      },
+      {
+        "slug": "age",
+        "description": "Image should be less than expected days old.",
+        "level": "info",
+        "tags": ["freshness"],
+        "passed": false,
+        "status": "failed",
+        "message": "Image is older than 90 days (548 days).",
+        "analyzers": ["freshness"]
+      },
+      {
+        "slug": "no-latest",
+        "description": "Image tag should not be 'latest'.",
+        "level": "info",
+        "tags": ["lifecycle"],
+        "passed": false,
+        "status": "failed",
+        "message": "Image is using the 'latest' tag. Use immutable version tags instead.",
+        "analyzers": []
       }
     ],
     "rules_summary": {
-      "score": 61,
+      "score": 67,
       "total": [
+        "cve-critical",
         "env-blacklist",
         "no-root",
         "registry-domain-whitelist",
         "secret-scan",
-        "user-blacklist",
-        "exposed-ports-whitelist",
-        "has-sbom",
-        "layers-count",
-        "max-size",
-        "required-labels",
-        "tag-blacklist",
-        "age",
-        "no-latest",
-        "platforms-count",
-        "cve-critical",
-        "cve-count",
         "cve-fixable",
         "cve-high",
-        "fix-available",
-        "min-score",
+        "exposed-ports-whitelist",
+        "layers-count",
+        "max-size",
+        "severity-count",
+        "platforms-count",
+        "has-sbom",
+        "required-labels",
         "scorecard-min",
         "severity-count",
-        "severity-count"
+        "age",
+        "no-latest"
       ],
       "passed": [
+        "cve-critical",
         "env-blacklist",
         "no-root",
         "registry-domain-whitelist",
         "secret-scan",
-        "user-blacklist",
+        "cve-fixable",
+        "cve-high",
         "exposed-ports-whitelist",
-        "has-sbom",
         "layers-count",
         "max-size",
-        "required-labels",
-        "tag-blacklist",
-        "age",
-        "no-latest",
+        "severity-count",
         "platforms-count"
       ],
       "by_tag": {
         "security": {
           "rules": [
+            "cve-critical",
             "env-blacklist",
             "no-root",
             "registry-domain-whitelist",
             "secret-scan",
-            "user-blacklist",
-            "exposed-ports-whitelist",
-            "cve-critical",
-            "cve-count",
             "cve-fixable",
             "cve-high",
-            "fix-available",
-            "min-score",
-            "scorecard-min",
-            "severity-count"
+            "exposed-ports-whitelist",
+            "severity-count",
+            "scorecard-min"
           ],
           "passed_rules": [
+            "cve-critical",
             "env-blacklist",
             "no-root",
             "registry-domain-whitelist",
             "secret-scan",
-            "user-blacklist",
-            "exposed-ports-whitelist"
+            "cve-fixable",
+            "cve-high",
+            "exposed-ports-whitelist",
+            "severity-count"
           ],
-          "score": 43
-        },
-        "compliance": {
-          "rules": ["has-sbom"],
-          "passed_rules": ["has-sbom"],
-          "score": 100
+          "score": 90
         },
         "performance": {
           "rules": ["layers-count"],
@@ -9804,28 +1688,33 @@
           "passed_rules": ["max-size"],
           "score": 100
         },
-        "metadata": {
-          "rules": ["required-labels"],
-          "passed_rules": ["required-labels"],
-          "score": 100
-        },
-        "lifecycle": {
-          "rules": ["tag-blacklist", "no-latest"],
-          "passed_rules": ["tag-blacklist", "no-latest"],
-          "score": 100
-        },
-        "freshness": {
-          "rules": ["age"],
-          "passed_rules": ["age"],
-          "score": 100
-        },
         "compatibility": {
           "rules": ["platforms-count"],
           "passed_rules": ["platforms-count"],
           "score": 100
         },
+        "compliance": {
+          "rules": ["has-sbom"],
+          "passed_rules": [],
+          "score": 0
+        },
+        "metadata": {
+          "rules": ["required-labels"],
+          "passed_rules": [],
+          "score": 0
+        },
         "best-practices": {
           "rules": ["severity-count"],
+          "passed_rules": [],
+          "score": 0
+        },
+        "freshness": {
+          "rules": ["age"],
+          "passed_rules": [],
+          "score": 0
+        },
+        "lifecycle": {
+          "rules": ["no-latest"],
           "passed_rules": [],
           "score": 0
         }
@@ -9835,25 +1724,11 @@
     "tier": "Bronze",
     "badges": [
       {
-        "slug": "cve-critical",
-        "scope": "CVE",
-        "value": "Critical",
-        "class": "error",
-        "label": "CVE: Critical"
-      },
-      {
-        "slug": "cve-high",
-        "scope": "CVE",
-        "value": "High",
-        "class": "warning",
-        "label": "CVE: High"
-      },
-      {
-        "slug": "freshness-fresh",
+        "slug": "freshness-stale",
         "scope": "Freshness",
-        "value": "Fresh",
-        "class": "success",
-        "label": "Freshness: Fresh"
+        "value": "Stale",
+        "class": "warning",
+        "label": "Freshness: Stale"
       }
     ],
     "mr_description_checklists": [
@@ -9866,7 +1741,7 @@
           },
           {
             "label": "Aucune vulnérabilité CRITIQUE détectée",
-            "checked": false
+            "checked": true
           },
           {
             "label": "Image issue d'un registre de confiance",
@@ -9888,29 +1763,5 @@
     "_meta": {
       "source_name": "default"
     }
-  },
-  "tier": "Bronze",
-  "badges": [
-    {
-      "slug": "cve-critical",
-      "scope": "CVE",
-      "value": "Critical",
-      "class": "error",
-      "label": "CVE: Critical"
-    },
-    {
-      "slug": "cve-high",
-      "scope": "CVE",
-      "value": "High",
-      "class": "warning",
-      "label": "CVE: High"
-    },
-    {
-      "slug": "freshness-fresh",
-      "scope": "Freshness",
-      "value": "Fresh",
-      "class": "success",
-      "label": "Freshness: Fresh"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `?report=<url>` query parameter support: the same built report viewer can now display any `report.json` hosted at an arbitrary URL
- Adds a **Load URL** button in the navbar that opens a dialog to enter the URL (pre-filled with the current `?report=` value if any)
- Cross-origin URLs require the remote server to send appropriate `Access-Control-Allow-Origin` headers

## Test plan

- [x] Build the report viewer: `pnpm --filter report-viewer build`
- [x] Serve and open with `?report=<url>` — verify the remote report loads
- [x] Open without the param — verify the default `report.json` still loads
- [x] Open the "Load URL" button in the navbar, enter a URL, submit — verify navigation to `?report=<url>`
- [x] Submit an empty URL — verify it navigates back to the base page

🤖 Generated with [Claude Code](https://claude.com/claude-code)