### PR TITLE
chore(deps): add dependabot configuration for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /apps/report-viewer
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /docs/website
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly update schedules for:
  - `pip` — Python dependencies (Pipfile)
  - `npm` — `apps/report-viewer`
  - `npm` — `docs/website`
  - `docker` — `Dockerfile`
  - `github-actions` — workflow action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)