### PR TITLE
fix(docs): repair broken rebrand links + rebuild next on push to main

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -3,6 +3,11 @@ name: CD / Docs
 on:
   release:
     types: [published]
+  push:
+    branches: [main]
+    paths:
+      - docs/website/**
+      - .github/workflows/cd-docs.yml
   workflow_dispatch:
 
 permissions:

--- a/docs/website/docs/roadmap.md
+++ b/docs/website/docs/roadmap.md
@@ -72,4 +72,4 @@ The following are considered **stable** and safe to depend on in custom playbook
 
 ## How to give feedback
 
-If your team is building custom playbooks or integrations and needs clarity on stability of a specific field or feature, open a [GitHub Discussion](https://github.com/trivoallan/regis-cli/discussions) or file an issue.
+If your team is building custom playbooks or integrations and needs clarity on stability of a specific field or feature, open a [GitHub Discussion](https://github.com/trivoallan/regis/discussions) or file an issue.

--- a/docs/website/docs/tools/viewer.mdx
+++ b/docs/website/docs/tools/viewer.mdx
@@ -4,11 +4,11 @@ sidebar_position: 1
 
 # Dashboard
 
-`regis-cli` embeds a dynamic React dashboard (the **Dashboard**) allowing you to visualize your Docker image security analysis reports (JSON) in a highly interactive and visual way.
+Regis embeds a dynamic React dashboard (the **Dashboard**) allowing you to visualize your Docker image security analysis reports (JSON) in a highly interactive and visual way.
 
 <div style={{ textAlign: "center", margin: "2rem 0" }}>
   <a
-    href="https://trivoallan.github.io/regis-cli/tools/main/viewer/"
+    href="https://trivoallan.github.io/regis/tools/main/dashboard/"
     target="_blank"
     className="button button--primary button--lg"
   >


### PR DESCRIPTION
## Summary

Two small but important fixes that didn't make it into #262 before it was squash-merged.

- **Broken rebrand links** — `docs/website/docs/roadmap.md` still pointed at `github.com/trivoallan/regis-cli/discussions` and `docs/website/docs/tools/viewer.mdx` still pointed at `trivoallan.github.io/regis-cli/tools/main/viewer/`. Both are now flagged by the new lychee job from #262, which is currently blocking Release Please PR #260. Updated to the post-rebrand URLs (`regis/discussions` and `regis/tools/main/dashboard/` respectively), and replaced the stale `regis-cli` mention in the viewer page's intro.

- **\`/docs/next/\` frozen on release** — `cd-docs.yml` only ran on `release: published`, so the unreleased "next" version of the Docusaurus site never reflected changes merged to `main`. Added a path-filtered `push: branches: [main]` trigger that fires on edits under `docs/website/**` or to the workflow file itself, so docs PRs go live as soon as they land.

## Test plan

- [x] `git grep trivoallan/regis-cli` returns no matches in `docs/website/docs/`
- [ ] CI: `docs-links` lychee job passes
- [ ] After merge: Release Please PR #260 re-runs and the link check unblocks it
- [ ] After merge: CD / Docs is triggered by the merge commit and `/docs/next/` refreshes