### PR TITLE
feat(docs): redirect root GitHub Pages URL to /docs/

### DIFF
--- a/.github/pages-root/index.html
+++ b/.github/pages-root/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/regis-cli/docs/" />
+    <link rel="canonical" href="/regis-cli/docs/" />
+    <title>regis-cli</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/regis-cli/docs/">documentation</a>…</p>
+  </body>
+</html>

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -198,3 +198,14 @@ jobs:
           user_name: regis-ci[bot]
           user_email: regis-ci[bot]@users.noreply.github.com
           commit_message: "ci(docs): deploy documentation"
+
+      - name: Deploy root redirect to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ steps.generate-token.outputs.token }}
+          publish_dir: .github/pages-root
+          destination_dir: .
+          keep_files: true
+          user_name: regis-ci[bot]
+          user_email: regis-ci[bot]@users.noreply.github.com
+          commit_message: "ci(docs): deploy root redirect"


### PR DESCRIPTION
## Summary

- Add `.github/pages-root/index.html` with a `<meta http-equiv="refresh">` redirect from `/regis-cli/` → `/regis-cli/docs/`
- Deploy it to the root of `gh-pages` via a second `peaceiris/actions-gh-pages` step in `cd-docs.yml` (`destination_dir: .`, `keep_files: true`)

## Test plan

- [ ] After merge, verify `https://trivoallan.github.io/regis-cli/` redirects to `https://trivoallan.github.io/regis-cli/docs/`