### PR TITLE
fix(ci): skip trunk checks on generated schema docs

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -43,13 +43,15 @@ lint:
   ignore:
     - linters: [bandit, mypy]
       paths: [tests/**, regis/cookiecutters/**]
+    - linters: [ALL]
+      paths:
+        - docs/website/docs/reference/schemas/**
+        - docs/website/versioned_docs/**
     - linters: [markdownlint]
       paths:
         - "**/*.mdx"
         - CHANGELOG.md
         - CLAUDE.md
-        - docs/website/docs/reference/schemas/**
-        - docs/website/versioned_docs/**
         - report.json
     - linters: [prettier]
       paths:


### PR DESCRIPTION
## Summary

- Ignore ALL linters for `docs/website/docs/reference/schemas/**` and `docs/website/versioned_docs/**` — these are machine-generated and should not trigger CI failures
- Previously only markdownlint was ignored for these paths

## Test plan

- [ ] Verify trunk check passes on PRs that only touch generated schemas (like #229)