### PR TITLE
feat(cli): add bootstrap gitlab-ci wizard for Request-to-MR pipeline

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -53,6 +53,9 @@ lint:
         - CHANGELOG.md
         - CLAUDE.md
         - report.json
+    - linters: [prettier, yamllint]
+      paths:
+        - regis/cookiecutters/**
     - linters: [prettier]
       paths:
         - docs/website/versions.json

--- a/regis/commands/bootstrap.py
+++ b/regis/commands/bootstrap.py
@@ -107,6 +107,53 @@ def bootstrap_playbook(output_dir: str, no_input: bool) -> None:
         raise click.ClickException(f"Failed to bootstrap playbook: {exc}") from exc
 
 
+@bootstrap.command(name="gitlab-ci")
+@click.argument(
+    "output_dir", type=click.Path(file_okay=False, dir_okay=True), default="."
+)
+@click.option(
+    "--no-input",
+    is_flag=True,
+    help="Do not prompt for parameters and only use cookiecutter.json defaults.",
+)
+def bootstrap_gitlab_ci(output_dir: str, no_input: bool) -> None:
+    """Scaffold a GitLab CI pipeline for the Request-to-MR analysis workflow."""
+    try:
+        from importlib import resources
+
+        from cookiecutter.main import cookiecutter
+    except ImportError as exc:
+        raise click.ClickException(
+            f"cookiecutter not found or failed to import: {exc}. "
+            "Please install it with 'pip install cookiecutter'."
+        ) from None
+
+    template_path = resources.files("regis") / "cookiecutters" / "gitlab-ci"
+
+    click.echo(f"Scaffolding GitLab CI pipeline into {output_dir}...", err=True)
+    try:
+        project_dir = cookiecutter(
+            str(template_path),
+            no_input=no_input,
+            output_dir=output_dir,
+        )
+        click.echo("  ✓ GitLab CI pipeline scaffolded successfully.", err=True)
+
+        notes_file = Path(project_dir) / ".regis-post-install.md"
+        if notes_file.exists():
+            click.echo("\n" + "=" * 40, err=True)
+            click.echo("POST-INSTALL NOTES:", err=True)
+            click.echo("=" * 40, err=True)
+            click.echo(notes_file.read_text(encoding="utf-8"), err=True)
+            click.echo("=" * 40 + "\n", err=True)
+            notes_file.unlink()
+
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to scaffold GitLab CI pipeline: {exc}"
+        ) from exc
+
+
 @bootstrap.command(name="archive")
 @click.argument(
     "output_dir", type=click.Path(file_okay=False, dir_okay=True), default="."

--- a/regis/cookiecutters/gitlab-ci/cookiecutter.json
+++ b/regis/cookiecutters/gitlab-ci/cookiecutter.json
@@ -1,0 +1,6 @@
+{
+  "project_name": "My Regis Pipeline",
+  "project_slug": "{{ cookiecutter.project_name | lower | replace(' ', '-') }}",
+  "default_image_url": "alpine:latest",
+  "regis_version": "latest"
+}

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -1,0 +1,93 @@
+# Regis — Request-to-MR Pipeline
+# Scaffolded by: regis bootstrap gitlab-ci
+# Docs: https://trivoallan.github.io/regis/docs/usage/integrations/gitlab
+
+variables:
+  REGIS_IMAGE: "ghcr.io/trivoallan/regis:{{ cookiecutter.regis_version }}"
+  IMAGE_URL: "{{ cookiecutter.default_image_url }}"
+
+stages:
+  - request
+  - analyze
+  - report
+
+# --- Stage 1: Create analysis branch and MR ---
+request_analysis:
+  stage: request
+  image: alpine:latest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web" && $IMAGE_URL
+  before_script:
+    - apk add --no-cache git curl
+  script:
+    - |
+      BRANCH="regis/analyze/$(date +%Y%m%d-%H%M%S)"
+      git config user.name "regis-ci"
+      git config user.email "regis-ci@noreply"
+      git checkout -b "$BRANCH"
+      echo "$IMAGE_URL" > .regis-image-url
+      git add .regis-image-url
+      git commit -m "chore(regis): request analysis of $IMAGE_URL"
+      git push \
+        -o merge_request.create \
+        -o merge_request.title="Regis Analysis: $IMAGE_URL" \
+        -o merge_request.description="Automated security analysis requested via pipeline." \
+        -o merge_request.remove_source_branch \
+        "https://oauth2:${GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" \
+        "$BRANCH"
+
+# --- Stage 2: Run regis analysis ---
+analyze_image:
+  stage: analyze
+  image: $REGIS_IMAGE
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - |
+      if [ -f .regis-image-url ]; then
+        IMAGE_URL=$(cat .regis-image-url)
+      fi
+
+      REPORT_BASE_URL="/${CI_PROJECT_PATH}/-/jobs/${CI_JOB_ID}/artifacts/file/reports/${CI_JOB_ID}/"
+
+      regis analyze "$IMAGE_URL" \
+        --playbook playbook.yaml \
+        --site \
+        --base-url "$REPORT_BASE_URL" \
+        --output-dir reports \
+        --meta "trigger.user=$GITLAB_USER_LOGIN" \
+        --meta "trigger.url=$CI_JOB_URL" \
+        --meta "gitlab.mr_url=$CI_MERGE_REQUEST_PROJECT_URL/-/merge_requests/$CI_MERGE_REQUEST_IID"
+  artifacts:
+    paths:
+      - reports/
+    expire_in: 30 days
+
+# --- Stage 3: Push results to MR ---
+push_results:
+  stage: report
+  image: $REGIS_IMAGE
+  needs:
+    - analyze_image
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  before_script:
+    - apk add --no-cache git || true
+  script:
+    - |
+      # Commit reports back to the branch
+      git config user.name "regis-ci"
+      git config user.email "regis-ci@noreply"
+      git add reports/ || true
+      git commit -m "chore(report): analysis complete" || true
+      git push "https://oauth2:${GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" HEAD:"$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME" || true
+
+      # Post results to MR
+      MR_API_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}"
+      REPORT_URL="${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/file/reports/${CI_JOB_ID}/index.html"
+
+      regis gitlab update-mr \
+        --report reports/report.json \
+        --report-url "$REPORT_URL" \
+        --mr-url "$MR_API_URL" \
+        --token "$GITLAB_TOKEN"

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/.regis-post-install.md
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/.regis-post-install.md
@@ -1,0 +1,26 @@
+# Next Steps
+
+Your GitLab CI pipeline has been scaffolded.
+
+## 1. Configure CI/CD Variables
+
+In your GitLab project, go to **Settings > CI/CD > Variables** and add:
+
+- `GITLAB_TOKEN` — Project Access Token with `api` + `write_repository` scopes
+
+See `CI-VARIABLES.md` for the full list.
+
+## 2. Commit and Push
+
+    git add .gitlab-ci.yml playbook.yaml CI-VARIABLES.md
+    git commit -m "feat(ci): add Regis analysis pipeline"
+    git push
+
+## 3. Run Your First Analysis
+
+Go to **Build > Pipelines > Run pipeline**, enter an `IMAGE_URL`, and click Run.
+
+## Documentation
+
+- [Pipeline setup](https://trivoallan.github.io/regis/docs/usage/integrations/gitlab)
+- [Playbook customization](https://trivoallan.github.io/regis/docs/usage/custom-playbook)

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/CI-VARIABLES.md
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/CI-VARIABLES.md
@@ -1,0 +1,23 @@
+# CI/CD Variables — {{ cookiecutter.project_name }}
+
+Configure these variables in **Settings > CI/CD > Variables** in your GitLab project.
+
+## Required
+
+| Variable       | Description                                                                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_TOKEN` | Project Access Token with `api` and `write_repository` scopes. Role: Developer (minimum). **Do not protect** this variable, or protect the `regis/analyze/*` branch pattern. |
+
+## Pipeline Input
+
+| Variable    | Description                                                                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IMAGE_URL` | Container image to analyze (e.g., `docker.io/library/alpine:3.18`). Set when running the pipeline manually via **Build > Pipelines > Run pipeline**. |
+
+## Optional
+
+| Variable                  | Description                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `REGIS_REGISTRY_USER`     | Username for private registry authentication.                                  |
+| `REGIS_REGISTRY_PASSWORD` | Password or token for private registry authentication.                         |
+| `DOCKER_AUTH_CONFIG`      | Docker config JSON for registry authentication (alternative to user/password). |

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
@@ -2,7 +2,7 @@
 # Scaffolded by: regis bootstrap gitlab-ci
 # Docs: https://trivoallan.github.io/regis/docs/concepts/playbooks
 
-name: { { cookiecutter.project_name } }
+name: "{{ cookiecutter.project_name }}"
 
 tiers:
   - name: Gold

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
@@ -1,0 +1,97 @@
+# Regis Playbook — {{ cookiecutter.project_name }}
+# Scaffolded by: regis bootstrap gitlab-ci
+# Docs: https://trivoallan.github.io/regis/docs/concepts/playbooks
+
+name: { { cookiecutter.project_name } }
+
+tiers:
+  - name: Gold
+    condition:
+      ">": [{ var: rules_summary.score }, 90]
+  - name: Silver
+    condition:
+      ">": [{ var: rules_summary.score }, 70]
+  - name: Bronze
+    condition:
+      ">": [{ var: rules_summary.score }, 50]
+
+rules:
+  - provider: trivy
+    rule: cve-count
+    slug: cve-critical
+    level: critical
+    options:
+      level: critical
+      max_count: 0
+
+  - provider: trivy
+    rule: cve-count
+    slug: cve-high
+    level: warning
+    options:
+      level: high
+      max_count: 10
+
+  - provider: trivy
+    rule: fix-available
+    slug: cve-fixable
+    level: warning
+
+  - provider: skopeo
+    rule: user-blacklist
+    slug: no-root
+    level: critical
+
+  - provider: freshness
+    rule: age
+    slug: age
+    level: info
+    options:
+      max_days: 90
+
+  - provider: sbom
+    rule: has-sbom
+    slug: has-sbom
+    level: warning
+
+badges:
+  - slug: cve-critical
+    scope: CVE
+    value: Critical
+    condition:
+      "!": [{ var: rules.cve-critical.passed }]
+    class: error
+  - slug: cve-high
+    scope: CVE
+    value: High
+    condition:
+      "!": [{ var: rules.cve-high.passed }]
+    class: warning
+  - slug: freshness
+    scope: Freshness
+    value: Fresh
+    condition:
+      "==": [{ var: rules.age.passed }, true]
+    class: success
+
+integrations:
+  gitlab:
+    badges:
+      - cve-critical
+      - cve-high
+      - freshness
+    checklists:
+      - title: "\U0001F4DD Security Review"  # yamllint disable-line rule:quoted-strings
+        items:
+          - label: Security review completed
+          - label: No critical vulnerabilities detected
+            show_if: { "!!": [{ var: rules.cve-critical }] }
+            check_if: { var: rules.cve-critical.passed }
+          - label: Image does not run as root
+            show_if: { "!!": [{ var: rules.no-root }] }
+            check_if: { var: rules.no-root.passed }
+
+links:
+  - label: Return to Merge Request
+    url: "{% raw %}{{ request.metadata['gitlab.mr_url'] }}{% endraw %}"
+    condition: { "!!": [{ var: request.metadata.gitlab.mr_url }] }

--- a/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
+++ b/regis/cookiecutters/gitlab-ci/{{cookiecutter.project_slug}}/playbook.yaml
@@ -81,7 +81,7 @@ integrations:
       - cve-high
       - freshness
     checklists:
-      - title: "\U0001F4DD Security Review"  # yamllint disable-line rule:quoted-strings
+      - title: "\U0001F4DD Security Review" # yamllint disable-line rule:quoted-strings
         items:
           - label: Security review completed
           - label: No critical vulnerabilities detected

--- a/tests/test_bootstrap_gitlab_ci.py
+++ b/tests/test_bootstrap_gitlab_ci.py
@@ -1,0 +1,80 @@
+"""Tests for regis bootstrap gitlab-ci command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from regis.cli import main
+
+
+def test_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["bootstrap", "gitlab-ci", "--help"])
+    assert result.exit_code == 0
+    assert "gitlab" in result.output.lower()
+    assert "--no-input" in result.output
+
+
+def test_no_input_generates_files():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["bootstrap", "gitlab-ci", ".", "--no-input"])
+        assert result.exit_code == 0, result.output
+
+        project_dir = Path("my-regis-pipeline")
+        assert project_dir.exists()
+        assert (project_dir / ".gitlab-ci.yml").exists()
+        assert (project_dir / "playbook.yaml").exists()
+        assert (project_dir / "CI-VARIABLES.md").exists()
+        # Post-install notes should be displayed and deleted
+        assert not (project_dir / ".regis-post-install.md").exists()
+
+
+def test_generated_gitlab_ci_is_valid_yaml():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["bootstrap", "gitlab-ci", ".", "--no-input"])
+        assert result.exit_code == 0, result.output
+
+        ci_file = Path("my-regis-pipeline/.gitlab-ci.yml")
+        data = yaml.safe_load(ci_file.read_text(encoding="utf-8"))
+        assert "stages" in data
+        assert "request_analysis" in data
+        assert "analyze_image" in data
+        assert "push_results" in data
+
+
+def test_generated_playbook_has_gitlab_integration():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["bootstrap", "gitlab-ci", ".", "--no-input"])
+        assert result.exit_code == 0, result.output
+
+        pb_file = Path("my-regis-pipeline/playbook.yaml")
+        data = yaml.safe_load(pb_file.read_text(encoding="utf-8"))
+        assert "integrations" in data
+        assert "gitlab" in data["integrations"]
+        assert "badges" in data["integrations"]["gitlab"]
+        assert "checklists" in data["integrations"]["gitlab"]
+
+
+def test_generated_ci_variables_lists_required_vars():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["bootstrap", "gitlab-ci", ".", "--no-input"])
+        assert result.exit_code == 0, result.output
+
+        content = Path("my-regis-pipeline/CI-VARIABLES.md").read_text(encoding="utf-8")
+        assert "GITLAB_TOKEN" in content
+        assert "IMAGE_URL" in content
+
+
+def test_post_install_notes_displayed():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["bootstrap", "gitlab-ci", ".", "--no-input"])
+        assert result.exit_code == 0, result.output
+        assert "POST-INSTALL NOTES" in result.output or "Next Steps" in result.output


### PR DESCRIPTION
## Summary

- Add `regis bootstrap gitlab-ci` command that scaffolds the complete GitLab CI pipeline for the self-service Request-to-MR analysis workflow
- Generates `.gitlab-ci.yml` (3-job pipeline: request_analysis, analyze_image, push_results), `playbook.yaml` (with `integrations.gitlab`), and `CI-VARIABLES.md`
- Supports `--no-input` for non-interactive scaffolding
- Post-install notes guide users through variable setup and first run

Phase 1 of: CLI wizard -> web form -> GitLab UI widget -> dashboard integration.

## Test plan

- [x] `pipenv run pytest --no-cov` — 376 tests pass
- [x] Generated `.gitlab-ci.yml` is valid YAML with all 3 jobs
- [x] Generated `playbook.yaml` has `integrations.gitlab` section
- [x] Generated `CI-VARIABLES.md` lists required variables
- [x] Post-install notes displayed and cleaned up