### PR TITLE
fix(ci): fall back to github.token when App secrets unavailable (dependabot PRs)

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
@@ -25,6 +26,6 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
@@ -30,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
@@ -36,7 +37,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
           fetch-depth: 0
 
       - name: Trunk Install


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the Generate GitHub App token step in all `pull_request`-triggered workflows
- Falls back to `github.token` via `steps.generate-token.outputs.token || github.token` when the App token step fails (e.g. Dependabot PRs where secrets are unavailable)
- Fixes https://github.com/trivoallan/regis-cli/actions/runs/23754764044/job/69206344128

## Root cause

Dependabot PRs run without access to repository secrets. `actions/create-github-app-token` throws `Input required and not supplied: app-id` and the workflow fails before any real work runs.

Note: `secrets` context is not available in step `if:` conditions (actionlint enforces this), so `continue-on-error` is the correct pattern.

## Affected workflows

- `trunk.yml`
- `test.yml`
- `auto-merge-prs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)