### PR TITLE
fix(config): update launch.json to use correct report-viewer package name

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,9 +4,8 @@
     {
       "name": "report-viewer",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@regis/dashboard", "dev"],
-      "port": 3000,
-      "autoPort": true
+      "runtimeArgs": ["--filter", "@regis/report-viewer", "dev"],
+      "port": 3000
     },
     {
       "name": "docs",


### PR DESCRIPTION
## Summary
- Changed `@regis/dashboard` to `@regis/report-viewer` in dev server configuration
- Removed deprecated `autoPort` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)