### PR TITLE
fix(ci): limit cd-docs workflow to release and manual triggers

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -1,12 +1,6 @@
 name: CD / Docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - docs/**
-      - regis/**
   release:
     types: [published]
   workflow_dispatch:
@@ -43,16 +37,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           ref: main
           fetch-depth: 0
-
-      - name: Detect changed sources
-        id: filter
-        uses: dorny/paths-filter@v4
-        with:
-          filters: |
-            schemas:
-              - 'regis/schemas/**'
-            rules:
-              - 'regis/**'
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -114,7 +98,6 @@ jobs:
         run: pnpm install
 
       - name: Generate Schema Docs
-        if: steps.filter.outputs.schemas == 'true' || github.event_name != 'push'
         run: |
           # Copy all schemas first to allow cross-category resolution
           mkdir -p docs/website/static/schemas
@@ -129,7 +112,6 @@ jobs:
           done
 
       - name: Generate Rules Reference
-        if: steps.filter.outputs.rules == 'true' || github.event_name != 'push'
         run: pipenv run regis rules list -f markdown -D docs/website/docs/reference/rules
 
       - name: Ensure whats-new label exists

--- a/.github/workflows/repo-automerge.yml
+++ b/.github/workflows/repo-automerge.yml
@@ -13,10 +13,8 @@ permissions:
 jobs:
   automerge:
     if: >-
-      github.event.pull_request.draft == false && (
-        !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') ||
-        !endsWith(github.event.pull_request.title, '.0')
-      )
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,20 @@
         "docs/website/docusaurus.config.ts",
         "docs/website/package.json"
       ],
-      "release-type": "python"
+      "release-type": "python",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove `push` trigger from `cd-docs.yml` — was running on every push to main touching `docs/` or `regis/`
- Remove `dorny/paths-filter` step (no longer needed without push trigger)
- Remove conditional `if` on schema/rules generation steps

The push trigger created trivial "docs: update documentation reference and snapshots" PRs that fed the release loop (fixed in #219). Docs regeneration now only runs on release publish and `workflow_dispatch`.

## Test plan

- [ ] Verify cd-docs does NOT run on next push to main
- [ ] Verify cd-docs still runs on `workflow_dispatch`
- [ ] Verify cd-docs still runs on release publish