### PR TITLE
fix(ci): skip auto-merge for release-please PRs

### DIFF
--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -12,7 +12,9 @@ permissions:
 
 jobs:
   automerge:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
## Summary
- Excludes PRs labelled `autorelease: pending` from the auto-merge job so release-please PRs are never merged automatically

## Test plan
- [ ] Verify the release-please PR (#101) does not get auto-merge enabled after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)