### PR TITLE
fix(build): install corepack before enabling pnpm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the React viewer assets
 FROM node:25-slim AS frontend-builder
-RUN corepack enable pnpm
+RUN npm install -g corepack@0.34.6 && corepack enable pnpm
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml* ./
 COPY apps/ apps/


### PR DESCRIPTION
## Summary
- Installs `corepack@0.34.6` explicitly before `corepack enable pnpm` — corepack is no longer bundled with Node.js since v23, causing the `node:25-slim` build stage to fail with exit code 127

## Test plan
- [ ] Docker build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)