### PR TITLE
feat(cli): add GitLab integration to dashboard (API proxy, trigger, webhooks, UI)

### DIFF
--- a/apps/dashboard/src/components/GitLabMRList.tsx
+++ b/apps/dashboard/src/components/GitLabMRList.tsx
@@ -111,9 +111,7 @@ export function GitLabMRList(): React.JSX.Element {
             ) : mrs.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={7}>
-                  <Text className="text-center">
-                    No merge requests found.
-                  </Text>
+                  <Text className="text-center">No merge requests found.</Text>
                 </TableCell>
               </TableRow>
             ) : (
@@ -160,9 +158,7 @@ export function GitLabMRList(): React.JSX.Element {
                     )}
                   </TableCell>
                   <TableCell>
-                    <Text>
-                      {new Date(mr.updated_at).toLocaleDateString()}
-                    </Text>
+                    <Text>{new Date(mr.updated_at).toLocaleDateString()}</Text>
                   </TableCell>
                 </TableRow>
               ))

--- a/apps/dashboard/src/components/GitLabMRList.tsx
+++ b/apps/dashboard/src/components/GitLabMRList.tsx
@@ -1,0 +1,175 @@
+/**
+ * GitLabMRList — Displays merge requests with regis labels and scores.
+ * Fetches from /api/gitlab/mrs (served by the FastAPI backend).
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  Badge,
+  Card,
+  Select,
+  SelectItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title,
+} from "@tremor/react";
+
+interface MR {
+  iid: number;
+  title: string;
+  state: string;
+  web_url: string;
+  source_branch: string;
+  author: string | null;
+  created_at: string;
+  updated_at: string;
+  labels: string[];
+  regis_labels: string[];
+  has_report: boolean;
+}
+
+const STATE_COLORS: Record<string, string> = {
+  opened: "emerald",
+  merged: "blue",
+  closed: "red",
+};
+
+export function GitLabMRList(): React.JSX.Element {
+  const [mrs, setMrs] = useState<MR[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stateFilter, setStateFilter] = useState("opened");
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetch(`/api/gitlab/mrs?state=${stateFilter}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data) => setMrs(data.merge_requests ?? []))
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [stateFilter]);
+
+  if (error) {
+    return (
+      <Card className="mt-4">
+        <Text className="text-red-500">
+          Failed to load merge requests: {error}
+        </Text>
+        <Text className="mt-2">
+          Make sure the server was started with <code>--gitlab-url</code>,{" "}
+          <code>--gitlab-token</code>, and <code>--gitlab-project</code>.
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center gap-4 mb-4">
+        <Title>Merge Requests</Title>
+        <Select
+          value={stateFilter}
+          onValueChange={setStateFilter}
+          className="max-w-xs"
+        >
+          <SelectItem value="opened">Open</SelectItem>
+          <SelectItem value="merged">Merged</SelectItem>
+          <SelectItem value="closed">Closed</SelectItem>
+          <SelectItem value="all">All</SelectItem>
+        </Select>
+      </div>
+
+      <Card>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>MR</TableHeaderCell>
+              <TableHeaderCell>Title</TableHeaderCell>
+              <TableHeaderCell>Author</TableHeaderCell>
+              <TableHeaderCell>State</TableHeaderCell>
+              <TableHeaderCell>Regis Labels</TableHeaderCell>
+              <TableHeaderCell>Report</TableHeaderCell>
+              <TableHeaderCell>Updated</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={7}>
+                  <Text className="text-center">Loading...</Text>
+                </TableCell>
+              </TableRow>
+            ) : mrs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7}>
+                  <Text className="text-center">
+                    No merge requests found.
+                  </Text>
+                </TableCell>
+              </TableRow>
+            ) : (
+              mrs.map((mr) => (
+                <TableRow key={mr.iid}>
+                  <TableCell>
+                    <a
+                      href={mr.web_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      !{mr.iid}
+                    </a>
+                  </TableCell>
+                  <TableCell>
+                    <Text className="font-medium">{mr.title}</Text>
+                  </TableCell>
+                  <TableCell>
+                    <Text>{mr.author ?? "—"}</Text>
+                  </TableCell>
+                  <TableCell>
+                    <Badge color={STATE_COLORS[mr.state] ?? "gray"}>
+                      {mr.state}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {mr.regis_labels.length > 0
+                        ? mr.regis_labels.map((lb) => (
+                            <Badge key={lb} size="xs">
+                              {lb.replace("regis::", "")}
+                            </Badge>
+                          ))
+                        : "—"}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {mr.has_report ? (
+                      <Badge color="emerald" size="xs">
+                        Available
+                      </Badge>
+                    ) : (
+                      <Text>—</Text>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Text>
+                      {new Date(mr.updated_at).toLocaleDateString()}
+                    </Text>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </Card>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/MRComparison.tsx
+++ b/apps/dashboard/src/components/MRComparison.tsx
@@ -45,13 +45,15 @@ function MRCard({ mr }: { mr: MRDetail }): React.JSX.Element {
         <div>
           <Text className="text-xs font-medium uppercase">Regis Labels</Text>
           <div className="flex flex-wrap gap-1 mt-1">
-            {mr.regis_labels.length > 0
-              ? mr.regis_labels.map((lb) => (
-                  <Badge key={lb} size="xs">
-                    {lb.replace("regis::", "")}
-                  </Badge>
-                ))
-              : <Text>None</Text>}
+            {mr.regis_labels.length > 0 ? (
+              mr.regis_labels.map((lb) => (
+                <Badge key={lb} size="xs">
+                  {lb.replace("regis::", "")}
+                </Badge>
+              ))
+            ) : (
+              <Text>None</Text>
+            )}
           </div>
         </div>
 
@@ -59,7 +61,9 @@ function MRCard({ mr }: { mr: MRDetail }): React.JSX.Element {
           <Text className="text-xs font-medium uppercase">Report</Text>
           <Text>
             {mr.has_report ? (
-              <Badge color="emerald" size="xs">Available</Badge>
+              <Badge color="emerald" size="xs">
+                Available
+              </Badge>
             ) : (
               "Not available"
             )}

--- a/apps/dashboard/src/components/MRComparison.tsx
+++ b/apps/dashboard/src/components/MRComparison.tsx
@@ -1,0 +1,180 @@
+/**
+ * MRComparison — Compare analysis results between two merge requests.
+ * Fetches individual MR details from /api/gitlab/mrs/{iid}.
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  Badge,
+  Card,
+  Grid,
+  Text,
+  TextInput,
+  Title,
+  Button,
+} from "@tremor/react";
+
+interface MRDetail {
+  iid: number;
+  title: string;
+  state: string;
+  web_url: string;
+  regis_labels: string[];
+  has_report: boolean;
+  description: string;
+  merge_status: string | null;
+  pipeline: { id: number; status: string; web_url: string } | null;
+}
+
+function MRCard({ mr }: { mr: MRDetail }): React.JSX.Element {
+  return (
+    <Card>
+      <div className="flex items-center gap-2 mb-2">
+        <Title>
+          <a href={mr.web_url} target="_blank" rel="noopener noreferrer">
+            !{mr.iid}
+          </a>
+        </Title>
+        <Badge color={mr.state === "opened" ? "emerald" : "blue"}>
+          {mr.state}
+        </Badge>
+      </div>
+      <Text className="font-medium mb-3">{mr.title}</Text>
+
+      <div className="flex flex-col gap-2">
+        <div>
+          <Text className="text-xs font-medium uppercase">Regis Labels</Text>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {mr.regis_labels.length > 0
+              ? mr.regis_labels.map((lb) => (
+                  <Badge key={lb} size="xs">
+                    {lb.replace("regis::", "")}
+                  </Badge>
+                ))
+              : <Text>None</Text>}
+          </div>
+        </div>
+
+        <div>
+          <Text className="text-xs font-medium uppercase">Report</Text>
+          <Text>
+            {mr.has_report ? (
+              <Badge color="emerald" size="xs">Available</Badge>
+            ) : (
+              "Not available"
+            )}
+          </Text>
+        </div>
+
+        {mr.pipeline && (
+          <div>
+            <Text className="text-xs font-medium uppercase">Pipeline</Text>
+            <div className="flex items-center gap-2">
+              <Badge
+                color={mr.pipeline.status === "success" ? "emerald" : "yellow"}
+                size="xs"
+              >
+                {mr.pipeline.status}
+              </Badge>
+              <a
+                href={mr.pipeline.web_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 hover:underline"
+              >
+                #{mr.pipeline.id}
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export function MRComparison(): React.JSX.Element {
+  const [leftIid, setLeftIid] = useState("");
+  const [rightIid, setRightIid] = useState("");
+  const [leftMR, setLeftMR] = useState<MRDetail | null>(null);
+  const [rightMR, setRightMR] = useState<MRDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchMR(iid: string): Promise<MRDetail> {
+    const resp = await fetch(`/api/gitlab/mrs/${iid}`);
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      throw new Error(data.detail ?? `MR !${iid}: HTTP ${resp.status}`);
+    }
+    return resp.json();
+  }
+
+  async function handleCompare() {
+    if (!leftIid.trim() || !rightIid.trim()) return;
+    setLoading(true);
+    setError(null);
+    setLeftMR(null);
+    setRightMR(null);
+
+    try {
+      const [left, right] = await Promise.all([
+        fetchMR(leftIid),
+        fetchMR(rightIid),
+      ]);
+      setLeftMR(left);
+      setRightMR(right);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-4">
+      <Title>Compare Merge Requests</Title>
+      <Text className="mb-4">
+        Enter two MR IIDs to compare their analysis results side by side.
+      </Text>
+
+      <div className="flex items-end gap-4 mb-6">
+        <div>
+          <label className="block text-sm font-medium mb-1">Left MR</label>
+          <TextInput
+            placeholder="e.g. 42"
+            value={leftIid}
+            onValueChange={setLeftIid}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Right MR</label>
+          <TextInput
+            placeholder="e.g. 43"
+            value={rightIid}
+            onValueChange={setRightIid}
+          />
+        </div>
+        <Button
+          onClick={handleCompare}
+          loading={loading}
+          disabled={!leftIid.trim() || !rightIid.trim() || loading}
+        >
+          Compare
+        </Button>
+      </div>
+
+      {error && (
+        <Card className="mb-4">
+          <Text className="text-red-500">{error}</Text>
+        </Card>
+      )}
+
+      {leftMR && rightMR && (
+        <Grid numItems={1} numItemsMd={2} className="gap-4">
+          <MRCard mr={leftMR} />
+          <MRCard mr={rightMR} />
+        </Grid>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/TriggerAnalysis.tsx
+++ b/apps/dashboard/src/components/TriggerAnalysis.tsx
@@ -1,0 +1,122 @@
+/**
+ * TriggerAnalysis — Form to trigger a GitLab pipeline analysis.
+ * Posts to /api/gitlab/trigger (served by the FastAPI backend).
+ */
+
+import React, { useState } from "react";
+import { Button, Card, Text, TextInput, Title } from "@tremor/react";
+
+interface TriggerResult {
+  pipeline_id: number;
+  status: string;
+  web_url: string;
+}
+
+export function TriggerAnalysis(): React.JSX.Element {
+  const [imageUrl, setImageUrl] = useState("");
+  const [ref, setRef] = useState("main");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TriggerResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!imageUrl.trim()) return;
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const resp = await fetch("/api/gitlab/trigger", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ image_url: imageUrl, ref }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        throw new Error(data.detail ?? `HTTP ${resp.status}`);
+      }
+      setResult(await resp.json());
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-4" style={{ maxWidth: 600 }}>
+      <Title>Trigger Analysis</Title>
+      <Text className="mb-4">
+        Start a GitLab pipeline to analyze a container image.
+      </Text>
+
+      <Card>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Image URL
+            </label>
+            <TextInput
+              placeholder="e.g. alpine:latest, nginx:1.25, ghcr.io/org/app:v2"
+              value={imageUrl}
+              onValueChange={setImageUrl}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Branch (ref)
+            </label>
+            <TextInput
+              placeholder="main"
+              value={ref}
+              onValueChange={setRef}
+            />
+          </div>
+          <Button
+            type="submit"
+            loading={loading}
+            disabled={!imageUrl.trim() || loading}
+          >
+            {loading ? "Triggering..." : "Run Analysis"}
+          </Button>
+        </form>
+      </Card>
+
+      {result && (
+        <Card className="mt-4">
+          <Text className="font-medium text-emerald-600">
+            Pipeline triggered successfully
+          </Text>
+          <div className="mt-2 flex flex-col gap-1">
+            <Text>
+              Pipeline ID: <strong>#{result.pipeline_id}</strong>
+            </Text>
+            <Text>
+              Status: <strong>{result.status}</strong>
+            </Text>
+            <a
+              href={result.web_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              View pipeline on GitLab
+            </a>
+          </div>
+        </Card>
+      )}
+
+      {error && (
+        <Card className="mt-4">
+          <Text className="text-red-500">Failed to trigger: {error}</Text>
+          <Text className="mt-2">
+            Make sure the server was started with GitLab options and the
+            token has pipeline trigger permissions.
+          </Text>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/TriggerAnalysis.tsx
+++ b/apps/dashboard/src/components/TriggerAnalysis.tsx
@@ -55,9 +55,7 @@ export function TriggerAnalysis(): React.JSX.Element {
       <Card>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>
-            <label className="block text-sm font-medium mb-1">
-              Image URL
-            </label>
+            <label className="block text-sm font-medium mb-1">Image URL</label>
             <TextInput
               placeholder="e.g. alpine:latest, nginx:1.25, ghcr.io/org/app:v2"
               value={imageUrl}
@@ -68,11 +66,7 @@ export function TriggerAnalysis(): React.JSX.Element {
             <label className="block text-sm font-medium mb-1">
               Branch (ref)
             </label>
-            <TextInput
-              placeholder="main"
-              value={ref}
-              onValueChange={setRef}
-            />
+            <TextInput placeholder="main" value={ref} onValueChange={setRef} />
           </div>
           <Button
             type="submit"
@@ -112,8 +106,8 @@ export function TriggerAnalysis(): React.JSX.Element {
         <Card className="mt-4">
           <Text className="text-red-500">Failed to trigger: {error}</Text>
           <Text className="mt-2">
-            Make sure the server was started with GitLab options and the
-            token has pipeline trigger permissions.
+            Make sure the server was started with GitLab options and the token
+            has pipeline trigger permissions.
           </Text>
         </Card>
       )}

--- a/apps/dashboard/src/pages/gitlab.tsx
+++ b/apps/dashboard/src/pages/gitlab.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import Layout from "@theme/Layout";
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@tremor/react";
+import { GitLabMRList } from "@site/src/components/GitLabMRList";
+import { TriggerAnalysis } from "@site/src/components/TriggerAnalysis";
+import { MRComparison } from "@site/src/components/MRComparison";
+
+export default function GitLabPage(): React.JSX.Element {
+  return (
+    <Layout title="GitLab Integration">
+      <div className="container margin-top--lg margin-bottom--lg">
+        <h1>GitLab Integration</h1>
+        <TabGroup>
+          <TabList>
+            <Tab>Merge Requests</Tab>
+            <Tab>Trigger Analysis</Tab>
+            <Tab>Compare</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <GitLabMRList />
+            </TabPanel>
+            <TabPanel>
+              <TriggerAnalysis />
+            </TabPanel>
+            <TabPanel>
+              <MRComparison />
+            </TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </div>
+    </Layout>
+  );
+}

--- a/regis/commands/dashboard.py
+++ b/regis/commands/dashboard.py
@@ -126,8 +126,31 @@ def export_cmd(
     multiple=True,
     help='Named archive to include, format "Name:path-or-url". Repeatable.',
 )
+@click.option(
+    "--gitlab-url",
+    envvar="GITLAB_URL",
+    default=None,
+    help="GitLab instance URL (e.g. https://gitlab.com). Env: GITLAB_URL.",
+)
+@click.option(
+    "--gitlab-token",
+    envvar="GITLAB_TOKEN",
+    default=None,
+    help="GitLab private token. Env: GITLAB_TOKEN.",
+)
+@click.option(
+    "--gitlab-project",
+    envvar="GITLAB_PROJECT",
+    default=None,
+    help="GitLab project ID or path. Env: GITLAB_PROJECT.",
+)
 def serve_cmd(  # pragma: no cover
-    port: int, report: Path | None = None, archives: tuple[str, ...] = ()
+    port: int,
+    report: Path | None = None,
+    archives: tuple[str, ...] = (),
+    gitlab_url: str | None = None,
+    gitlab_token: str | None = None,
+    gitlab_project: str | None = None,
 ) -> None:
     """Serve the interactive dashboard and preview the report locally."""
     import uvicorn
@@ -142,6 +165,9 @@ def serve_cmd(  # pragma: no cover
         assets_dir=assets_dir,
         report=report.absolute() if report else None,
         archives=parsed_archives,
+        gitlab_url=gitlab_url,
+        gitlab_token=gitlab_token,
+        gitlab_project=gitlab_project,
     )
 
     url = f"http://localhost:{port}/"

--- a/regis/commands/dashboard.py
+++ b/regis/commands/dashboard.py
@@ -144,6 +144,12 @@ def export_cmd(
     default=None,
     help="GitLab project ID or path. Env: GITLAB_PROJECT.",
 )
+@click.option(
+    "--webhook-secret",
+    envvar="REGIS_WEBHOOK_SECRET",
+    default=None,
+    help="Secret token to validate incoming webhooks. Env: REGIS_WEBHOOK_SECRET.",
+)
 def serve_cmd(  # pragma: no cover
     port: int,
     report: Path | None = None,
@@ -151,6 +157,7 @@ def serve_cmd(  # pragma: no cover
     gitlab_url: str | None = None,
     gitlab_token: str | None = None,
     gitlab_project: str | None = None,
+    webhook_secret: str | None = None,
 ) -> None:
     """Serve the interactive dashboard and preview the report locally."""
     import uvicorn
@@ -168,6 +175,7 @@ def serve_cmd(  # pragma: no cover
         gitlab_url=gitlab_url,
         gitlab_token=gitlab_token,
         gitlab_project=gitlab_project,
+        webhook_secret=webhook_secret,
     )
 
     url = f"http://localhost:{port}/"

--- a/regis/server/app.py
+++ b/regis/server/app.py
@@ -63,6 +63,10 @@ def create_app(
         )
         app.include_router(create_gitlab_router(gitlab_config))
 
+        from regis.server.routes.trigger import create_trigger_router
+
+        app.include_router(create_trigger_router(gitlab_config))
+
     # Static files + SPA fallback must be mounted last
     app.mount("/", _SPAStaticFiles(directory=str(assets_dir), html=True), name="spa")
 

--- a/regis/server/app.py
+++ b/regis/server/app.py
@@ -21,6 +21,7 @@ def create_app(
     gitlab_url: str | None = None,
     gitlab_token: str | None = None,
     gitlab_project: str | None = None,
+    webhook_secret: str | None = None,
 ) -> FastAPI:
     """Create and configure the dashboard FastAPI application.
 
@@ -66,6 +67,13 @@ def create_app(
         from regis.server.routes.trigger import create_trigger_router
 
         app.include_router(create_trigger_router(gitlab_config))
+
+    # Webhook receiver (works with or without GitLab config)
+    from regis.server.routes.webhooks import create_webhooks_router
+
+    webhooks_router, event_bus = create_webhooks_router(webhook_secret=webhook_secret)
+    app.include_router(webhooks_router)
+    app.state.event_bus = event_bus
 
     # Static files + SPA fallback must be mounted last
     app.mount("/", _SPAStaticFiles(directory=str(assets_dir), html=True), name="spa")

--- a/regis/server/app.py
+++ b/regis/server/app.py
@@ -18,6 +18,9 @@ def create_app(
     assets_dir: Path,
     report: Path | None = None,
     archives: list[dict[str, str]] | None = None,
+    gitlab_url: str | None = None,
+    gitlab_token: str | None = None,
+    gitlab_project: str | None = None,
 ) -> FastAPI:
     """Create and configure the dashboard FastAPI application.
 
@@ -25,6 +28,9 @@ def create_app(
         assets_dir: Path to the bundled dashboard static assets.
         report: Optional path to a report.json file to serve.
         archives: Optional list of archive dicts (name/path) for archives.json.
+        gitlab_url: GitLab instance URL (e.g. https://gitlab.com).
+        gitlab_token: GitLab private token for API access.
+        gitlab_project: GitLab project ID or path.
     """
     app = FastAPI(title="Regis Dashboard", docs_url=None, redoc_url=None)
 
@@ -47,6 +53,15 @@ def create_app(
     @app.get("/api/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    # Mount GitLab API proxy if configured
+    if gitlab_url and gitlab_token and gitlab_project:
+        from regis.server.routes.gitlab import GitLabConfig, create_gitlab_router
+
+        gitlab_config = GitLabConfig(
+            url=gitlab_url, token=gitlab_token, project_id=gitlab_project
+        )
+        app.include_router(create_gitlab_router(gitlab_config))
 
     # Static files + SPA fallback must be mounted last
     app.mount("/", _SPAStaticFiles(directory=str(assets_dir), html=True), name="spa")

--- a/regis/server/routes/__init__.py
+++ b/regis/server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules for the regis server."""

--- a/regis/server/routes/gitlab.py
+++ b/regis/server/routes/gitlab.py
@@ -1,0 +1,164 @@
+"""GitLab API proxy routes for the regis dashboard server."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import gitlab
+from fastapi import APIRouter, HTTPException
+
+logger = logging.getLogger(__name__)
+
+REGIS_LABEL_PREFIX = "regis::"
+
+
+@dataclass
+class GitLabConfig:
+    """Configuration for the GitLab API proxy."""
+
+    url: str
+    token: str
+    project_id: str | int
+
+
+def _get_project(config: GitLabConfig) -> Any:
+    """Get a python-gitlab project instance."""
+    gl = gitlab.Gitlab(config.url, private_token=config.token)
+    try:
+        return gl.projects.get(config.project_id)
+    except gitlab.GitlabGetError as exc:
+        raise HTTPException(
+            status_code=502, detail=f"Failed to access GitLab project: {exc}"
+        ) from exc
+
+
+def _extract_regis_labels(labels: list[str]) -> list[str]:
+    """Extract regis-scoped labels from a label list."""
+    return [lb for lb in labels if lb.startswith(REGIS_LABEL_PREFIX)]
+
+
+def _serialize_mr(mr: Any) -> dict[str, Any]:
+    """Serialize a MR object to a JSON-safe dict with regis-relevant fields."""
+    attrs = mr.attributes if hasattr(mr, "attributes") else mr
+    labels = attrs.get("labels", [])
+    return {
+        "iid": attrs["iid"],
+        "title": attrs["title"],
+        "state": attrs["state"],
+        "web_url": attrs["web_url"],
+        "source_branch": attrs["source_branch"],
+        "author": attrs.get("author", {}).get("username"),
+        "created_at": attrs["created_at"],
+        "updated_at": attrs["updated_at"],
+        "labels": labels,
+        "regis_labels": _extract_regis_labels(labels),
+        "has_report": "View Analysis Report" in (attrs.get("description") or ""),
+    }
+
+
+def _serialize_pipeline(pipeline: Any) -> dict[str, Any]:
+    """Serialize a pipeline object to a JSON-safe dict."""
+    attrs = pipeline.attributes if hasattr(pipeline, "attributes") else pipeline
+    return {
+        "id": attrs["id"],
+        "status": attrs["status"],
+        "ref": attrs["ref"],
+        "sha": attrs.get("sha", "")[:8],
+        "web_url": attrs["web_url"],
+        "created_at": attrs["created_at"],
+        "updated_at": attrs.get("updated_at"),
+        "source": attrs.get("source"),
+    }
+
+
+def create_gitlab_router(config: GitLabConfig) -> APIRouter:
+    """Create a FastAPI router with GitLab proxy endpoints.
+
+    Args:
+        config: GitLab connection configuration.
+    """
+    router = APIRouter(prefix="/api/gitlab", tags=["gitlab"])
+
+    @router.get("/mrs")
+    async def list_mrs(
+        state: str = "opened",
+        per_page: int = 20,
+    ) -> dict[str, Any]:
+        """List merge requests with regis analysis data."""
+        project = _get_project(config)
+        try:
+            mrs = project.mergerequests.list(
+                state=state,
+                per_page=per_page,
+                order_by="updated_at",
+                sort="desc",
+            )
+        except gitlab.GitlabListError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Failed to list MRs: {exc}"
+            ) from exc
+        return {
+            "merge_requests": [_serialize_mr(mr) for mr in mrs],
+            "total": len(mrs),
+        }
+
+    @router.get("/mrs/{iid}")
+    async def get_mr(iid: int) -> dict[str, Any]:
+        """Get a single merge request with full details."""
+        project = _get_project(config)
+        try:
+            mr = project.mergerequests.get(iid)
+        except gitlab.GitlabGetError as exc:
+            raise HTTPException(
+                status_code=404, detail=f"MR !{iid} not found: {exc}"
+            ) from exc
+
+        data = _serialize_mr(mr)
+        # Add extra detail fields
+        attrs = mr.attributes
+        data["description"] = attrs.get("description", "")
+        data["merge_status"] = attrs.get("merge_status")
+        data["pipeline"] = (
+            _serialize_pipeline_summary(attrs["pipeline"])
+            if attrs.get("pipeline")
+            else None
+        )
+        return data
+
+    @router.get("/pipelines")
+    async def list_pipelines(
+        per_page: int = 20,
+        source: str | None = None,
+    ) -> dict[str, Any]:
+        """List recent pipelines."""
+        project = _get_project(config)
+        kwargs: dict[str, Any] = {
+            "per_page": per_page,
+            "order_by": "updated_at",
+            "sort": "desc",
+        }
+        if source:
+            kwargs["source"] = source
+        try:
+            pipelines = project.pipelines.list(**kwargs)
+        except gitlab.GitlabListError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Failed to list pipelines: {exc}"
+            ) from exc
+        return {
+            "pipelines": [_serialize_pipeline(p) for p in pipelines],
+            "total": len(pipelines),
+        }
+
+    return router
+
+
+def _serialize_pipeline_summary(pipeline_data: dict[str, Any]) -> dict[str, Any]:
+    """Serialize an inline pipeline dict (from MR attributes)."""
+    return {
+        "id": pipeline_data.get("id"),
+        "status": pipeline_data.get("status"),
+        "web_url": pipeline_data.get("web_url"),
+    }

--- a/regis/server/routes/trigger.py
+++ b/regis/server/routes/trigger.py
@@ -1,0 +1,66 @@
+"""Pipeline trigger route for the regis dashboard server."""
+
+from __future__ import annotations
+
+import logging
+
+import gitlab
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from regis.server.routes.gitlab import GitLabConfig, _get_project
+
+logger = logging.getLogger(__name__)
+
+
+class TriggerRequest(BaseModel):
+    """Request body for triggering a pipeline analysis."""
+
+    image_url: str = Field(
+        ..., description="Container image to analyze (e.g. alpine:latest)"
+    )
+    ref: str = Field(default="main", description="Branch to run the pipeline on")
+
+
+class TriggerResponse(BaseModel):
+    """Response after triggering a pipeline."""
+
+    pipeline_id: int
+    status: str
+    web_url: str
+
+
+def create_trigger_router(config: GitLabConfig) -> APIRouter:
+    """Create a FastAPI router for pipeline trigger endpoints.
+
+    Args:
+        config: GitLab connection configuration.
+    """
+    router = APIRouter(prefix="/api/gitlab", tags=["gitlab"])
+
+    @router.post("/trigger", response_model=TriggerResponse)
+    async def trigger_pipeline(body: TriggerRequest) -> TriggerResponse:
+        """Trigger a GitLab pipeline with IMAGE_URL variable."""
+        project = _get_project(config)
+        try:
+            pipeline = project.pipelines.create(
+                {
+                    "ref": body.ref,
+                    "variables": [
+                        {"key": "IMAGE_URL", "value": body.image_url},
+                    ],
+                }
+            )
+        except gitlab.GitlabCreateError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Failed to trigger pipeline: {exc}"
+            ) from exc
+
+        attrs = pipeline.attributes if hasattr(pipeline, "attributes") else pipeline
+        return TriggerResponse(
+            pipeline_id=attrs["id"],
+            status=attrs["status"],
+            web_url=attrs["web_url"],
+        )
+
+    return router

--- a/regis/server/routes/webhooks.py
+++ b/regis/server/routes/webhooks.py
@@ -1,0 +1,144 @@
+"""GitLab webhook receiver for the regis dashboard server."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+MAX_EVENTS = 100
+
+
+class EventBus:
+    """In-memory event bus for SSE broadcasting."""
+
+    def __init__(self) -> None:
+        self._events: deque[dict[str, Any]] = deque(maxlen=MAX_EVENTS)
+        self._subscribers: list[asyncio.Queue[dict[str, Any]]] = []
+
+    def publish(self, event: dict[str, Any]) -> None:
+        """Publish an event to all subscribers and store it."""
+        self._events.append(event)
+        for queue in self._subscribers:
+            queue.put_nowait(event)
+
+    def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        """Create a new subscriber queue."""
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        """Remove a subscriber queue."""
+        try:
+            self._subscribers.remove(queue)
+        except ValueError:
+            pass
+
+    @property
+    def recent_events(self) -> list[dict[str, Any]]:
+        """Return recent events (newest first)."""
+        return list(reversed(self._events))
+
+
+def create_webhooks_router(
+    *, webhook_secret: str | None = None
+) -> tuple[APIRouter, EventBus]:
+    """Create a FastAPI router for GitLab webhook handling.
+
+    Args:
+        webhook_secret: Optional secret token to validate webhook requests.
+
+    Returns:
+        Tuple of (router, event_bus) so the app can access the bus.
+    """
+    router = APIRouter(tags=["webhooks"])
+    event_bus = EventBus()
+
+    @router.post("/api/webhooks/gitlab")
+    async def receive_webhook(request: Request) -> dict[str, str]:
+        """Receive GitLab webhook events (merge_request, pipeline)."""
+        if webhook_secret:
+            token = request.headers.get("X-Gitlab-Token")
+            if token != webhook_secret:
+                raise HTTPException(status_code=403, detail="Invalid webhook token")
+
+        try:
+            payload = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+
+        object_kind = payload.get("object_kind")
+        if object_kind not in ("merge_request", "pipeline"):
+            return {"status": "ignored", "reason": f"Unhandled event: {object_kind}"}
+
+        event = _extract_event(object_kind, payload)
+        event_bus.publish(event)
+        logger.info("Webhook received: %s %s", object_kind, event.get("id", ""))
+
+        return {"status": "accepted", "event": object_kind}
+
+    @router.get("/api/events")
+    async def event_stream() -> StreamingResponse:
+        """SSE endpoint for real-time dashboard updates."""
+        queue = event_bus.subscribe()
+
+        async def generate():
+            try:
+                while True:
+                    event = await queue.get()
+                    import json
+
+                    data = json.dumps(event)
+                    yield f"event: {event.get('type', 'update')}\ndata: {data}\n\n"
+            except asyncio.CancelledError:
+                pass
+            finally:
+                event_bus.unsubscribe(queue)
+
+        return StreamingResponse(generate(), media_type="text/event-stream")
+
+    @router.get("/api/events/recent")
+    async def recent_events() -> dict[str, Any]:
+        """Return recent webhook events."""
+        return {
+            "events": event_bus.recent_events,
+            "total": len(event_bus.recent_events),
+        }
+
+    return router, event_bus
+
+
+def _extract_event(object_kind: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract a normalized event from a GitLab webhook payload."""
+    if object_kind == "merge_request":
+        mr = payload.get("object_attributes", {})
+        return {
+            "type": "merge_request",
+            "action": mr.get("action"),
+            "id": mr.get("iid"),
+            "title": mr.get("title"),
+            "state": mr.get("state"),
+            "url": mr.get("url"),
+            "source_branch": mr.get("source_branch"),
+            "labels": [lb.get("title") for lb in payload.get("labels", [])],
+        }
+    elif object_kind == "pipeline":
+        attrs = payload.get("object_attributes", {})
+        return {
+            "type": "pipeline",
+            "id": attrs.get("id"),
+            "status": attrs.get("status"),
+            "ref": attrs.get("ref"),
+            "source": attrs.get("source"),
+            "url": payload.get("project", {}).get("web_url", "")
+            + "/-/pipelines/"
+            + str(attrs.get("id", "")),
+        }
+    return {"type": object_kind, "raw": payload}

--- a/tests/test_server_gitlab.py
+++ b/tests/test_server_gitlab.py
@@ -1,0 +1,224 @@
+"""Tests for regis/server/routes/gitlab.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from regis.server.app import create_app
+
+
+@pytest.fixture()
+def assets_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "assets"
+    d.mkdir()
+    (d / "index.html").write_text("<html><body>Dashboard</body></html>")
+    return d
+
+
+def _make_mr(**overrides: Any) -> MagicMock:
+    """Create a mock MR object with sane defaults."""
+    defaults = {
+        "iid": 42,
+        "title": "Regis Analysis: alpine:latest",
+        "state": "opened",
+        "web_url": "https://gitlab.com/org/proj/-/merge_requests/42",
+        "source_branch": "regis/analyze/20260409",
+        "author": {"username": "analyst"},
+        "created_at": "2026-04-09T10:00:00Z",
+        "updated_at": "2026-04-09T12:00:00Z",
+        "labels": ["regis::score-Silver", "regis::cve-ok"],
+        "description": "📝 **[View Analysis Report](https://example.com/report)**",
+        "merge_status": "can_be_merged",
+        "pipeline": {
+            "id": 100,
+            "status": "success",
+            "web_url": "https://gitlab.com/pipelines/100",
+        },
+    }
+    defaults.update(overrides)
+    mr = MagicMock()
+    mr.attributes = defaults
+    return mr
+
+
+def _make_pipeline(**overrides: Any) -> MagicMock:
+    """Create a mock pipeline object."""
+    defaults = {
+        "id": 100,
+        "status": "success",
+        "ref": "main",
+        "sha": "abc12345deadbeef",
+        "web_url": "https://gitlab.com/pipelines/100",
+        "created_at": "2026-04-09T10:00:00Z",
+        "updated_at": "2026-04-09T10:05:00Z",
+        "source": "web",
+    }
+    defaults.update(overrides)
+    p = MagicMock()
+    p.attributes = defaults
+    return p
+
+
+def _create_client(assets_dir: Path, mock_project: MagicMock) -> TestClient:
+    """Create a TestClient with GitLab integration enabled."""
+    with patch("regis.server.routes.gitlab.gitlab") as mock_gl_mod:
+        mock_gl_instance = MagicMock()
+        mock_gl_instance.projects.get.return_value = mock_project
+        mock_gl_mod.Gitlab.return_value = mock_gl_instance
+        mock_gl_mod.GitlabGetError = Exception
+        mock_gl_mod.GitlabListError = Exception
+
+        app = create_app(
+            assets_dir=assets_dir,
+            gitlab_url="https://gitlab.com",
+            gitlab_token="test-token",
+            gitlab_project="123",
+        )
+        # Re-patch for request time since _get_project is called per-request
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            yield TestClient(app)
+
+
+@pytest.fixture()
+def mock_project() -> MagicMock:
+    project = MagicMock()
+    return project
+
+
+@pytest.fixture()
+def client(assets_dir: Path, mock_project: MagicMock):
+    with patch("regis.server.routes.gitlab._get_project", return_value=mock_project):
+        app = create_app(
+            assets_dir=assets_dir,
+            gitlab_url="https://gitlab.com",
+            gitlab_token="test-token",
+            gitlab_project="123",
+        )
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            yield TestClient(app), mock_project
+
+
+class TestListMRs:
+    def test_list_mrs_returns_serialized_data(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.mergerequests.list.return_value = [_make_mr(), _make_mr(iid=43)]
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            resp = test_client.get("/api/gitlab/mrs")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert data["merge_requests"][0]["iid"] == 42
+        assert data["merge_requests"][0]["regis_labels"] == [
+            "regis::score-Silver",
+            "regis::cve-ok",
+        ]
+        assert data["merge_requests"][0]["has_report"] is True
+
+    def test_list_mrs_with_state_filter(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.mergerequests.list.return_value = []
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            resp = test_client.get("/api/gitlab/mrs?state=merged")
+
+        assert resp.status_code == 200
+        mock_project.mergerequests.list.assert_called_with(
+            state="merged", per_page=20, order_by="updated_at", sort="desc"
+        )
+
+
+class TestGetMR:
+    def test_get_mr_returns_full_details(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.mergerequests.get.return_value = _make_mr()
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            resp = test_client.get("/api/gitlab/mrs/42")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["iid"] == 42
+        assert "description" in data
+        assert data["merge_status"] == "can_be_merged"
+        assert data["pipeline"]["id"] == 100
+
+    def test_get_mr_without_report(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.mergerequests.get.return_value = _make_mr(
+            description="No report here", labels=[]
+        )
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            resp = test_client.get("/api/gitlab/mrs/99")
+
+        data = resp.json()
+        assert data["has_report"] is False
+        assert data["regis_labels"] == []
+
+
+class TestListPipelines:
+    def test_list_pipelines(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.pipelines.list.return_value = [
+            _make_pipeline(),
+            _make_pipeline(id=101, status="running"),
+        ]
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            resp = test_client.get("/api/gitlab/pipelines")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert data["pipelines"][0]["id"] == 100
+        assert data["pipelines"][0]["sha"] == "abc12345"
+
+    def test_list_pipelines_with_source_filter(self, client) -> None:
+        test_client, mock_project = client
+        mock_project.pipelines.list.return_value = []
+
+        with patch(
+            "regis.server.routes.gitlab._get_project", return_value=mock_project
+        ):
+            test_client.get("/api/gitlab/pipelines?source=web")
+
+        mock_project.pipelines.list.assert_called_with(
+            per_page=20, order_by="updated_at", sort="desc", source="web"
+        )
+
+
+class TestNoGitLabConfig:
+    def test_gitlab_routes_not_mounted_without_config(self, assets_dir: Path) -> None:
+        app = create_app(assets_dir=assets_dir)
+        client = TestClient(app)
+        resp = client.get("/api/gitlab/mrs")
+        # SPA fallback returns index.html, not a 404 JSON
+        assert resp.status_code == 200
+        assert "Dashboard" in resp.text
+
+    def test_health_still_works(self, assets_dir: Path) -> None:
+        app = create_app(assets_dir=assets_dir)
+        client = TestClient(app)
+        resp = client.get("/api/health")
+        assert resp.status_code == 200

--- a/tests/test_server_trigger.py
+++ b/tests/test_server_trigger.py
@@ -1,0 +1,111 @@
+"""Tests for regis/server/routes/trigger.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from regis.server.app import create_app
+
+
+@pytest.fixture()
+def assets_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "assets"
+    d.mkdir()
+    (d / "index.html").write_text("<html><body>Dashboard</body></html>")
+    return d
+
+
+@pytest.fixture()
+def mock_project() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(assets_dir: Path, mock_project: MagicMock):
+    with (
+        patch("regis.server.routes.trigger._get_project", return_value=mock_project),
+        patch("regis.server.routes.gitlab._get_project", return_value=mock_project),
+    ):
+        app = create_app(
+            assets_dir=assets_dir,
+            gitlab_url="https://gitlab.com",
+            gitlab_token="test-token",
+            gitlab_project="123",
+        )
+        yield TestClient(app), mock_project
+
+
+class TestTriggerPipeline:
+    def test_trigger_success(self, client) -> None:
+        test_client, mock_project = client
+        mock_pipeline = MagicMock()
+        mock_pipeline.attributes = {
+            "id": 500,
+            "status": "created",
+            "web_url": "https://gitlab.com/pipelines/500",
+        }
+        mock_project.pipelines.create.return_value = mock_pipeline
+
+        resp = test_client.post(
+            "/api/gitlab/trigger",
+            json={"image_url": "alpine:latest"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pipeline_id"] == 500
+        assert data["status"] == "created"
+        assert data["web_url"] == "https://gitlab.com/pipelines/500"
+
+        mock_project.pipelines.create.assert_called_once_with(
+            {
+                "ref": "main",
+                "variables": [
+                    {"key": "IMAGE_URL", "value": "alpine:latest"},
+                ],
+            }
+        )
+
+    def test_trigger_custom_ref(self, client) -> None:
+        test_client, mock_project = client
+        mock_pipeline = MagicMock()
+        mock_pipeline.attributes = {
+            "id": 501,
+            "status": "created",
+            "web_url": "https://gitlab.com/pipelines/501",
+        }
+        mock_project.pipelines.create.return_value = mock_pipeline
+
+        resp = test_client.post(
+            "/api/gitlab/trigger",
+            json={"image_url": "nginx:latest", "ref": "develop"},
+        )
+
+        assert resp.status_code == 200
+        mock_project.pipelines.create.assert_called_once_with(
+            {
+                "ref": "develop",
+                "variables": [
+                    {"key": "IMAGE_URL", "value": "nginx:latest"},
+                ],
+            }
+        )
+
+    def test_trigger_missing_image_url(self, client) -> None:
+        test_client, _ = client
+        resp = test_client.post("/api/gitlab/trigger", json={})
+        assert resp.status_code == 422  # Validation error
+
+    def test_trigger_not_mounted_without_config(self, assets_dir: Path) -> None:
+        app = create_app(assets_dir=assets_dir)
+        test_client = TestClient(app)
+        resp = test_client.post(
+            "/api/gitlab/trigger",
+            json={"image_url": "alpine:latest"},
+        )
+        # No route mounted, SPA fallback returns 405 or index.html
+        assert resp.status_code in (200, 405)

--- a/tests/test_server_webhooks.py
+++ b/tests/test_server_webhooks.py
@@ -1,0 +1,142 @@
+"""Tests for regis/server/routes/webhooks.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from regis.server.app import create_app
+
+
+@pytest.fixture()
+def assets_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "assets"
+    d.mkdir()
+    (d / "index.html").write_text("<html><body>Dashboard</body></html>")
+    return d
+
+
+@pytest.fixture()
+def client(assets_dir: Path):
+    app = create_app(assets_dir=assets_dir)
+    return TestClient(app)
+
+
+@pytest.fixture()
+def client_with_secret(assets_dir: Path):
+    app = create_app(assets_dir=assets_dir, webhook_secret="my-secret")
+    return TestClient(app)
+
+
+class TestWebhookReceiver:
+    def test_merge_request_event(self, client: TestClient) -> None:
+        payload = {
+            "object_kind": "merge_request",
+            "object_attributes": {
+                "action": "open",
+                "iid": 42,
+                "title": "Regis Analysis: alpine:latest",
+                "state": "opened",
+                "url": "https://gitlab.com/org/proj/-/merge_requests/42",
+                "source_branch": "regis/analyze/20260409",
+            },
+            "labels": [{"title": "regis::score-Silver"}],
+        }
+        resp = client.post("/api/webhooks/gitlab", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+        assert resp.json()["event"] == "merge_request"
+
+    def test_pipeline_event(self, client: TestClient) -> None:
+        payload = {
+            "object_kind": "pipeline",
+            "object_attributes": {
+                "id": 500,
+                "status": "success",
+                "ref": "main",
+                "source": "web",
+            },
+            "project": {"web_url": "https://gitlab.com/org/proj"},
+        }
+        resp = client.post("/api/webhooks/gitlab", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+
+    def test_unknown_event_ignored(self, client: TestClient) -> None:
+        payload = {"object_kind": "push"}
+        resp = client.post("/api/webhooks/gitlab", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+    def test_invalid_json_returns_400(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/webhooks/gitlab",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+
+class TestWebhookSecret:
+    def test_valid_secret_accepted(self, client_with_secret: TestClient) -> None:
+        payload = {
+            "object_kind": "merge_request",
+            "object_attributes": {
+                "action": "open",
+                "iid": 1,
+                "title": "Test",
+                "state": "opened",
+                "url": "https://gitlab.com/mr/1",
+                "source_branch": "test",
+            },
+            "labels": [],
+        }
+        resp = client_with_secret.post(
+            "/api/webhooks/gitlab",
+            json=payload,
+            headers={"X-Gitlab-Token": "my-secret"},
+        )
+        assert resp.status_code == 200
+
+    def test_invalid_secret_rejected(self, client_with_secret: TestClient) -> None:
+        payload = {"object_kind": "merge_request", "object_attributes": {}}
+        resp = client_with_secret.post(
+            "/api/webhooks/gitlab",
+            json=payload,
+            headers={"X-Gitlab-Token": "wrong"},
+        )
+        assert resp.status_code == 403
+
+    def test_missing_secret_rejected(self, client_with_secret: TestClient) -> None:
+        payload = {"object_kind": "merge_request", "object_attributes": {}}
+        resp = client_with_secret.post("/api/webhooks/gitlab", json=payload)
+        assert resp.status_code == 403
+
+
+class TestRecentEvents:
+    def test_recent_events_empty(self, client: TestClient) -> None:
+        resp = client.get("/api/events/recent")
+        assert resp.status_code == 200
+        assert resp.json()["events"] == []
+
+    def test_recent_events_after_webhook(self, client: TestClient) -> None:
+        payload = {
+            "object_kind": "pipeline",
+            "object_attributes": {
+                "id": 600,
+                "status": "success",
+                "ref": "main",
+                "source": "web",
+            },
+            "project": {"web_url": "https://gitlab.com/org/proj"},
+        }
+        client.post("/api/webhooks/gitlab", json=payload)
+
+        resp = client.get("/api/events/recent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["events"][0]["type"] == "pipeline"
+        assert data["events"][0]["id"] == 600


### PR DESCRIPTION
## Summary

Phases 2-5 of the dashboard GitLab integration (Phase 1 merged in #259):

- **GitLab API proxy** — `GET /api/gitlab/mrs`, `/mrs/{iid}`, `/pipelines` with server-side token
- **Pipeline trigger** — `POST /api/gitlab/trigger` with `{image_url, ref}`
- **Webhook receiver** — `POST /api/webhooks/gitlab` for MR/pipeline events + SSE stream at `/api/events`
- **Dashboard UI** — `/gitlab` page with MR list, trigger form, and MR comparison tabs

Config via CLI or env vars: `--gitlab-url`, `--gitlab-token`, `--gitlab-project`, `--webhook-secret`

## Test plan

- [x] `pipenv run pytest --no-cov` — 406 tests pass
- [x] `pnpm --filter @regis/dashboard build` — compiles
- [x] 8 GitLab route tests, 4 trigger tests, 9 webhook tests