### PR TITLE
fix(ci): use pull_request_target so auto-merge works on Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -1,7 +1,7 @@
 name: Enable auto-merge on PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 env:
@@ -17,7 +17,6 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
@@ -26,6 +25,6 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ steps.generate-token.outputs.token || github.token }}
+          token: ${{ steps.generate-token.outputs.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash


### PR DESCRIPTION
## Summary
- Changes the trigger from `pull_request` to `pull_request_target`
- Drops `continue-on-error` and `|| github.token` fallback (no longer needed)

## Why

With `pull_request`, Dependabot PRs run with a **read-only** `GITHUB_TOKEN` and **no secret access**. The App token step silently fails with `continue-on-error: true`, and the Enable auto-merge step is then skipped entirely — auto-merge is never enabled.

`pull_request_target` runs the workflow in the **base-branch context** with full secret access, so the App token is generated and auto-merge is enabled correctly. This is safe because we never check out or execute code from the PR branch.

## Test plan
- [ ] Merge to main, verify a Dependabot PR gets the auto-merge icon in the GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)