### PR TITLE
chore(ci): use actions/create-github-app-token consistently across all workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,8 +22,17 @@ jobs:
       packages: write
 
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,17 +17,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Checkout PR branch
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
         with:
           ref: ${{ fromJson(steps.release.outputs.pr).head_branch }}
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install Trunk
         if: ${{ steps.release.outputs.pr }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,17 @@ jobs:
     name: pytest
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/viewer-publish.yml
+++ b/.github/workflows/viewer-publish.yml
@@ -27,9 +27,17 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           ref: main
           fetch-depth: 0
 
@@ -82,7 +90,7 @@ jobs:
       - name: Deploy Viewer to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ steps.generate-token.outputs.token }}
           publish_dir: apps/report-viewer/build
           destination_dir: ${{ steps.meta.outputs.deploy_path }}
           keep_files: true


### PR DESCRIPTION
## Summary

- Adds `actions/create-github-app-token@v1` to all remaining workflows (`test`, `docker-publish`, `viewer-publish`, `release-please`)
- Replaces `secrets.RELEASE_TOKEN` (PAT) in `release-please.yml` with the App token
- Replaces `github_token` with `personal_token` in `peaceiris/actions-gh-pages` in `viewer-publish.yml`
- All workflows now use a single consistent authentication mechanism (regis-ci GitHub App)

## Why

Centralising on the GitHub App token ensures:
- Pushes and PR creations trigger new workflow runs (unlike `GITHUB_TOKEN`)
- No PATs to rotate or manage
- Consistent with `docs-publish.yml` and `trunk.yml` which were already migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)