### PR TITLE
fix: Add fallback to pre-built dashboard assets for bundled mode

### DIFF
--- a/regis/report/docusaurus.py
+++ b/regis/report/docusaurus.py
@@ -3,6 +3,10 @@
 Replaces the previous Jinja2 HTML renderer. Copies report.json
 into the Docusaurus static directory, runs `pnpm build`, and
 copies the output to the desired location.
+
+Supports two modes:
+- Source mode: Dynamically builds from apps/dashboard (requires Node.js)
+- Bundled mode: Uses pre-built dashboard_assets (no external dependencies)
 """
 
 from __future__ import annotations
@@ -21,6 +25,22 @@ logger = logging.getLogger(__name__)
 _VIEWER_DIR = Path(__file__).resolve().parent.parent.parent / "apps" / "dashboard"
 
 
+def _get_bundled_assets_dir() -> Path | None:
+    """Get path to pre-built bundled dashboard assets.
+
+    Returns the path to the installed dashboard assets directory,
+    used as a fallback when the source apps/dashboard is not available.
+    This is the normal case for pip-installed packages and Docker images.
+
+    Returns:
+        Path to dashboard_assets directory, or None if not found.
+    """
+    assets_dir = Path(__file__).parent.parent / "dashboard_assets"
+    if assets_dir.is_dir():
+        return assets_dir
+    return None
+
+
 def build_report_site(
     report: dict[str, Any],
     output_dir: Path,
@@ -28,6 +48,12 @@ def build_report_site(
     pretty: bool = True,
 ) -> Path:
     """Build the Docusaurus report site and copy to output_dir.
+
+    Supports two modes:
+    1. Source mode: If apps/dashboard exists, dynamically builds with pnpm/npm
+       (requires Node.js, pnpm/npm, and source code)
+    2. Bundled mode: If apps/dashboard doesn't exist, uses pre-built dashboard_assets
+       (no external dependencies, used in Docker images and pip-installed packages)
 
     Args:
         report: Full report dict to embed as report.json.
@@ -39,19 +65,56 @@ def build_report_site(
         Path to the output directory.
 
     Raises:
-        RuntimeError: If the Docusaurus build fails.
+        RuntimeError: If the build fails in source mode or assets are missing in bundled mode.
     """
     # Ensure base_url ends with a slash for Docusaurus
     if not base_url.endswith("/"):
         base_url += "/"
-    if not _VIEWER_DIR.is_dir():
-        raise RuntimeError(
-            f"Dashboard app not found at {_VIEWER_DIR}. "
-            "Make sure the apps/dashboard directory exists and "
-            "dependencies are installed (pnpm install)."
-        )
 
-    static_dir = _VIEWER_DIR / "static"
+    # Try source mode first (for development)
+    if _VIEWER_DIR.is_dir():
+        return _build_from_source(_VIEWER_DIR, report, output_dir, base_url, pretty)
+
+    # Fall back to bundled mode (for installed packages/Docker images)
+    bundled_assets = _get_bundled_assets_dir()
+    if bundled_assets:
+        return _build_from_bundled(bundled_assets, report, output_dir, pretty)
+
+    # Neither source nor bundled assets found
+    raise RuntimeError(
+        f"Dashboard assets not found. Tried:\n"
+        f"  1. Source: {_VIEWER_DIR}\n"
+        f"  2. Bundled: {Path(__file__).parent.parent / 'dashboard_assets'}\n"
+        f"Make sure either the apps/dashboard directory exists or the package "
+        f"was installed with dashboard assets included."
+    )
+
+
+def _build_from_source(
+    viewer_dir: Path,
+    report: dict[str, Any],
+    output_dir: Path,
+    base_url: str,
+    pretty: bool,
+) -> Path:
+    """Build report site from source using pnpm/npm.
+
+    Args:
+        viewer_dir: Path to apps/dashboard directory.
+        report: Full report dict to embed as report.json.
+        output_dir: Where to copy the built static site.
+        base_url: Base URL for the site.
+        pretty: Whether to pretty-print the report JSON.
+
+    Returns:
+        Path to the output directory.
+
+    Raises:
+        RuntimeError: If the build fails.
+    """
+    logger.info("Building report site from source: %s", viewer_dir)
+
+    static_dir = viewer_dir / "static"
     static_dir.mkdir(parents=True, exist_ok=True)
 
     # Write report.json into the dashboard's static directory
@@ -72,11 +135,11 @@ def build_report_site(
     }
 
     # Check if node_modules exists
-    if not (_VIEWER_DIR / "node_modules").is_dir():
+    if not (viewer_dir / "node_modules").is_dir():
         logger.warning(
             "node_modules not found in %s. Docusaurus build may fail. "
             "Run 'pnpm install' in the workspace root.",
-            _VIEWER_DIR,
+            viewer_dir,
         )
 
     # Prefer pnpm, fall back to npm
@@ -98,7 +161,7 @@ def build_report_site(
     try:
         result = subprocess.run(
             build_cmd,  # nosec B603
-            cwd=str(_VIEWER_DIR),
+            cwd=str(viewer_dir),
             env=env,
             capture_output=True,
             text=True,
@@ -116,7 +179,7 @@ def build_report_site(
     logger.debug("Docusaurus build output:\n%s", result.stdout)
 
     # Copy build output to the target directory
-    build_output = _VIEWER_DIR / "build"
+    build_output = viewer_dir / "build"
     if not build_output.is_dir():
         raise RuntimeError(f"Docusaurus build directory not found at {build_output}")
 
@@ -128,5 +191,52 @@ def build_report_site(
     output_report = output_dir / "report.json"
     if not output_report.exists():
         shutil.copy2(str(report_path), str(output_report))
+
+    return output_dir
+
+
+def _build_from_bundled(
+    bundled_assets: Path,
+    report: dict[str, Any],
+    output_dir: Path,
+    pretty: bool,
+) -> Path:
+    """Build report site from pre-built bundled assets.
+
+    Used as a fallback when source apps/dashboard is not available.
+    Simply copies the bundled assets and adds report.json.
+
+    Args:
+        bundled_assets: Path to regis/dashboard_assets directory.
+        report: Full report dict to embed as report.json.
+        output_dir: Where to copy the built static site.
+        pretty: Whether to pretty-print the report JSON.
+
+    Returns:
+        Path to the output directory.
+    """
+    logger.info("Using pre-built bundled dashboard assets: %s", bundled_assets)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy bundled assets to output directory
+    for item in bundled_assets.iterdir():
+        src = bundled_assets / item.name
+        dst = output_dir / item.name
+        if src.is_dir():
+            shutil.copytree(str(src), str(dst), dirs_exist_ok=True)
+        else:
+            shutil.copy2(str(src), str(dst))
+
+    logger.debug("Copied bundled assets to %s", output_dir)
+
+    # Write report.json to output directory
+    report_path = output_dir / "report.json"
+    indent = 2 if pretty else None
+    report_path.write_text(
+        json.dumps(report, indent=indent, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    logger.info("Report site copied to %s (using bundled assets)", output_dir)
 
     return output_dir

--- a/tests/test_docusaurus.py
+++ b/tests/test_docusaurus.py
@@ -14,10 +14,12 @@ from regis.report.docusaurus import build_report_site
 class TestBuildReportSite:
     """Tests for build_report_site()."""
 
-    def test_dashboard_dir_not_found_raises(self, tmp_path: Path) -> None:
+    def test_neither_source_nor_bundled_assets_raises(self, tmp_path: Path) -> None:
+        """Raises when both source and bundled assets are missing."""
         with patch("regis.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
-            with pytest.raises(RuntimeError, match="Dashboard app not found"):
-                build_report_site({"key": "val"}, tmp_path / "output")
+            with patch("regis.report.docusaurus._get_bundled_assets_dir", return_value=None):
+                with pytest.raises(RuntimeError, match="Dashboard assets not found"):
+                    build_report_site({"key": "val"}, tmp_path / "output")
 
     def test_no_package_manager_raises(self, tmp_path: Path) -> None:
         dashboard_dir = tmp_path / "dashboard"
@@ -154,3 +156,97 @@ class TestBuildReportSite:
                     build_report_site({"data": "value"}, output_dir, base_url="/sub")
         env = mock_run.call_args.kwargs["env"]
         assert env["REPORT_BASE_URL"] == "/sub/"
+
+    def test_bundled_assets_fallback_when_source_missing(self, tmp_path: Path) -> None:
+        """Falls back to bundled assets when source directory doesn't exist."""
+        # Set up bundled assets directory with some files
+        bundled_dir = tmp_path / "bundled_assets"
+        bundled_dir.mkdir()
+        (bundled_dir / "index.html").write_text("<html>Bundled</html>")
+        (bundled_dir / "styles.css").write_text("body { color: blue; }")
+        assets_subdir = bundled_dir / "assets"
+        assets_subdir.mkdir()
+        (assets_subdir / "app.js").write_text("console.log('hello');")
+
+        output_dir = tmp_path / "output"
+        report_data = {"image": "test:latest", "findings": []}
+
+        # Mock source dir as nonexistent, bundled assets as existing
+        with patch("regis.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
+            with patch(
+                "regis.report.docusaurus._get_bundled_assets_dir",
+                return_value=bundled_dir,
+            ):
+                ret = build_report_site(report_data, output_dir)
+
+        # Verify output contains all bundled files plus report.json
+        assert ret == output_dir
+        assert (output_dir / "index.html").read_text() == "<html>Bundled</html>"
+        assert (output_dir / "styles.css").read_text() == "body { color: blue; }"
+        assert (output_dir / "assets" / "app.js").exists()
+        assert (output_dir / "report.json").exists()
+        # Verify report.json contains our data
+        import json
+
+        report_json = json.loads((output_dir / "report.json").read_text())
+        assert report_json == report_data
+
+    def test_bundled_assets_fallback_respects_pretty_flag(self, tmp_path: Path) -> None:
+        """Bundled assets mode respects pretty JSON formatting."""
+        bundled_dir = tmp_path / "bundled_assets"
+        bundled_dir.mkdir()
+        (bundled_dir / "index.html").write_text("<html/>")
+
+        output_dir = tmp_path / "output"
+        output_dir_compact = tmp_path / "output_compact"
+        report_data = {"key": "value"}
+
+        with patch("regis.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
+            with patch(
+                "regis.report.docusaurus._get_bundled_assets_dir",
+                return_value=bundled_dir,
+            ):
+                # Test with pretty=True (default)
+                build_report_site(report_data, output_dir, pretty=True)
+                report_text = (output_dir / "report.json").read_text()
+                # Pretty JSON should have newlines and indentation
+                assert "\n" in report_text
+                assert "  " in report_text  # indentation
+
+        with patch("regis.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
+            with patch(
+                "regis.report.docusaurus._get_bundled_assets_dir",
+                return_value=bundled_dir,
+            ):
+                # Test with pretty=False
+                build_report_site(report_data, output_dir_compact, pretty=False)
+                report_text = (output_dir_compact / "report.json").read_text()
+                # Compact JSON should have no extra whitespace
+                assert "\n" not in report_text
+
+    def test_source_mode_preferred_over_bundled(self, tmp_path: Path) -> None:
+        """Source mode is used when available, even if bundled assets exist."""
+        # Set up both source and bundled directories
+        dashboard_dir = tmp_path / "dashboard"
+        dashboard_dir.mkdir()
+        (dashboard_dir / "build").mkdir()
+        (dashboard_dir / "build" / "index.html").write_text("<html>Source</html>")
+
+        bundled_dir = tmp_path / "bundled_assets"
+        bundled_dir.mkdir()
+        (bundled_dir / "index.html").write_text("<html>Bundled</html>")
+
+        output_dir = tmp_path / "output"
+        result = MagicMock(returncode=0, stdout="OK", stderr="")
+
+        with patch("regis.report.docusaurus._VIEWER_DIR", dashboard_dir):
+            with patch(
+                "regis.report.docusaurus.shutil.which", return_value="/usr/bin/pnpm"
+            ):
+                with patch(
+                    "regis.report.docusaurus.subprocess.run", return_value=result
+                ):
+                    build_report_site({"data": "value"}, output_dir)
+
+        # Should have source mode's output, not bundled
+        assert (output_dir / "index.html").read_text() == "<html>Source</html>"

--- a/tests/test_docusaurus.py
+++ b/tests/test_docusaurus.py
@@ -17,7 +17,9 @@ class TestBuildReportSite:
     def test_neither_source_nor_bundled_assets_raises(self, tmp_path: Path) -> None:
         """Raises when both source and bundled assets are missing."""
         with patch("regis.report.docusaurus._VIEWER_DIR", tmp_path / "nonexistent"):
-            with patch("regis.report.docusaurus._get_bundled_assets_dir", return_value=None):
+            with patch(
+                "regis.report.docusaurus._get_bundled_assets_dir", return_value=None
+            ):
                 with pytest.raises(RuntimeError, match="Dashboard assets not found"):
                     build_report_site({"key": "val"}, tmp_path / "output")
 


### PR DESCRIPTION
## Summary
This PR adds support for a bundled/fallback mode to the Docusaurus report builder, allowing the report site to be generated without requiring Node.js, pnpm, or the source dashboard code. This is essential for Docker images and pip-installed packages where the source code may not be available.

## Key Changes
- **Dual-mode support**: The report builder now supports two modes:
  1. **Source mode**: Dynamically builds from `apps/dashboard` using pnpm/npm (requires Node.js)
  2. **Bundled mode**: Uses pre-built `dashboard_assets` as a fallback (no external dependencies)

- **New `_get_bundled_assets_dir()` function**: Locates pre-built dashboard assets in the installed package, returning `None` if not found

- **Refactored `build_report_site()`**: 
  - Now attempts source mode first (for development)
  - Falls back to bundled mode if source directory doesn't exist
  - Provides clear error messages indicating which locations were checked

- **New `_build_from_source()` function**: Extracted the existing pnpm/npm build logic into a dedicated function for clarity

- **New `_build_from_bundled()` function**: Implements bundled mode by copying pre-built assets and adding `report.json`

- **Updated documentation**: Module docstring and function docstrings now explain both modes and their use cases

- **Comprehensive test coverage**: Added tests for:
  - Bundled assets fallback behavior
  - Pretty JSON formatting in bundled mode
  - Source mode preference when both options are available
  - Error handling when neither source nor bundled assets exist

## Implementation Details
- Source mode is preferred when available, ensuring development workflows use the latest code
- Bundled mode gracefully handles missing external dependencies, making it suitable for containerized and pip-installed deployments
- Both modes produce identical output (report.json + static assets)
- Error messages clearly indicate which asset locations were checked to aid debugging

https://claude.ai/code/session_013TCNmEVPEatDp2PinnLjRS