### PR TITLE
fix(ci): use personal_token for peaceiris/actions-gh-pages in docs-publish

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Deploy docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ steps.generate-token.outputs.token }}
+          personal_token: ${{ steps.generate-token.outputs.token }}
           publish_dir: docs/website/build
           destination_dir: docs
           keep_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,9 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). A
 
 ## CI/CD
 
+- **GitHub App authentication**: All workflows use `actions/create-github-app-token@v1` with secrets `REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`. Never use `GITHUB_TOKEN` for checkouts that need to trigger downstream CI runs — it won't.
+- **`peaceiris/actions-gh-pages` with App token**: use `personal_token:`, not `github_token:`.
+- **Trunk auto-fmt in CI**: The trunk workflow commits formatting fixes using `stefanzweifel/git-auto-commit-action`. The checkout must use the App token so the auto-commit triggers a new workflow run.
 - Use **GitHub Actions** and [Release Please](https://github.com/googleapis/release-please).
 - GitHub project configuration as code via the [GitHub Settings App](https://github.com/apps/settings).
 - [Semantic Versioning](https://semver.org/).


### PR DESCRIPTION
## Summary

- Fixes `docs-publish.yml`: changes `github_token:` to `personal_token:` for `peaceiris/actions-gh-pages`
- `github_token:` only accepts `GITHUB_TOKEN` — passing a GitHub App token through it uses the wrong credentials
- Documents this gotcha in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)