### PR TITLE
feat(cli): add github update-pr command for PR comment posting

### DIFF
--- a/docs/website/docs/reference/cli.md
+++ b/docs/website/docs/reference/cli.md
@@ -186,6 +186,12 @@ After a successful bootstrap, all `bootstrap` commands display **Post-install no
 
 ## Utility Commands
 
+### `github`
+
+Commands for seamless integration with GitHub Actions.
+
+- `github update-pr`: Post or update a Pull Request comment with analysis results, score, and report link. Applies playbook labels to the PR.
+
 ### `gitlab`
 
 Commands for seamless integration with GitLab CI/CD.

--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -206,12 +206,12 @@ regis-cli github update-pr \
   --token <github-token>  # or set GITHUB_TOKEN env var
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--report` | Path to the `report.json` file produced by `regis-cli analyze` |
-| `--report-url` | URL where the HTML report is hosted (artifact, Pages, etc.) |
-| `--pr-url` | Full GitHub PR URL (`https://github.com/owner/repo/pull/42`) |
-| `--token` | GitHub token — also reads `GITHUB_TOKEN` environment variable |
+| Option         | Description                                                    |
+| -------------- | -------------------------------------------------------------- |
+| `--report`     | Path to the `report.json` file produced by `regis-cli analyze` |
+| `--report-url` | URL where the HTML report is hosted (artifact, Pages, etc.)    |
+| `--pr-url`     | Full GitHub PR URL (`https://github.com/owner/repo/pull/42`)   |
+| `--token`      | GitHub token — also reads `GITHUB_TOKEN` environment variable  |
 
 ## Viewing Reports
 

--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -172,6 +172,47 @@ regis-cli analyze <image-url> \
   --meta "trigger.url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 ```
 
+## Posting Results to Pull Requests
+
+After running the analysis, you can post the results directly to a Pull Request
+as a comment using the `github update-pr` command:
+
+```yaml
+- name: Post analysis results to PR
+  if: github.event_name == 'pull_request'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    regis-cli github update-pr \
+      --report reports/report.json \
+      --report-url "${{ steps.pages.outputs.page_url }}" \
+      --pr-url "${{ github.event.pull_request.html_url }}"
+```
+
+The command will:
+
+- Post a summary comment with the playbook score, tier, and vulnerability counts.
+- Include a link to the full HTML report.
+- Apply any labels defined in the playbook.
+- **Update** the existing comment on re-runs instead of creating duplicates.
+
+### CLI reference
+
+```bash
+regis-cli github update-pr \
+  --report <path-to-report.json> \
+  --report-url <url-to-html-report> \
+  --pr-url <github-pr-url> \
+  --token <github-token>  # or set GITHUB_TOKEN env var
+```
+
+| Option | Description |
+|--------|-------------|
+| `--report` | Path to the `report.json` file produced by `regis-cli analyze` |
+| `--report-url` | URL where the HTML report is hosted (artifact, Pages, etc.) |
+| `--pr-url` | Full GitHub PR URL (`https://github.com/owner/repo/pull/42`) |
+| `--token` | GitHub token — also reads `GITHUB_TOKEN` environment variable |
+
 ## Viewing Reports
 
 When using the `--site` flag, `regis-cli` generates a full HTML site in the `reports/` directory. By uploading this directory as a workflow artifact (as shown in the example), you can download and view the interactive reports directly from the GitHub Actions run page.

--- a/regis_cli/cli.py
+++ b/regis_cli/cli.py
@@ -14,6 +14,7 @@ from regis_cli.commands.bootstrap import bootstrap
 from regis_cli.commands.check import check, version_cmd
 from regis_cli.commands.rules import rules_group
 from regis_cli.commands.viewer import viewer_group
+from regis_cli.github_cli import github_cmd
 from regis_cli.gitlab_cli import gitlab_cmd
 from regis_cli.utils.process import require_tool, run_cmd
 from regis_cli.utils.report import (
@@ -59,6 +60,7 @@ def main(verbose: bool) -> None:
     )
 
 
+main.add_command(github_cmd, name="github")
 main.add_command(gitlab_cmd, name="gitlab")
 main.add_command(analyze)
 main.add_command(evaluate_cmd, name="evaluate")

--- a/regis_cli/github_cli.py
+++ b/regis_cli/github_cli.py
@@ -69,6 +69,48 @@ def _build_comment_body(report_data: dict, report_url: str) -> str:
     return "\n".join(lines)
 
 
+def _apply_labels(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    token: str,
+    report_data: dict,
+    headers: dict,
+) -> None:
+    """Apply playbook labels and badge labels to a GitHub PR.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: Pull request number as a string.
+        token: GitHub authentication token (unused directly; passed via headers).
+        report_data: Parsed report.json contents.
+        headers: Pre-built GitHub API request headers.
+    """
+    playbook = report_data.get("playbook", {})
+    labels: list[str] = list(playbook.get("labels", []))
+    badge_labels: list[dict] = playbook.get("badge_labels", [])
+    for badge in badge_labels:
+        name = badge.get("name")
+        if name:
+            labels.append(name)
+
+    if not labels:
+        return
+
+    labels_url = (
+        f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/labels"
+    )
+    try:
+        resp = requests.post(
+            labels_url, headers=headers, json={"labels": labels}, timeout=30
+        )
+        resp.raise_for_status()
+        click.echo(f"Applied {len(labels)} label(s) to PR.", err=True)
+    except Exception as exc:
+        click.echo(f"Warning: failed to apply labels to PR: {exc}", err=True)
+
+
 @github_cmd.command(name="update-pr")
 @click.option(
     "--report",
@@ -171,3 +213,5 @@ def update_pr(
             click.echo("Posted new PR comment.", err=True)
     except Exception as exc:
         raise click.ClickException(f"Failed to post/update PR comment: {exc}") from exc
+
+    _apply_labels(owner, repo, pr_number, token, report_data, headers)

--- a/regis_cli/github_cli.py
+++ b/regis_cli/github_cli.py
@@ -34,29 +34,32 @@ def _build_comment_body(report_data: dict, report_url: str) -> str:
     Returns:
         Markdown string to post as a PR comment.
     """
-    rules_summary = report_data.get("rules_summary", {})
-    score = rules_summary.get("score", "N/A")
-    total_rules = len(rules_summary.get("total", []))
-    passed_rules = len(rules_summary.get("passed", []))
-    tier = report_data.get("tier") or "N/A"
+    playbook = report_data.get("playbook", {})
+    summary = playbook.get("rules_summary", {})
+    score = summary.get("score", "N/A")
+    total = summary.get("total", 0)
+    passed = summary.get("passed", 0)
+    tier = playbook.get("tier") or "N/A"
 
-    trivy = report_data.get("results", {}).get("trivy", {})
-    critical_count: int | None = trivy.get("critical_count")
-    high_count: int | None = trivy.get("high_count")
+    trivy = report_data.get("analyzers", {}).get("trivy", {})
+    vuln_summary = trivy.get("vulnerabilities", {}).get("summary", {})
 
     lines = [
         _COMMENT_MARKER,
         "",
         "## regis-cli Analysis Results",
         "",
-        f"**Score:** {score}/100 &nbsp; **Tier:** {tier}",
-        f"**Rules:** {passed_rules}/{total_rules} passed",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| **Score** | {score}/100 |",
+        f"| **Tier** | {tier} |",
+        f"| **Rules** | {passed}/{total} passed |",
     ]
 
-    if critical_count is not None and high_count is not None:
-        lines.append(
-            f"**Vulnerabilities:** {critical_count} critical, {high_count} high"
-        )
+    if vuln_summary:
+        critical = vuln_summary.get("CRITICAL", 0)
+        high = vuln_summary.get("HIGH", 0)
+        lines.append(f"| **Vulnerabilities** | {critical} critical, {high} high |")
 
     lines += [
         "",

--- a/regis_cli/github_cli.py
+++ b/regis_cli/github_cli.py
@@ -1,0 +1,170 @@
+"""GitHub CLI commands for regis-cli."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import click
+import requests
+
+logger = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(
+    r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)"
+)
+
+_COMMENT_MARKER = "<!-- regis-cli -->"
+
+
+@click.group()
+def github_cmd() -> None:
+    """GitHub CI integration commands."""
+    pass
+
+
+def _build_comment_body(report_data: dict, report_url: str) -> str:
+    """Build the Markdown comment body from report data.
+
+    Args:
+        report_data: Parsed report.json contents.
+        report_url: URL to the generated HTML report.
+
+    Returns:
+        Markdown string to post as a PR comment.
+    """
+    rules_summary = report_data.get("rules_summary", {})
+    score = rules_summary.get("score", "N/A")
+    total_rules = len(rules_summary.get("total", []))
+    passed_rules = len(rules_summary.get("passed", []))
+    tier = report_data.get("tier") or "N/A"
+
+    trivy = report_data.get("results", {}).get("trivy", {})
+    critical_count: int | None = trivy.get("critical_count")
+    high_count: int | None = trivy.get("high_count")
+
+    lines = [
+        _COMMENT_MARKER,
+        "",
+        "## regis-cli Analysis Results",
+        "",
+        f"**Score:** {score}/100 &nbsp; **Tier:** {tier}",
+        f"**Rules:** {passed_rules}/{total_rules} passed",
+    ]
+
+    if critical_count is not None and high_count is not None:
+        lines.append(
+            f"**Vulnerabilities:** {critical_count} critical, {high_count} high"
+        )
+
+    lines += [
+        "",
+        f"[View Full Report]({report_url})",
+    ]
+
+    return "\n".join(lines)
+
+
+@github_cmd.command(name="update-pr")
+@click.option(
+    "--report",
+    "report_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to report.json",
+)
+@click.option(
+    "--report-url",
+    "report_url",
+    required=True,
+    help="URL to the generated HTML report",
+)
+@click.option(
+    "--pr-url",
+    "pr_url",
+    required=True,
+    help="GitHub PR URL (e.g. https://github.com/owner/repo/pull/42)",
+)
+@click.option(
+    "--token",
+    "token",
+    default=None,
+    envvar="GITHUB_TOKEN",
+    help="GitHub token (also reads GITHUB_TOKEN env var)",
+)
+def update_pr(
+    report_path: str, report_url: str, pr_url: str, token: str | None
+) -> None:
+    """Post or update a PR comment with analysis results."""
+    # Parse the PR URL
+    match = _PR_URL_RE.fullmatch(pr_url.strip())
+    if not match:
+        raise click.ClickException(
+            f"Invalid GitHub PR URL: '{pr_url}'. "
+            "Expected format: https://github.com/<owner>/<repo>/pull/<number>"
+        )
+
+    owner = match.group("owner")
+    repo = match.group("repo")
+    pr_number = match.group("number")
+
+    if not token:
+        raise click.ClickException(
+            "GitHub token is required. Use --token or set GITHUB_TOKEN."
+        )
+
+    # Load the report
+    try:
+        with open(report_path, encoding="utf-8") as f:
+            report_data = json.load(f)
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to read report file {report_path}: {exc}"
+        ) from exc
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    comments_url = (
+        f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    )
+
+    # Fetch existing comments
+    try:
+        response = requests.get(comments_url, headers=headers, timeout=30)
+        response.raise_for_status()
+        comments = response.json()
+    except Exception as exc:
+        raise click.ClickException(f"Failed to fetch PR comments: {exc}") from exc
+
+    comment_body = _build_comment_body(report_data, report_url)
+
+    # Look for an existing regis-cli comment
+    existing_id: int | None = None
+    for comment in comments:
+        if _COMMENT_MARKER in comment.get("body", ""):
+            existing_id = comment["id"]
+            break
+
+    try:
+        if existing_id is not None:
+            patch_url = (
+                f"https://api.github.com/repos/{owner}/{repo}"
+                f"/issues/comments/{existing_id}"
+            )
+            resp = requests.patch(
+                patch_url, headers=headers, json={"body": comment_body}, timeout=30
+            )
+            resp.raise_for_status()
+            click.echo(f"Updated existing PR comment (id={existing_id}).", err=True)
+        else:
+            resp = requests.post(
+                comments_url, headers=headers, json={"body": comment_body}, timeout=30
+            )
+            resp.raise_for_status()
+            click.echo("Posted new PR comment.", err=True)
+    except Exception as exc:
+        raise click.ClickException(f"Failed to post/update PR comment: {exc}") from exc

--- a/tests/test_github_cli.py
+++ b/tests/test_github_cli.py
@@ -17,17 +17,21 @@ def runner():
 @pytest.fixture
 def report_data():
     return {
-        "tier": "Gold",
-        "rules_summary": {
+        "playbook": {
+            "playbook_name": "default",
             "score": 85,
-            "total": ["rule-a", "rule-b", "rule-c", "rule-d"],
-            "passed": ["rule-a", "rule-b", "rule-c"],
+            "tier": "Gold",
+            "rules_summary": {"score": 85, "total": 10, "passed": 7},
+            "badges": [],
+            "labels": [],
+            "badge_labels": [],
+            "mr_description_checklists": [],
         },
-        "results": {
+        "analyzers": {
             "trivy": {
-                "analyzer": "trivy",
-                "critical_count": 2,
-                "high_count": 5,
+                "vulnerabilities": {
+                    "summary": {"CRITICAL": 2, "HIGH": 5, "MEDIUM": 12, "LOW": 8}
+                }
             }
         },
     }
@@ -74,7 +78,8 @@ def test_creates_new_comment(runner, report_file):
 
         post_body = mock_requests.post.call_args[1]["json"]["body"]
         assert "<!-- regis-cli -->" in post_body
-        assert "85" in post_body  # score
+        assert "85/100" in post_body  # score
+        assert "7/10" in post_body  # rules
 
         # PATCH must NOT be called
         mock_requests.patch.assert_not_called()
@@ -200,5 +205,7 @@ def test_token_read_from_env(runner, report_file, monkeypatch):
 
         assert result.exit_code == 0, result.output
 
-        get_headers = mock_requests.get.call_args[1]["headers"]
-        assert get_headers["Authorization"] == "Bearer env_token"
+        # Verify the token was used in the request
+        get_call = mock_requests.get.call_args
+        headers = get_call.kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer env_token"

--- a/tests/test_github_cli.py
+++ b/tests/test_github_cli.py
@@ -179,6 +179,62 @@ def test_comment_body_contains_tier_and_vuln_counts(runner, report_file):
         assert "https://example.com/report.html" in post_body  # report link
 
 
+def test_applies_labels_to_pr(runner, tmp_path):
+    """Labels from playbook.labels and playbook.badge_labels are POSTed to the labels endpoint."""
+    data = {
+        "playbook": {
+            "rules_summary": {"score": 90, "total": 5, "passed": 5},
+            "tier": "Gold",
+            "labels": ["regis:security-review"],
+            "badge_labels": [{"name": "regis::trivy::critical", "class": "error"}],
+        },
+        "analyzers": {},
+    }
+    report_file = tmp_path / "report.json"
+    report_file.write_text(json.dumps(data))
+
+    with mock.patch("regis_cli.github_cli.requests") as mock_requests:
+        mock_requests.get.return_value.json.return_value = []
+        mock_requests.get.return_value.raise_for_status.return_value = None
+        mock_requests.post.return_value.status_code = 201
+        mock_requests.post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            main,
+            [
+                "github",
+                "update-pr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--pr-url",
+                "https://github.com/owner/repo/pull/42",
+                "--token",
+                "ghp_fake",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        # POST must be called twice: once for comment, once for labels
+        assert mock_requests.post.call_count == 2
+
+        # First call: create comment
+        comment_url = mock_requests.post.call_args_list[0][0][0]
+        assert "comments" in comment_url
+
+        # Second call: apply labels
+        labels_url = mock_requests.post.call_args_list[1][0][0]
+        assert "/labels" in labels_url
+        assert "owner/repo" in labels_url
+        assert "42" in labels_url
+
+        labels_body = mock_requests.post.call_args_list[1][1]["json"]["labels"]
+        assert "regis:security-review" in labels_body
+        assert "regis::trivy::critical" in labels_body
+
+
 def test_token_read_from_env(runner, report_file, monkeypatch):
     """The --token option should fall back to GITHUB_TOKEN env var."""
     monkeypatch.setenv("GITHUB_TOKEN", "env_token")

--- a/tests/test_github_cli.py
+++ b/tests/test_github_cli.py
@@ -1,0 +1,204 @@
+"""Tests for the github CLI subcommands in regis-cli."""
+
+import json
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from regis_cli.cli import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def report_data():
+    return {
+        "tier": "Gold",
+        "rules_summary": {
+            "score": 85,
+            "total": ["rule-a", "rule-b", "rule-c", "rule-d"],
+            "passed": ["rule-a", "rule-b", "rule-c"],
+        },
+        "results": {
+            "trivy": {
+                "analyzer": "trivy",
+                "critical_count": 2,
+                "high_count": 5,
+            }
+        },
+    }
+
+
+@pytest.fixture
+def report_file(tmp_path, report_data):
+    f = tmp_path / "report.json"
+    f.write_text(json.dumps(report_data))
+    return f
+
+
+def test_creates_new_comment(runner, report_file):
+    """When no existing comment is found, POST is called to create a new one."""
+    with mock.patch("regis_cli.github_cli.requests") as mock_requests:
+        # GET returns empty list — no existing comment
+        mock_requests.get.return_value.json.return_value = []
+        mock_requests.get.return_value.raise_for_status.return_value = None
+        mock_requests.post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            main,
+            [
+                "github",
+                "update-pr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--pr-url",
+                "https://github.com/owner/repo/pull/42",
+                "--token",
+                "ghp_fake",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        # POST must be called once to create the comment
+        mock_requests.post.assert_called_once()
+        post_url = mock_requests.post.call_args[0][0]
+        assert "owner/repo" in post_url
+        assert "42" in post_url
+
+        post_body = mock_requests.post.call_args[1]["json"]["body"]
+        assert "<!-- regis-cli -->" in post_body
+        assert "85" in post_body  # score
+
+        # PATCH must NOT be called
+        mock_requests.patch.assert_not_called()
+
+
+def test_updates_existing_comment(runner, report_file):
+    """When a comment with the marker is found, PATCH is called to update it."""
+    existing_comment_id = 999
+    with mock.patch("regis_cli.github_cli.requests") as mock_requests:
+        # GET returns one comment containing the marker
+        mock_requests.get.return_value.json.return_value = [
+            {"id": existing_comment_id, "body": "<!-- regis-cli -->\nOld content"},
+        ]
+        mock_requests.get.return_value.raise_for_status.return_value = None
+        mock_requests.patch.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            main,
+            [
+                "github",
+                "update-pr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--pr-url",
+                "https://github.com/owner/repo/pull/42",
+                "--token",
+                "ghp_fake",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        # PATCH must be called with the correct comment ID
+        mock_requests.patch.assert_called_once()
+        patch_url = mock_requests.patch.call_args[0][0]
+        assert str(existing_comment_id) in patch_url
+
+        patch_body = mock_requests.patch.call_args[1]["json"]["body"]
+        assert "<!-- regis-cli -->" in patch_body
+
+        # POST must NOT be called
+        mock_requests.post.assert_not_called()
+
+
+def test_rejects_invalid_pr_url(runner, report_file):
+    """Non-GitHub PR URLs should cause a non-zero exit code."""
+    result = runner.invoke(
+        main,
+        [
+            "github",
+            "update-pr",
+            "--report",
+            str(report_file),
+            "--report-url",
+            "https://example.com/report.html",
+            "--pr-url",
+            "https://gitlab.com/owner/repo/merge_requests/1",
+            "--token",
+            "ghp_fake",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_comment_body_contains_tier_and_vuln_counts(runner, report_file):
+    """The comment body should include tier and vulnerability counts."""
+    with mock.patch("regis_cli.github_cli.requests") as mock_requests:
+        mock_requests.get.return_value.json.return_value = []
+        mock_requests.get.return_value.raise_for_status.return_value = None
+        mock_requests.post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            main,
+            [
+                "github",
+                "update-pr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--pr-url",
+                "https://github.com/owner/repo/pull/42",
+                "--token",
+                "ghp_fake",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        post_body = mock_requests.post.call_args[1]["json"]["body"]
+        assert "Gold" in post_body  # tier
+        assert "2" in post_body  # critical count
+        assert "5" in post_body  # high count
+        assert "https://example.com/report.html" in post_body  # report link
+
+
+def test_token_read_from_env(runner, report_file, monkeypatch):
+    """The --token option should fall back to GITHUB_TOKEN env var."""
+    monkeypatch.setenv("GITHUB_TOKEN", "env_token")
+
+    with mock.patch("regis_cli.github_cli.requests") as mock_requests:
+        mock_requests.get.return_value.json.return_value = []
+        mock_requests.get.return_value.raise_for_status.return_value = None
+        mock_requests.post.return_value.raise_for_status.return_value = None
+
+        result = runner.invoke(
+            main,
+            [
+                "github",
+                "update-pr",
+                "--report",
+                str(report_file),
+                "--report-url",
+                "https://example.com/report.html",
+                "--pr-url",
+                "https://github.com/owner/repo/pull/42",
+                # --token intentionally omitted
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        get_headers = mock_requests.get.call_args[1]["headers"]
+        assert get_headers["Authorization"] == "Bearer env_token"


### PR DESCRIPTION
## Summary

- Add `regis-cli github update-pr` command that posts/updates a PR comment with analysis results — achieving parity with the existing `regis-cli gitlab update-mr`
- Comment includes playbook score, tier, rules passed/total, and vulnerability counts (critical/high from Trivy)
- Uses `<!-- regis-cli -->` HTML marker for idempotent upsert (updates existing comment on re-runs)
- Applies playbook labels and badge labels to the PR via GitHub API
- Token reads from `--token` flag or `GITHUB_TOKEN` env var

## Test plan

- [x] 6 unit tests covering: new comment creation, existing comment update, invalid URL rejection, comment body content, label application, env var token
- [x] 336 tests pass (full suite), lint clean
- [ ] Manual smoke test on a real PR with `GITHUB_TOKEN`