### PR TITLE
test(cli): enforce 90% unit test coverage permanently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,28 @@ jobs:
 
       - name: Run pytest
         run: pipenv run pytest
+
+      - name: Generate coverage badge
+        if: always()
+        continue-on-error: true
+        run: pipenv run genbadge coverage -i coverage.xml -o coverage-badge.svg
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            htmlcov/
+            coverage-badge.svg
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Commit coverage badge
+        if: github.ref == 'refs/heads/main' && hashFiles('coverage-badge.svg') != ''
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "ci(cli): update coverage badge"
+          file_pattern: coverage-badge.svg
+          commit_user_name: regis-ci[bot]
+          commit_user_email: regis-ci[bot]@users.noreply.github.com

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # IDE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 ```bash
 pipenv install --dev        # Install all dependencies
-pipenv run pytest           # Run test suite
+pipenv run pytest           # Run tests with coverage (fails if < 90%)
+pipenv run pytest --no-cov  # Run tests without coverage check
 pipenv run ruff check .     # Lint
 pipenv run ruff format .    # Format
 pipenv run regis-cli --help # Run CLI locally

--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ urllib3 = ">=1.26.0,<3"
 pytest = ">=7.4"
 pytest-cov = ">=4.1"
 responses = ">=0.24"
+genbadge = {extras = ["coverage"], version = ">=1.1"}
 ruff = "*"
 jsonschema2md = "*"
 types-PyYAML = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e8758c040cea57026eb4063e58bb4b3dce641c1f03a420ee791133283ca83667"
+            "sha256": "3b5b55e83e96bd028d8a50cc9403352c84f64e16bba29ce686dc5374e9f25456"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -447,7 +447,6 @@
                 "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
                 "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.20.0"
         },
@@ -461,12 +460,12 @@
         },
         "python-gitlab": {
             "hashes": [
-                "sha256:660f15e3f889ec430797d260322bc61d90f8d90accfc10ba37593b11aed371bd",
-                "sha256:b1a59e81e5e0363185b446a707dc92c27ee8bf1fc14ce75ed8eafa58cbdce63a"
+                "sha256:884618d4d60beadb21bb0c5f0cca46e70c6e501784f136bf0b6f85f5bc15ce62",
+                "sha256:de874dc538db6dceb48929f4c8fb55d6064dd19cb3ffdad1100190f835c5b674"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==8.1.0"
+            "version": "==8.2.0"
         },
         "python-slugify": {
             "hashes": [
@@ -578,12 +577,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b",
-                "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652"
+                "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517",
+                "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==2.33.0"
+            "version": "==2.33.1"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -940,6 +939,15 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.4.6"
         },
+        "click": {
+            "hashes": [
+                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
+                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==8.3.1"
+        },
         "coverage": {
             "extras": [
                 "toml"
@@ -1055,6 +1063,24 @@
             "markers": "python_version >= '3.10'",
             "version": "==7.13.5"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
+                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.7.1"
+        },
+        "genbadge": {
+            "extras": [
+                "coverage"
+            ],
+            "hashes": [
+                "sha256:2292ea9cc20af4463dfde952c6b15544fdab9d6e50945f63a42cc400c521fa74",
+                "sha256:6e4316c171c6f0f84becae4eb116258340bdc054458632abc622d36b8040655e"
+            ],
+            "version": "==1.1.3"
+        },
         "idna": {
             "hashes": [
                 "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
@@ -1095,6 +1121,103 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==26.0"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9",
+                "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da",
+                "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f",
+                "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642",
+                "sha256:178aa072084bd88ec759052feca8e56cbb14a60b39322b99a049e58090479713",
+                "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850",
+                "sha256:1a9b0ee305220b392e1124a764ee4265bd063e54a751a6b62eff69992f457fa9",
+                "sha256:1f1625b72740fdda5d77b4def688eb8fd6490975d06b909fd19f13f391e077e0",
+                "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9",
+                "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8",
+                "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6",
+                "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd",
+                "sha256:2c1fc0f2ca5f96a3c8407e41cca26a16e46b21060fe6d5b099d2cb01412222f5",
+                "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c",
+                "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35",
+                "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1",
+                "sha256:36341d06738a9f66c8287cf8b876d24b18db9bd8740fa0672c74e259ad408cff",
+                "sha256:365b10bb9417dd4498c0e3b128018c4a624dc11c7b97d8cc54effe3b096f4c38",
+                "sha256:3a5cbdcddad0af3da87cb16b60d23648bc3b51967eb07223e9fed77a82b457c4",
+                "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af",
+                "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60",
+                "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986",
+                "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13",
+                "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717",
+                "sha256:495c302af3aad1ca67420ddd5c7bd480c8867ad173528767d906428057a11f0e",
+                "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b",
+                "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15",
+                "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a",
+                "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb",
+                "sha256:578510d88c6229d735855e1f278aa305270438d36a05031dfaae5067cc8eb04d",
+                "sha256:597bd9c8419bc7c6af5604e55847789b69123bbe25d65cc6ad3012b4f3c98d8b",
+                "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e",
+                "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a",
+                "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f",
+                "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a",
+                "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce",
+                "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc",
+                "sha256:600fd103672b925fe62ed08e0d874ea34d692474df6f4bf7ebe148b30f89f39f",
+                "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586",
+                "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f",
+                "sha256:665e1b916b043cef294bc54d47bf02d87e13f769bc4bc5fa225a24b3a6c5aca9",
+                "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8",
+                "sha256:6c52f062424c523d6c4db85518774cc3d50f5539dd6eed32b8f6229b26f24d40",
+                "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60",
+                "sha256:7311c0a0dcadb89b36b7025dfd8326ecfa36964e29913074d47382706e516a7c",
+                "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0",
+                "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334",
+                "sha256:7e7976bf1910a8116b523b9f9f58bf410f3e8aa330cd9a2bb2953f9266ab49af",
+                "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735",
+                "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524",
+                "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf",
+                "sha256:89c7e895002bbe49cdc5426150377cbbc04767d7547ed145473f496dfa40408b",
+                "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2",
+                "sha256:8fd420ef0c52c88b5a035a0886f367748c72147b2b8f384c9d12656678dfdfa9",
+                "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7",
+                "sha256:99c1506ea77c11531d75e3a412832a13a71c7ebc8192ab9e4b2e355555920e3e",
+                "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4",
+                "sha256:9f51079765661884a486727f0729d29054242f74b46186026582b4e4769918e4",
+                "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b",
+                "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397",
+                "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c",
+                "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e",
+                "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029",
+                "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3",
+                "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052",
+                "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984",
+                "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293",
+                "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523",
+                "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f",
+                "sha256:b66e95d05ba806247aaa1561f080abc7975daf715c30780ff92a20e4ec546e1b",
+                "sha256:b81b5e3511211631b3f672a595e3221252c90af017e399056d0faabb9538aa80",
+                "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f",
+                "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79",
+                "sha256:c6008de247150668a705a6338156efb92334113421ceecf7438a12c9a12dab23",
+                "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8",
+                "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e",
+                "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3",
+                "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e",
+                "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36",
+                "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f",
+                "sha256:d4ce8e329c93845720cd2014659ca67eac35f6433fd3050393d85f3ecef0dad5",
+                "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f",
+                "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6",
+                "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32",
+                "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20",
+                "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202",
+                "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0",
+                "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3",
+                "sha256:fbfa2a7c10cc2623f412753cddf391c7f971c52ca40a3f65dc5039b2939e8563",
+                "sha256:fc354a04072b765eccf2204f588a7a532c9511e8b9c7f900e1b64e3e33487090",
+                "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==12.1.1"
         },
         "pluggy": {
             "hashes": [
@@ -1215,17 +1338,18 @@
                 "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa",
                 "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==0.36.2"
         },
         "requests": {
             "hashes": [
-                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
-                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+                "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517",
+                "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==2.32.5"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.33.1"
         },
         "responses": {
             "hashes": [
@@ -1382,6 +1506,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.15.8"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9",
+                "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==82.0.1"
+        },
         "types-jsonschema": {
             "hashes": [
                 "sha256:032a952fd32d9e06b71bdce5a5b4005dd58a074f6cb2899e96b633cbe1c28f40",
@@ -1414,6 +1546,7 @@
                 "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
                 "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.6.3"
         }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # regis-cli
 
+![Coverage](./coverage-badge.svg)
+
 `regis-cli` is a **Container Security & Policy-as-Code Orchestration**. It provides unified analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD.
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ hadolint = "regis_cli.analyzers.hadolint:HadolintAnalyzer"
 dockle = "regis_cli.analyzers.dockle:DockleAnalyzer"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "pytest-cov>=4.1", "responses>=0.24"]
+dev = ["pytest>=7.4", "pytest-cov>=4.1", "responses>=0.24", "genbadge[coverage]>=1.1"]
 
 [tool.setuptools.packages.find]
 include = ["regis_cli*"]
@@ -61,6 +61,24 @@ regis_cli = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--cov=regis_cli --cov-report=term-missing --cov-report=html --cov-report=xml --cov-fail-under=90"
+
+[tool.coverage.run]
+source = ["regis_cli"]
+omit = [
+  "regis_cli/cookiecutters/*",
+  "regis_cli/viewer_assets/*",
+]
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "@(abc\\.)?abstractmethod",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,12 @@ hadolint = "regis_cli.analyzers.hadolint:HadolintAnalyzer"
 dockle = "regis_cli.analyzers.dockle:DockleAnalyzer"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "pytest-cov>=4.1", "responses>=0.24", "genbadge[coverage]>=1.1"]
+dev = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "responses>=0.24",
+  "genbadge[coverage]>=1.1",
+]
 
 [tool.setuptools.packages.find]
 include = ["regis_cli*"]
@@ -65,10 +70,7 @@ addopts = "--cov=regis_cli --cov-report=term-missing --cov-report=html --cov-rep
 
 [tool.coverage.run]
 source = ["regis_cli"]
-omit = [
-  "regis_cli/cookiecutters/*",
-  "regis_cli/viewer_assets/*",
-]
+omit = ["regis_cli/cookiecutters/*", "regis_cli/viewer_assets/*"]
 
 [tool.coverage.report]
 fail_under = 90

--- a/regis_cli/commands/viewer.py
+++ b/regis_cli/commands/viewer.py
@@ -75,7 +75,7 @@ def export_cmd(output: Path, report: Path | None = None) -> None:
     default=8000,
     help="Port to listen on (default: 8000).",
 )
-def serve_cmd(port: int, report: Path | None = None) -> None:
+def serve_cmd(port: int, report: Path | None = None) -> None:  # pragma: no cover
     """Serve the static React viewer and preview the report locally."""
     assets_dir = get_viewer_assets_dir()
 

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from regis_cli.analyzers.base import AnalyzerError
@@ -14,6 +16,36 @@ from regis_cli.analyzers.skopeo import SkopeoAnalyzer
 # ---------------------------------------------------------------------------
 # Schema validation — negative tests
 # ---------------------------------------------------------------------------
+
+
+class TestDiscoverAnalyzers:
+    """Tests for discover_analyzers()."""
+
+    def test_skips_failed_entry_points(self) -> None:
+        """A broken entry point is logged and skipped, not raised."""
+        from regis_cli.analyzers.discovery import discover_analyzers
+
+        bad_ep = MagicMock()
+        bad_ep.name = "broken"
+        bad_ep.load.side_effect = ImportError("missing dep")
+
+        with patch("regis_cli.analyzers.discovery.entry_points", return_value=[bad_ep]):
+            result = discover_analyzers()
+
+        assert "broken" not in result
+
+
+class TestRunCmd:
+    """Tests for utils/process.run_cmd()."""
+
+    def test_file_not_found_raises_click_exception(self) -> None:
+        import click
+
+        from regis_cli.utils.process import run_cmd
+
+        with patch("regis_cli.utils.process.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(click.ClickException, match="not found in PATH"):
+                run_cmd(["nonexistent-binary", "--version"])
 
 
 class TestSchemaValidation:

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -43,7 +43,9 @@ class TestRunCmd:
 
         from regis_cli.utils.process import run_cmd
 
-        with patch("regis_cli.utils.process.subprocess.run", side_effect=FileNotFoundError):
+        with patch(
+            "regis_cli.utils.process.subprocess.run", side_effect=FileNotFoundError
+        ):
             with pytest.raises(click.ClickException, match="not found in PATH"):
                 run_cmd(["nonexistent-binary", "--version"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,3 +335,129 @@ class TestCliCheck:
         result = runner.invoke(main, ["check", "https://not-a-registry"])
 
         assert result.exit_code != 0
+
+
+class TestEvaluateCmd:
+    """Tests for the `evaluate` subcommand."""
+
+    def test_evaluate_basic(self, tmp_path):
+        report = {
+            "version": "0.22.0",
+            "request": {
+                "url": "nginx:latest",
+                "registry": "registry-1.docker.io",
+                "repository": "library/nginx",
+                "tag": "latest",
+                "digest": "latest",
+                "analyzers": [],
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "results": {},
+        }
+        report_file = tmp_path / "report.json"
+        report_file.write_text(json.dumps(report))
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["evaluate", str(report_file)])
+        assert result.exit_code == 0
+
+    def test_evaluate_missing_results_key(self, tmp_path):
+        bad_report = {"version": "0.22.0", "not_results": {}}
+        report_file = tmp_path / "bad.json"
+        report_file.write_text(json.dumps(bad_report))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["evaluate", str(report_file)])
+        assert result.exit_code != 0
+        assert "missing 'results'" in result.output
+
+    def test_evaluate_invalid_json(self, tmp_path):
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not valid json {{{")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["evaluate", str(bad_file)])
+        assert result.exit_code != 0
+        assert "Failed to load" in result.output
+
+
+class TestAnalyzeCacheAndFail:
+    """Tests for --cache and --fail options of the `analyze` command."""
+
+    @patch("regis_cli.commands.analyze.RegistryClient")
+    def test_analyze_cache_hit_skips_analyzers(self, mock_client):
+        mock_client.return_value.get_digest.return_value = "sha256:abc123"
+        cached_report = {
+            "version": "0.22.0",
+            "request": {
+                "url": "nginx:latest",
+                "registry": "registry-1.docker.io",
+                "repository": "library/nginx",
+                "tag": "latest",
+                "digest": "sha256-abc123",
+                "analyzers": [],
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "results": {},
+        }
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            cache_dir = Path("reports/registry-1.docker.io/library-nginx/sha256-abc123")
+            cache_dir.mkdir(parents=True)
+            (cache_dir / "report.json").write_text(json.dumps(cached_report))
+
+            result = runner.invoke(main, ["analyze", "nginx:latest", "--cache"])
+
+        assert result.exit_code == 0
+        assert "cached" in result.output
+
+    @patch("regis_cli.commands.analyze.render_mr_templates")
+    @patch("regis_cli.commands.analyze.render_and_save_reports")
+    @patch("regis_cli.commands.analyze.validate_report")
+    @patch("regis_cli.commands.analyze.run_playbooks")
+    @patch("regis_cli.commands.analyze.RegistryClient")
+    @patch("regis_cli.commands.analyze._discover_analyzers")
+    def test_analyze_fail_exits_on_breached_rules(
+        self,
+        mock_discover,
+        mock_client,
+        mock_playbooks,
+        mock_validate,
+        mock_render,
+        mock_mr,
+    ):
+        from regis_cli.analyzers.base import BaseAnalyzer
+
+        class DummyAnalyzer(BaseAnalyzer):
+            def analyze(self, client, repo, tag, platform=None):
+                return {"analyzer": "dummy"}
+
+            def validate(self, report):
+                pass
+
+        mock_discover.return_value = {"dummy": DummyAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
+        mock_playbooks.return_value = {
+            "version": "0.22.0",
+            "request": {},
+            "results": {},
+            "playbooks": [
+                {
+                    "rules": [{"passed": False, "level": "critical", "slug": "rule-x"}],
+                    "rules_summary": {},
+                    "tier": None,
+                    "badges": [],
+                }
+            ],
+            "rules": [{"passed": False, "level": "critical", "slug": "rule-x"}],
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                main, ["analyze", "nginx:latest", "--evaluate", "--fail"]
+            )
+
+        assert result.exit_code == 1
+        assert "rule breaches" in result.output

--- a/tests/test_docusaurus.py
+++ b/tests/test_docusaurus.py
@@ -1,0 +1,137 @@
+"""Tests for report/docusaurus.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from regis_cli.report.docusaurus import build_report_site
+
+
+class TestBuildReportSite:
+    """Tests for build_report_site()."""
+
+    def test_viewer_dir_not_found_raises(self, tmp_path: Path) -> None:
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
+            with pytest.raises(RuntimeError, match="Report viewer app not found"):
+                build_report_site({"key": "val"}, tmp_path / "output")
+
+    def test_no_package_manager_raises(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value=None):
+                with pytest.raises(RuntimeError, match="Neither pnpm nor npm"):
+                    build_report_site({"key": "val"}, tmp_path / "output")
+
+    def test_build_failure_raises(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        result = MagicMock(returncode=1, stderr="Build error", stdout="")
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+                    with pytest.raises(RuntimeError, match="Docusaurus build failed"):
+                        build_report_site({"key": "val"}, tmp_path / "output")
+
+    def test_build_timeout_raises(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run",
+                    side_effect=subprocess.TimeoutExpired(["pnpm"], 120),
+                ):
+                    with pytest.raises(RuntimeError, match="timed out"):
+                        build_report_site({"key": "val"}, tmp_path / "output")
+
+    def test_build_output_dir_missing_raises(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        result = MagicMock(returncode=0, stdout="OK", stderr="")
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+                    with pytest.raises(RuntimeError, match="build directory not found"):
+                        build_report_site({"key": "val"}, tmp_path / "output")
+
+    def test_successful_build_with_pnpm(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        (viewer_dir / "node_modules").mkdir()
+        build_dir = viewer_dir / "build"
+        build_dir.mkdir()
+        (build_dir / "index.html").write_text("<html/>")
+        result = MagicMock(returncode=0, stdout="Build OK", stderr="")
+        output_dir = tmp_path / "output"
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ) as mock_run:
+                    ret = build_report_site({"data": "value"}, output_dir)
+        assert ret == output_dir
+        assert (output_dir / "index.html").exists()
+        assert (output_dir / "report.json").exists()
+        call_cmd = mock_run.call_args[0][0]
+        assert "/usr/bin/pnpm" in call_cmd
+
+    def test_successful_build_with_npm_fallback(self, tmp_path: Path) -> None:
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        build_dir = viewer_dir / "build"
+        build_dir.mkdir()
+        (build_dir / "index.html").write_text("<html/>")
+        result = MagicMock(returncode=0, stdout="Build OK", stderr="")
+        output_dir = tmp_path / "output"
+
+        def which_side_effect(cmd: str) -> str | None:
+            return None if cmd == "pnpm" else "/usr/bin/npm"
+
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", side_effect=which_side_effect
+            ):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ) as mock_run:
+                    ret = build_report_site({"data": "value"}, output_dir)
+        assert ret == output_dir
+        call_cmd = mock_run.call_args[0][0]
+        assert "/usr/bin/npm" in call_cmd
+
+    def test_report_json_copied_when_absent_from_build(self, tmp_path: Path) -> None:
+        """report.json is explicitly copied to output if not present after copytree."""
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        build_dir = viewer_dir / "build"
+        build_dir.mkdir()
+        # No report.json in build output — function should copy it separately.
+        result = MagicMock(returncode=0, stdout="OK", stderr="")
+        output_dir = tmp_path / "output"
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+                    build_report_site({"data": "value"}, output_dir)
+        assert (output_dir / "report.json").exists()
+
+    def test_base_url_trailing_slash_added(self, tmp_path: Path) -> None:
+        """base_url without trailing slash gets one appended."""
+        viewer_dir = tmp_path / "viewer"
+        viewer_dir.mkdir()
+        build_dir = viewer_dir / "build"
+        build_dir.mkdir()
+        result = MagicMock(returncode=0, stdout="OK", stderr="")
+        output_dir = tmp_path / "output"
+        with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
+            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ) as mock_run:
+                    build_report_site({"data": "value"}, output_dir, base_url="/sub")
+        env = mock_run.call_args.kwargs["env"]
+        assert env["REPORT_BASE_URL"] == "/sub/"

--- a/tests/test_docusaurus.py
+++ b/tests/test_docusaurus.py
@@ -32,8 +32,12 @@ class TestBuildReportSite:
         viewer_dir.mkdir()
         result = MagicMock(returncode=1, stderr="Build error", stdout="")
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
-                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ):
                     with pytest.raises(RuntimeError, match="Docusaurus build failed"):
                         build_report_site({"key": "val"}, tmp_path / "output")
 
@@ -41,7 +45,9 @@ class TestBuildReportSite:
         viewer_dir = tmp_path / "viewer"
         viewer_dir.mkdir()
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
                 with patch(
                     "regis_cli.report.docusaurus.subprocess.run",
                     side_effect=subprocess.TimeoutExpired(["pnpm"], 120),
@@ -54,8 +60,12 @@ class TestBuildReportSite:
         viewer_dir.mkdir()
         result = MagicMock(returncode=0, stdout="OK", stderr="")
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
-                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ):
                     with pytest.raises(RuntimeError, match="build directory not found"):
                         build_report_site({"key": "val"}, tmp_path / "output")
 
@@ -69,7 +79,9 @@ class TestBuildReportSite:
         result = MagicMock(returncode=0, stdout="Build OK", stderr="")
         output_dir = tmp_path / "output"
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
                 with patch(
                     "regis_cli.report.docusaurus.subprocess.run", return_value=result
                 ) as mock_run:
@@ -94,7 +106,8 @@ class TestBuildReportSite:
 
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
             with patch(
-                "regis_cli.report.docusaurus.shutil.which", side_effect=which_side_effect
+                "regis_cli.report.docusaurus.shutil.which",
+                side_effect=which_side_effect,
             ):
                 with patch(
                     "regis_cli.report.docusaurus.subprocess.run", return_value=result
@@ -114,8 +127,12 @@ class TestBuildReportSite:
         result = MagicMock(returncode=0, stdout="OK", stderr="")
         output_dir = tmp_path / "output"
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
-                with patch("regis_cli.report.docusaurus.subprocess.run", return_value=result):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
+                with patch(
+                    "regis_cli.report.docusaurus.subprocess.run", return_value=result
+                ):
                     build_report_site({"data": "value"}, output_dir)
         assert (output_dir / "report.json").exists()
 
@@ -128,7 +145,9 @@ class TestBuildReportSite:
         result = MagicMock(returncode=0, stdout="OK", stderr="")
         output_dir = tmp_path / "output"
         with patch("regis_cli.report.docusaurus._VIEWER_DIR", viewer_dir):
-            with patch("regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"):
+            with patch(
+                "regis_cli.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
                 with patch(
                     "regis_cli.report.docusaurus.subprocess.run", return_value=result
                 ) as mock_run:

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,67 @@
+"""Tests for commands/viewer.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from regis_cli.commands.viewer import get_viewer_assets_dir, viewer_group
+
+
+class TestGetViewerAssetsDir:
+    """Tests for get_viewer_assets_dir()."""
+
+    def test_returns_path_when_dir_exists(self) -> None:
+        with patch.object(Path, "exists", return_value=True):
+            result = get_viewer_assets_dir()
+        assert result.name == "viewer_assets"
+
+    def test_exits_when_dir_missing(self) -> None:
+        with patch.object(Path, "exists", return_value=False):
+            with pytest.raises(SystemExit) as exc_info:
+                get_viewer_assets_dir()
+        assert exc_info.value.code == 1
+
+
+class TestViewerExportCmd:
+    """Tests for the `viewer export` subcommand."""
+
+    @patch("regis_cli.commands.viewer.get_viewer_assets_dir")
+    @patch("regis_cli.commands.viewer.shutil.copytree")
+    def test_export_without_report(self, mock_copytree, mock_get_dir, tmp_path: Path) -> None:
+        mock_get_dir.return_value = tmp_path / "assets"
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(viewer_group, ["export", "-o", "output"])
+        assert result.exit_code == 0
+        assert "Successfully exported" in result.output
+        mock_copytree.assert_called_once()
+
+    @patch("regis_cli.commands.viewer.get_viewer_assets_dir")
+    @patch("regis_cli.commands.viewer.shutil.copytree")
+    @patch("regis_cli.commands.viewer.shutil.copy2")
+    def test_export_with_report(
+        self, mock_copy2, mock_copytree, mock_get_dir, tmp_path: Path
+    ) -> None:
+        mock_get_dir.return_value = tmp_path / "assets"
+        report_file = tmp_path / "report.json"
+        report_file.write_text('{"results": {}}')
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                viewer_group,
+                ["export", "-o", "output", str(report_file)],
+            )
+        assert result.exit_code == 0
+        assert "Successfully exported" in result.output
+        mock_copy2.assert_called_once()
+
+    def test_viewer_group_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(viewer_group, ["--help"])
+        assert result.exit_code == 0
+        assert "export" in result.output
+        assert "serve" in result.output

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -31,7 +31,9 @@ class TestViewerExportCmd:
 
     @patch("regis_cli.commands.viewer.get_viewer_assets_dir")
     @patch("regis_cli.commands.viewer.shutil.copytree")
-    def test_export_without_report(self, mock_copytree, mock_get_dir, tmp_path: Path) -> None:
+    def test_export_without_report(
+        self, mock_copytree, mock_get_dir, tmp_path: Path
+    ) -> None:
         mock_get_dir.return_value = tmp_path / "assets"
         runner = CliRunner()
         with runner.isolated_filesystem():


### PR DESCRIPTION
## Summary

- **Threshold enforced**: `pytest` now fails automatically if coverage drops below 90% (`--cov-fail-under=90` in `addopts`), blocking any PR via the required CI status check.
- **Coverage bridged**: 21 targeted new tests to go from 86% → **90.02%** (330 tests, 0 failing).
- **Badge + report**: `genbadge` generates `coverage-badge.svg` in CI; the badge is auto-committed on `main` and the `htmlcov/` artifact is uploaded on every run.

## Changed files

| File | Change |
|------|--------|
| `pyproject.toml` | `addopts`, `[tool.coverage.run]`, `[tool.coverage.report]`, `genbadge` dep |
| `Pipfile` / `Pipfile.lock` | Add `genbadge[coverage]>=1.1` |
| `.github/workflows/test.yml` | Badge generation, artifact upload, auto-commit on `main` |
| `.gitignore` | Ignore generated `coverage.xml` |
| `README.md` | Coverage badge |
| `CLAUDE.md` | Updated commands |
| `regis_cli/commands/viewer.py` | `# pragma: no cover` on `serve_cmd` (blocking TCP server + `webbrowser.open`, not unit-testable) |
| `tests/test_viewer.py` | New — `get_viewer_assets_dir`, `export_cmd` |
| `tests/test_docusaurus.py` | New — `build_report_site` (8 scenarios) |
| `tests/test_cli.py` | Add `TestEvaluateCmd`, `TestAnalyzeCacheAndFail` |
| `tests/test_analyzers.py` | Add discovery error path + `run_cmd` FileNotFoundError |

## Test plan

- [ ] `pipenv run pytest` → exits 0, reports `90.01%` or above
- [ ] Remove an existing test → exits non-zero with `Required test coverage of 90% not reached`
- [ ] `pipenv run pytest --no-cov` → runs without coverage check
- [ ] GitHub Actions CI → `Tests` workflow green, `coverage-report` artifact visible in the Actions tab
- [ ] After merge to `main` → `coverage-badge.svg` auto-committed, badge visible in `README.md`

https://claude.ai/code/session_013KH7ewUhKNbaVXnnrizsYd