### PR TITLE
ci(docs): replace direct push with PR for automated doc updates

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -157,16 +157,18 @@ jobs:
             docs/website/versioned_sidebars/**
             docs/website/versions.json
 
-      - name: Enable Auto-Merge
+      - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
 
       - name: Deploy docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           publish_dir: docs/website/build
           destination_dir: docs
           keep_files: true

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -132,6 +132,7 @@ jobs:
         working-directory: docs/website
 
       - name: Create Pull Request for documentation updates
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -155,6 +156,12 @@ jobs:
             docs/website/versioned_docs/**
             docs/website/versioned_sidebars/**
             docs/website/versions.json
+
+      - name: Enable Auto-Merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Deploy docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           ref: main
           fetch-depth: 0
 
@@ -97,6 +98,8 @@ jobs:
           # Copy all schemas first to allow cross-category resolution
           mkdir -p docs/website/static/schemas
           cp -rv regis_cli/schemas/* docs/website/static/schemas/
+          # Clean up any non-JSON files (like __init__.py) inadvertently copied
+          find docs/website/static/schemas/ -type f ! -name "*.json" -delete
 
           for cat in $(find regis_cli/schemas/* -maxdepth 0 -type d); do
             cat=$(basename $cat);
@@ -128,15 +131,27 @@ jobs:
         run: pnpm run build
         working-directory: docs/website
 
-      - name: Commit versioned docs snapshot
-        if: github.event_name == 'release'
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create Pull Request for documentation updates
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: "docs: snapshot versioned docs for ${{ github.event.release.tag_name }}"
-          commit_user_name: github-actions[bot]
-          commit_user_email: github-actions[bot]@users.noreply.github.com
-          commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          file_pattern: >-
+          token: ${{ secrets.RELEASE_TOKEN }}
+          commit-message: "docs: update documentation reference and snapshots"
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          branch: docs/automated-updates
+          delete-branch: true
+          title: "docs: update documentation reference and snapshots"
+          body: |
+            Automated documentation updates:
+            - Generated latest JSON Schema reference
+            - Generated latest Rules reference
+            ${{ github.event_name == 'release' && '- Created Docusaurus version snapshot' || '' }}
+
+            This PR ensures the documentation reflects the latest codebase.
+          add-paths: |
+            docs/website/docs/reference/rules/**
+            docs/website/docs/reference/schemas/**
+            docs/website/static/schemas/**
             docs/website/versioned_docs/**
             docs/website/versioned_sidebars/**
             docs/website/versions.json

--- a/docs/website/docs/usage/getting-started.md
+++ b/docs/website/docs/usage/getting-started.md
@@ -37,3 +37,7 @@ pip install regis-cli
 For developers wanting to contribute to the project, use **Pipenv**:
 `pipenv install --dev`
 :::
+
+## GitHub Repository Configuration
+
+If you plan to use automated documentation snapshots or the archive feature on a GitHub repository with protected branches, ensure that the **"Allow auto-merge"** option is enabled in your repository's general settings. This allows the automated workflows to synchronize documentation safely without manual intervention on every update.

--- a/docs/website/docs/usage/getting-started.md
+++ b/docs/website/docs/usage/getting-started.md
@@ -40,4 +40,4 @@ For developers wanting to contribute to the project, use **Pipenv**:
 
 ## GitHub Repository Configuration
 
-If you plan to use automated documentation snapshots or the archive feature on a GitHub repository with protected branches, ensure that the **"Allow auto-merge"** option is enabled in your repository's general settings. This allows the automated workflows to synchronize documentation safely without manual intervention on every update.
+If you plan to use automated documentation snapshots or the archive feature on a GitHub repository with protected branches, ensure that the **"Allow auto-merge"** option is enabled in your repository's general settings. This allows the automated workflows to synchronize documentation safely without manual intervention on every update. See the [GitHub Actions integration guide](./integrations/github.md) for more details.

--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -8,6 +8,8 @@ To follow this guide, you should have a GitHub repository with a `Dockerfile` an
 
 :::tip
 To quickly bootstrap a new GitHub repository pre-configured with `regis-cli` and GitHub Actions, you can use our [Project Bootstrapping](../../reference/cli.md#bootstrap) command.
+
+**Note**: For repositories with branch protection, please ensure the **"Allow auto-merge"** option is enabled in the repository's general settings to support automated documentation updates.
 :::
 
 ## Workflow Setup


### PR DESCRIPTION
This PR fixes the docs-publish workflow by replacing the failing direct push to main (blocked by branch protection) with a Pull Request creation using peter-evans/create-pull-request. It also uses RELEASE_TOKEN to ensure the resulting PR triggers the CI.