### PR TITLE
refactor(ci): rename and reorganise workflow files by category

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Image
+name: CD / Docker
 
 on:
   push:

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -1,4 +1,4 @@
-name: Publish Documentation
+name: CD / Docs
 
 on:
   push:

--- a/.github/workflows/cd-viewer.yml
+++ b/.github/workflows/cd-viewer.yml
@@ -1,4 +1,4 @@
-name: Publish Viewer
+name: CD / Viewer
 
 on:
   push:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,4 +1,4 @@
-name: Trunk Checks
+name: CI / Lint
 
 on:
   push:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI / Test
 
 on:
   push:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release / Release Please
 
 on:
   push:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,4 +1,4 @@
-name: Create Docusaurus version snapshot for release
+name: Release / Docs snapshot
 
 on:
   pull_request_target:

--- a/.github/workflows/repo-automerge.yml
+++ b/.github/workflows/repo-automerge.yml
@@ -1,4 +1,4 @@
-name: Enable auto-merge on PRs
+name: Repo / Auto-merge
 
 on:
   pull_request_target:

--- a/.github/workflows/repo-automerge.yml
+++ b/.github/workflows/repo-automerge.yml
@@ -13,8 +13,10 @@ permissions:
 jobs:
   automerge:
     if: >-
-      github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+      github.event.pull_request.draft == false && (
+        !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') ||
+        !endsWith(github.event.pull_request.title, '.0')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/repo-autorebase.yml
+++ b/.github/workflows/repo-autorebase.yml
@@ -1,4 +1,4 @@
-name: Auto-rebase PRs
+name: Repo / Auto-rebase
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Apply consistent `{category}-{action}.yml` filename convention across all 9 workflows
- Update `name:` fields to `Category / Action` format — creates visual grouping in the GitHub Actions sidebar
- Auto-merge patch release PRs (`autorelease: pending` with version not ending in `.0`); minor/major still require manual merge

| Old | New |
|-----|-----|
| `test.yml` | `ci-test.yml` — CI / Test |
| `trunk.yml` | `ci-lint.yml` — CI / Lint |
| `docker-publish.yml` | `cd-docker.yml` — CD / Docker |
| `docs-publish.yml` | `cd-docs.yml` — CD / Docs |
| `viewer-publish.yml` | `cd-viewer.yml` — CD / Viewer |
| `release-please.yml` | unchanged — Release / Release Please |
| `release-snapshot.yml` | unchanged — Release / Docs snapshot |
| `auto-merge-prs.yml` | `repo-automerge.yml` — Repo / Auto-merge |
| `auto-rebase-prs.yml` | `repo-autorebase.yml` — Repo / Auto-rebase |

No logic changes except the patch release auto-merge rule.