### PR TITLE
feat(cli): add archive configure command for multi-archive setup

### DIFF
--- a/docs/website/docs/usage/multi-archive.md
+++ b/docs/website/docs/usage/multi-archive.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 6
+title: Multi-Archive Setup
+description: Configure multiple archives for cross-environment comparison in the Regis dashboard.
+---
+
+Regis supports multiple named archives, allowing you to organize analyses by environment (production, staging), team, or image typology and compare them side by side in the dashboard.
+
+## Quick start
+
+### 1. Configure archives
+
+```bash
+regis archive configure \
+  --add "Production:static/archive/prod" \
+  -o static/archives.json
+
+regis archive configure \
+  --add "Staging:static/archive/staging" \
+  -o static/archives.json
+```
+
+### 2. Add reports to each archive
+
+```bash
+regis analyze myimage:latest --archive static/archive/prod
+regis analyze myimage:staging --archive static/archive/staging
+```
+
+### 3. View in the dashboard
+
+```bash
+regis dashboard serve \
+  --archive "Production:static/archive/prod/manifest.json" \
+  --archive "Staging:static/archive/staging/manifest.json"
+```
+
+The dashboard shows archive tabs and a combined "All Archives" view with source filtering.
+
+---
+
+## Managing archives
+
+### List configured archives
+
+```bash
+regis archive configure --list static/archives.json
+```
+
+### Remove an archive
+
+```bash
+regis archive configure --remove "Staging" -o static/archives.json
+```
+
+### Interactive mode
+
+Run without flags to add archives interactively:
+
+```bash
+regis archive configure -o static/archives.json
+```
+
+You'll be prompted for each archive's name and path.
+
+---
+
+## Archive paths
+
+Archive paths can be:
+
+- **Relative paths** — `static/archive/prod/manifest.json` (relative to the site root)
+- **HTTP(S) URLs** — `https://host.example.com/archive/manifest.json` (for remote archives)
+
+---
+
+## Bootstrapping with multi-archive
+
+When you scaffold a new archive site with `regis bootstrap archive`, the post-install notes explain how to add more archives. The scaffolded site starts with a single archive — use `regis archive configure` to add more.
+
+---
+
+## How it works
+
+The `archives.json` file lists named archives:
+
+```json
+{
+  "archives": [
+    { "name": "Production", "path": "static/archive/prod/manifest.json" },
+    { "name": "Staging", "path": "static/archive/staging/manifest.json" }
+  ]
+}
+```
+
+The dashboard detects this file and enables:
+
+- **Archive tabs** — switch between individual archives
+- **All Archives view** — merged view with a source column and filter
+- **Session persistence** — remembers the selected archive tab

--- a/regis/commands/archive.py
+++ b/regis/commands/archive.py
@@ -8,6 +8,35 @@ from pathlib import Path
 import click
 
 
+def _load_archives_config(path: Path) -> list[dict[str, str]]:
+    """Load existing archives.json, returning the archives list."""
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("archives", [])
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _write_archives_config(path: Path, archives: list[dict[str, str]]) -> None:
+    """Write archives list to archives.json and validate against schema."""
+    import importlib.resources
+
+    import jsonschema
+
+    config = {"archives": archives}
+
+    schema_text = (
+        importlib.resources.files("regis") / "schemas" / "archives.schema.json"
+    ).read_text(encoding="utf-8")
+    schema = json.loads(schema_text)
+    jsonschema.validate(config, schema)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
 @click.group()
 def archive():
     """Manage the report archive."""
@@ -36,3 +65,111 @@ def archive_add(report_file: Path, archive_dir: Path):
     dest = add_to_archive(report, archive_dir)
     click.echo(f"Archived to {dest}")
     click.echo(f"Manifest updated: {archive_dir / 'manifest.json'}")
+
+
+@archive.command("configure")
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default="archives.json",
+    show_default=True,
+    help="Path to archives.json file.",
+)
+@click.option(
+    "--add",
+    "add_entry",
+    default=None,
+    help='Add an archive non-interactively. Format: "Name:path-or-url".',
+)
+@click.option(
+    "--list",
+    "list_archives",
+    is_flag=True,
+    help="List configured archives and exit.",
+)
+@click.option(
+    "--remove",
+    "remove_name",
+    default=None,
+    help="Remove an archive by name.",
+)
+def archive_configure(
+    output_path: Path,
+    add_entry: str | None,
+    list_archives: bool,
+    remove_name: str | None,
+) -> None:
+    """Configure multi-archive setup for the dashboard viewer."""
+    archives = _load_archives_config(output_path)
+
+    if list_archives:
+        if not archives:
+            click.echo("No archives configured.", err=True)
+        else:
+            click.echo(f"Archives in {output_path}:", err=True)
+            for a in archives:
+                click.echo(f"  {a['name']}: {a['path']}")
+        return
+
+    if remove_name:
+        before = len(archives)
+        archives = [a for a in archives if a["name"] != remove_name]
+        if len(archives) == before:
+            raise click.ClickException(f"Archive '{remove_name}' not found.")
+        _write_archives_config(output_path, archives)
+        click.echo(
+            f"Removed '{remove_name}'. {len(archives)} archive(s) remaining.", err=True
+        )
+        return
+
+    if add_entry:
+        if ":" not in add_entry:
+            raise click.ClickException(
+                f'Invalid format: {add_entry!r}. Expected "Name:path-or-url".'
+            )
+        name, path = add_entry.split(":", 1)
+        if not name.strip() or not path.strip():
+            raise click.ClickException(
+                f"Invalid format: {add_entry!r}. Name and path must not be empty."
+            )
+        if any(a["name"] == name for a in archives):
+            raise click.ClickException(
+                f"Archive '{name}' already exists. Remove it first with --remove."
+            )
+        archives.append({"name": name, "path": path})
+        _write_archives_config(output_path, archives)
+        click.echo(f"Added '{name}' -> {path}", err=True)
+        click.echo(f"Config written to {output_path}", err=True)
+        return
+
+    # Interactive mode
+    click.echo("Configure archives for the dashboard viewer.\n", err=True)
+    if archives:
+        click.echo(f"Existing archives in {output_path}:", err=True)
+        for a in archives:
+            click.echo(f"  {a['name']}: {a['path']}", err=True)
+        click.echo("", err=True)
+
+    while True:
+        name = click.prompt(
+            "Archive name (empty to finish)", default="", show_default=False
+        )
+        if not name:
+            break
+        path = click.prompt("  Path or URL")
+        if any(a["name"] == name for a in archives):
+            click.echo(f"  Archive '{name}' already exists, skipping.", err=True)
+            continue
+        archives.append({"name": name, "path": path})
+        click.echo(f"  Added '{name}' -> {path}", err=True)
+
+    if not archives:
+        click.echo("No archives configured. Nothing written.", err=True)
+        return
+
+    _write_archives_config(output_path, archives)
+    click.echo(
+        f"\nConfig written to {output_path} ({len(archives)} archive(s)).", err=True
+    )

--- a/regis/cookiecutters/archive/{{cookiecutter.project_slug}}/.regis-post-install.md
+++ b/regis/cookiecutters/archive/{{cookiecutter.project_slug}}/.regis-post-install.md
@@ -1,0 +1,21 @@
+# Next Steps
+
+Your archive site has been scaffolded with a single default archive.
+
+## Adding More Archives
+
+To set up multiple archives (e.g., production, staging):
+
+    regis archive configure --add "Production:static/archive/prod" -o static/archives.json
+    regis archive configure --add "Staging:static/archive/staging" -o static/archives.json
+
+Then add reports to each:
+
+    regis analyze <IMAGE> --archive static/archive/prod
+    regis analyze <IMAGE> --archive static/archive/staging
+
+List configured archives:
+
+    regis archive configure --list static/archives.json
+
+The dashboard will automatically show archive tabs when archives.json is present.

--- a/tests/test_archive_configure.py
+++ b/tests/test_archive_configure.py
@@ -1,0 +1,200 @@
+"""Tests for regis archive configure command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from regis.cli import main
+
+
+class TestArchiveConfigureAdd:
+    """Tests for non-interactive --add mode."""
+
+    def test_add_creates_new_config(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "archive",
+                "configure",
+                "-o",
+                str(out),
+                "--add",
+                "Prod:static/archive/prod",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert len(data["archives"]) == 1
+        assert data["archives"][0] == {"name": "Prod", "path": "static/archive/prod"}
+
+    def test_add_appends_to_existing(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        out.write_text(json.dumps({"archives": [{"name": "Prod", "path": "p"}]}))
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "archive",
+                "configure",
+                "-o",
+                str(out),
+                "--add",
+                "Staging:static/archive/staging",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert len(data["archives"]) == 2
+
+    def test_add_rejects_duplicate_name(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        out.write_text(json.dumps({"archives": [{"name": "Prod", "path": "p"}]}))
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "configure", "-o", str(out), "--add", "Prod:other/path"],
+        )
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower()
+
+    def test_add_rejects_invalid_format(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "configure", "--add", "no-colon-here"],
+        )
+        assert result.exit_code != 0
+        assert "invalid format" in result.output.lower()
+
+    def test_add_rejects_empty_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "configure", "--add", ":some/path"],
+        )
+        assert result.exit_code != 0
+        assert "must not be empty" in result.output.lower()
+
+    def test_add_url_with_port(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "archive",
+                "configure",
+                "-o",
+                str(out),
+                "--add",
+                "Remote:https://host:8080/archive/manifest.json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert data["archives"][0]["path"] == "https://host:8080/archive/manifest.json"
+
+
+class TestArchiveConfigureList:
+    """Tests for --list mode."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        runner = CliRunner()
+        result = runner.invoke(main, ["archive", "configure", "-o", str(out), "--list"])
+        assert result.exit_code == 0
+        assert "no archives" in result.output.lower()
+
+    def test_list_shows_archives(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        out.write_text(
+            json.dumps(
+                {
+                    "archives": [
+                        {"name": "Prod", "path": "prod/"},
+                        {"name": "Staging", "path": "staging/"},
+                    ]
+                }
+            )
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["archive", "configure", "-o", str(out), "--list"])
+        assert result.exit_code == 0
+        assert "Prod" in result.output
+        assert "Staging" in result.output
+
+
+class TestArchiveConfigureRemove:
+    """Tests for --remove mode."""
+
+    def test_remove_existing(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        out.write_text(
+            json.dumps(
+                {
+                    "archives": [
+                        {"name": "Prod", "path": "p"},
+                        {"name": "Staging", "path": "s"},
+                    ]
+                }
+            )
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["archive", "configure", "-o", str(out), "--remove", "Prod"]
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert len(data["archives"]) == 1
+        assert data["archives"][0]["name"] == "Staging"
+
+    def test_remove_nonexistent_fails(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        out.write_text(json.dumps({"archives": [{"name": "Prod", "path": "p"}]}))
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["archive", "configure", "-o", str(out), "--remove", "Nope"]
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestArchiveConfigureInteractive:
+    """Tests for interactive mode."""
+
+    def test_interactive_add_two(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "configure", "-o", str(out)],
+            input="Prod\nstatic/archive/prod\nStaging\nstatic/archive/staging\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert len(data["archives"]) == 2
+
+    def test_interactive_empty_exits(self, tmp_path: Path) -> None:
+        out = tmp_path / "archives.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["archive", "configure", "-o", str(out)],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert not out.exists()
+
+
+class TestArchiveConfigureHelp:
+    def test_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["archive", "configure", "--help"])
+        assert result.exit_code == 0
+        assert "--add" in result.output
+        assert "--list" in result.output
+        assert "--remove" in result.output


### PR DESCRIPTION
## Summary

- Add `regis archive configure` command with `--add`, `--list`, `--remove` flags and interactive mode for creating/editing `archives.json`
- Validates output against `archives.schema.json`
- Add post-install notes to the archive bootstrap template showing how to set up multiple archives
- Add multi-archive usage guide to Docusaurus docs at `/usage/multi-archive`

## Test plan

- [x] `pipenv run pytest --no-cov` — 370 tests pass
- [x] `pipenv run ruff check . && ruff format --check .` — clean
- [x] `trunk check` — no new issues
- [ ] `regis archive configure --add "Test:path" -o /tmp/test.json` — creates valid archives.json
- [ ] `regis bootstrap archive . --no-input` — post-install notes mention archive configure