### PR TITLE
feat(ci): reusable GitHub composite action for container image analysis

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3b5b55e83e96bd028d8a50cc9403352c84f64e16bba29ce686dc5374e9f25456"
+            "sha256": "a9360594a7b9de818ba1b571adc4d3c4041344afa234f73723b4ce2c8f6dfa11"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,134 @@
+name: Regis Security Analysis
+description: Analyze a container image with regis-cli and optionally post results to a PR.
+author: trivoallan
+
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  image-url:
+    description: Container image URL to analyze.
+    required: true
+  auth:
+    description: Registry credentials as `registry=user:pass`.
+    required: false
+    default: ""
+  playbook:
+    description: URL or path to a custom playbook YAML.
+    required: false
+    default: ""
+  report-url:
+    description: URL to the hosted report (used as a link in the PR comment).
+    required: false
+    default: ""
+  github-token:
+    description: Token for posting PR comments.
+    required: false
+    default: ${{ github.token }}
+  pr-url:
+    description: PR URL to post the comment on (auto-detected in pull_request context).
+    required: false
+    default: ""
+  upload-artifact:
+    description: Whether to upload the report as a workflow artifact.
+    required: false
+    default: "true"
+  artifact-name:
+    description: Name for the uploaded artifact.
+    required: false
+    default: regis-security-report
+  version:
+    description: regis-cli Docker image version tag.
+    required: false
+    default: latest
+
+outputs:
+  report-path:
+    description: Absolute path to the report directory on the runner.
+    value: ${{ steps.analyze.outputs.report-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run regis-cli analysis
+      id: analyze
+      shell: bash
+      env:
+        REGIS_IMAGE_URL: ${{ inputs.image-url }}
+        REGIS_AUTH: ${{ inputs.auth }}
+        REGIS_PLAYBOOK: ${{ inputs.playbook }}
+        REGIS_VERSION: ${{ inputs.version }}
+        REGIS_ACTOR: ${{ github.actor }}
+        REGIS_SERVER_URL: ${{ github.server_url }}
+        REGIS_REPOSITORY: ${{ github.repository }}
+        REGIS_RUN_ID: ${{ github.run_id }}
+      run: |
+        REPORT_DIR="${RUNNER_TEMP}/regis-reports"
+        mkdir -p "${REPORT_DIR}"
+
+        DOCKER_ARGS=(
+          run --rm
+          -v "${REPORT_DIR}:/app/reports"
+          -e REGIS_IMAGE_URL
+        )
+
+        CLI_ARGS=(
+          analyze "${REGIS_IMAGE_URL}"
+          --site
+          --output-dir reports
+          --meta "trigger.user=${REGIS_ACTOR}"
+          --meta "trigger.url=${REGIS_SERVER_URL}/${REGIS_REPOSITORY}/actions/runs/${REGIS_RUN_ID}"
+        )
+
+        if [ -n "${REGIS_AUTH}" ]; then
+          DOCKER_ARGS+=(-e REGIS_AUTH)
+          CLI_ARGS+=(--auth "${REGIS_AUTH}")
+        fi
+
+        if [ -n "${REGIS_PLAYBOOK}" ]; then
+          CLI_ARGS+=(--playbook "${REGIS_PLAYBOOK}")
+        fi
+
+        docker "${DOCKER_ARGS[@]}" \
+          "ghcr.io/trivoallan/regis-cli:${REGIS_VERSION}" \
+          "${CLI_ARGS[@]}"
+
+        echo "report-path=${REPORT_DIR}" >> "${GITHUB_OUTPUT}"
+
+    - name: Upload report artifact
+      if: inputs.upload-artifact == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.analyze.outputs.report-path }}
+
+    - name: Post PR comment
+      if: inputs.pr-url != '' || github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REGIS_PR_URL: ${{ inputs.pr-url != '' && inputs.pr-url || github.event.pull_request.html_url }}
+        REGIS_REPORT_URL: ${{ inputs.report-url }}
+        REGIS_VERSION: ${{ inputs.version }}
+        REGIS_REPORT_DIR: ${{ steps.analyze.outputs.report-path }}
+      run: |
+        DOCKER_ARGS=(
+          run --rm
+          -v "${REGIS_REPORT_DIR}:/app/reports"
+          -e GH_TOKEN
+        )
+
+        CLI_ARGS=(
+          github update-pr
+          --report /app/reports/report.json
+          --pr-url "${REGIS_PR_URL}"
+        )
+
+        if [ -n "${REGIS_REPORT_URL}" ]; then
+          CLI_ARGS+=(--report-url "${REGIS_REPORT_URL}")
+        fi
+
+        docker "${DOCKER_ARGS[@]}" \
+          "ghcr.io/trivoallan/regis-cli:${REGIS_VERSION}" \
+          "${CLI_ARGS[@]}"

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,8 @@ inputs:
     required: false
     default: ""
   github-token:
-    description: Token for posting PR comments.
+    description: >
+      Token for posting PR comments. Requires the pull-requests: write permission.
     required: false
     default: ${{ github.token }}
   pr-url:
@@ -82,7 +83,6 @@ runs:
         )
 
         if [ -n "${REGIS_AUTH}" ]; then
-          DOCKER_ARGS+=(-e REGIS_AUTH)
           CLI_ARGS+=(--auth "${REGIS_AUTH}")
         fi
 
@@ -104,6 +104,7 @@ runs:
         path: ${{ steps.analyze.outputs.report-path }}
 
     - name: Post PR comment
+      # Requires regis-cli v0.25.0+ in the Docker image for the `github update-pr` command.
       if: inputs.pr-url != '' || github.event_name == 'pull_request'
       shell: bash
       env:
@@ -113,6 +114,11 @@ runs:
         REGIS_VERSION: ${{ inputs.version }}
         REGIS_REPORT_DIR: ${{ steps.analyze.outputs.report-path }}
       run: |
+        if [ -z "${REGIS_PR_URL}" ]; then
+          echo "::error::No PR URL available. Pass pr-url explicitly or run on a pull_request event."
+          exit 1
+        fi
+
         DOCKER_ARGS=(
           run --rm
           -v "${REGIS_REPORT_DIR}:/app/reports"

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,6 @@ runs:
         DOCKER_ARGS=(
           run --rm
           -v "${REPORT_DIR}:/app/reports"
-          -e REGIS_IMAGE_URL
         )
 
         CLI_ARGS=(
@@ -108,7 +107,7 @@ runs:
       if: inputs.pr-url != '' || github.event_name == 'pull_request'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         REGIS_PR_URL: ${{ inputs.pr-url != '' && inputs.pr-url || github.event.pull_request.html_url }}
         REGIS_REPORT_URL: ${{ inputs.report-url }}
         REGIS_VERSION: ${{ inputs.version }}
@@ -122,7 +121,7 @@ runs:
         DOCKER_ARGS=(
           run --rm
           -v "${REGIS_REPORT_DIR}:/app/reports"
-          -e GH_TOKEN
+          -e GITHUB_TOKEN
         )
 
         CLI_ARGS=(

--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -12,6 +12,94 @@ To quickly bootstrap a new GitHub repository pre-configured with `regis-cli` and
 **Note**: For repositories with branch protection, please ensure the **"Allow auto-merge"** option is enabled in the repository's general settings to support automated documentation updates.
 :::
 
+## Quick Start with the Reusable Action
+
+The fastest way to integrate `regis-cli` is to use the official reusable GitHub
+Action. It wraps the full analysis workflow—running the scanner, uploading the
+report artifact, and posting a PR comment—into a single step.
+
+### Permissions
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write # Required only for PR comments
+```
+
+### Minimal example
+
+```yaml
+name: Build and Analyze
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+
+      - name: Analyze with regis-cli
+        uses: trivoallan/regis-cli@v0.25.0
+        with:
+          image-url: ghcr.io/${{ github.repository }}:latest
+          auth: ghcr.io=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+```
+
+### Action inputs
+
+| Input             | Required | Default                 | Description                                                                     |
+| ----------------- | -------- | ----------------------- | ------------------------------------------------------------------------------- |
+| `image-url`       | Yes      | —                       | Container image URL to analyze.                                                 |
+| `auth`            | No       | —                       | Registry credentials as `registry=user:pass`.                                   |
+| `playbook`        | No       | —                       | URL or path to a custom playbook YAML file.                                     |
+| `report-url`      | No       | —                       | URL to a hosted report (used as a link in the PR comment).                      |
+| `github-token`    | No       | `${{ github.token }}`   | Token used to post PR comments (`pull-requests: write` required).               |
+| `pr-url`          | No       | Auto-detected           | PR URL to post results on. Defaults to the current PR on `pull_request` events. |
+| `upload-artifact` | No       | `true`                  | Upload the report directory as a workflow artifact.                             |
+| `artifact-name`   | No       | `regis-security-report` | Name for the uploaded artifact.                                                 |
+| `version`         | No       | `latest`                | `regis-cli` Docker image version to use.                                        |
+
+### Action outputs
+
+| Output        | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| `report-path` | Absolute path to the report directory on the runner. |
+
+:::note
+PR comments require `regis-cli` **v0.25.0 or later**. When running on a
+`pull_request` event, the action posts automatically. For other events, pass
+`pr-url` explicitly.
+:::
+
 ## Workflow Setup
 
 A robust integration typically involves building your image, pushing it to a registry (like GitHub Container Registry), and then running `regis-cli` to analyze the results.
@@ -81,7 +169,7 @@ jobs:
       - name: Run Analysis
         run: |
           pipenv run regis-cli analyze ghcr.io/${{ github.repository }}:latest \
-            --auth ghcr.io:${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+            --auth ghcr.io=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
             --site \
             --meta "trigger.user=${{ github.actor }}" \
             --meta "trigger.url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -144,7 +232,7 @@ You can further customize the integration to meet specific security requirements
 To analyze images in private registries, use the `--auth` flag. For GitHub Container Registry, you can use the automatically provided `GITHUB_TOKEN`.
 
 ```bash
-regis-cli analyze <image-url> --auth ghcr.io:<username>:<token>
+regis-cli analyze <image-url> --auth ghcr.io=<username>:<token>
 ```
 
 ### Using Security Playbooks

--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -23,7 +23,7 @@ report artifact, and posting a PR comment—into a single step.
 ```yaml
 permissions:
   contents: read
-  packages: write
+  packages: write # Required only if pushing to GHCR
   pull-requests: write # Required only for PR comments
 ```
 
@@ -83,7 +83,7 @@ jobs:
 | `playbook`        | No       | —                       | URL or path to a custom playbook YAML file.                                     |
 | `report-url`      | No       | —                       | URL to a hosted report (used as a link in the PR comment).                      |
 | `github-token`    | No       | `${{ github.token }}`   | Token used to post PR comments (`pull-requests: write` required).               |
-| `pr-url`          | No       | Auto-detected           | PR URL to post results on. Defaults to the current PR on `pull_request` events. |
+| `pr-url`          | No       | —                       | PR URL to post results on. Defaults to the current PR on `pull_request` events. |
 | `upload-artifact` | No       | `true`                  | Upload the report directory as a workflow artifact.                             |
 | `artifact-name`   | No       | `regis-security-report` | Name for the uploaded artifact.                                                 |
 | `version`         | No       | `latest`                | `regis-cli` Docker image version to use.                                        |


### PR DESCRIPTION
## Summary

- Adds `action.yml` at the repository root, enabling `uses: trivoallan/regis-cli@VERSION` as a single-step integration
- Wraps the full analysis workflow: `docker run analyze` → upload artifact → post PR comment (v0.25.0+)
- Fixes the `--auth` format bug in the GitHub integration docs (`registry:user:pass` → `registry=user:pass`)
- Adds a Quick Start section to the GitHub integration docs with minimal example, full input/output reference, and a `:::note` about the v0.25.0 requirement for PR comments

## Dependency

The PR comment step (`github update-pr`) requires the `regis-cli github` command group, which is being added in PR #180. The action ships now with the comment step defined; it becomes fully functional once #180 merges and the v0.25.0 Docker image is published.

## Test Plan

- [x] `trunk check action.yml` — no issues
- [x] `trunk check docs/website/docs/usage/integrations/github.md` — no issues
- [x] Full test suite (330 tests) — all passing
- [ ] Smoke test after #180 merges: run the action on a pull request and verify PR comment is posted
- [ ] Verify `uses: trivoallan/regis-cli@v0.25.0` resolves correctly after the release tag is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)