### PR TITLE
fix(ci): break release-please auto-merge feedback loop

### DIFF
--- a/.github/workflows/repo-automerge.yml
+++ b/.github/workflows/repo-automerge.yml
@@ -13,10 +13,8 @@ permissions:
 jobs:
   automerge:
     if: >-
-      github.event.pull_request.draft == false && (
-        !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') ||
-        !endsWith(github.event.pull_request.title, '.0')
-      )
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,20 @@
         "docs/website/docusaurus.config.ts",
         "docs/website/package.json"
       ],
-      "release-type": "python"
+      "release-type": "python",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Fix auto-merge condition**: block ALL `autorelease: pending` PRs from auto-merge, not just `.0` releases. The previous OR condition (`!contains(labels, 'autorelease: pending') || !endsWith(title, '.0')`) evaluated to `true` for every patch release, auto-merging them immediately.
- **Hide non-user-facing commit types**: mark `docs`, `ci`, `style`, `refactor`, `test`, `build`, `chore` as `hidden` in Release Please `changelog-sections` so they don't trigger release PRs.

### Root cause

The loop was: `docs commit → Release Please PR → auto-merge → release → docs snapshot commit → repeat`. This produced 15 spurious patch releases (v0.25.1 through v0.25.15) in a single day.

## Test plan

- [ ] Merge this PR and verify no new release PR is auto-created for the merge commit
- [ ] Push a `docs:` commit to main and verify Release Please does NOT create a release PR
- [ ] Push a `feat:` commit and verify Release Please creates a release PR that is NOT auto-merged