### PR TITLE
feat(ci): add auto-rebase and auto-merge workflows for PRs

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -1,0 +1,30 @@
+name: Enable auto-merge on PRs
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  automerge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -1,0 +1,27 @@
+name: Auto-rebase PRs
+
+on:
+  push:
+    branches: [main]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REGIS_CI_APP_ID }}
+          private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
+
+      - uses: peter-evans/rebase@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          exclude-drafts: true

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -166,14 +166,6 @@ jobs:
             docs/website/versioned_sidebars/**
             docs/website/versions.json
 
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
-
       - name: Deploy docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
## Summary

- **`auto-rebase-prs.yml`**: On every push to `main`, rebases all open non-draft PR branches using [`peter-evans/rebase@v4`](https://github.com/peter-evans/rebase). Keeps PR branches up to date automatically.
- **`auto-merge-prs.yml`**: When a non-draft PR is opened or marked ready for review, enables GitHub's native auto-merge (squash) via [`peter-evans/enable-pull-request-automerge@v3`](https://github.com/peter-evans/enable-pull-request-automerge). The PR merges automatically once all required checks pass.

Both use the GitHub App token so triggered commits fire downstream CI runs.

## Notes

- Auto-merge respects branch protection rules — won't merge until checks pass and reviews are approved
- Draft PRs are excluded from both workflows
- `peter-evans/rebase` requires the GitHub App to have `workflows` write permission if a PR branch modifies workflow files; conflicting PRs are skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)