### PR TITLE
fix(ci): remove broken @dependabot rebase comment approach

### DIFF
--- a/.github/workflows/auto-rebase-prs.yml
+++ b/.github/workflows/auto-rebase-prs.yml
@@ -29,26 +29,3 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           exclude-drafts: true
-          exclude-labels: dependencies
-
-      - name: Rebase Dependabot PRs
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-            });
-            for (const pr of prs) {
-              if (pr.user.login === 'dependabot[bot]' && !pr.draft) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body: '@dependabot rebase',
-                });
-                core.info(`Requested rebase for Dependabot PR #${pr.number} (${pr.title})`);
-              }
-            }


### PR DESCRIPTION
## Summary
- Drops the `github-script` step that posted `@dependabot rebase` comments — GitHub Apps cannot trigger Dependabot commands (error: "only users with push access can use that command")
- Removes the `exclude-labels: dependencies` filter — `peter-evans/rebase@v4` now handles all open non-draft PRs uniformly, including Dependabot branches

Auto-merge for Dependabot PRs is already covered by `auto-merge-prs.yml` via the `|| github.token` fallback.

## Test plan
- [ ] Merge to main, verify the auto-rebase workflow runs without errors
- [ ] Confirm Dependabot PRs are rebased by `peter-evans/rebase@v4` on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)