### PR TITLE
fix(ci): resolve docker build failure for GHCR package generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,10 @@ COPY --chown=regis:regis . .
 COPY --from=frontend-builder --chown=regis:regis /app/apps/dashboard/build ./regis/dashboard_assets
 
 # Install regis
-RUN git config --global --add safe.directory /app && \
-    pip install --no-cache-dir .
+# Use SETUPTOOLS_SCM_PRETEND_VERSION to avoid git operations inside container
+# Extract version from pyproject.toml (e.g., version = "0.28.3" -> 0.28.3)
+RUN VERSION=$(grep -oP '(?<=version = ")[^"]+' pyproject.toml) && \
+    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip install --no-cache-dir .
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \


### PR DESCRIPTION
## Summary

Docker builds were failing on v0.28.2+ (after rebrand to Regis) because git operations inside the container were failing in worktree environments.

**Root Cause**: The Dockerfile attempted to run `git config` inside the container to configure git for setuptools-scm, but this failed because the git directory from the worktree wasn't recognized inside the container.

**Solution**: Use `SETUPTOOLS_SCM_PRETEND_VERSION` environment variable to tell setuptools-scm the exact version from pyproject.toml, bypassing the need for git introspection entirely.

## Changes

- ✅ Docker image builds successfully locally
- ✅ Version is extracted dynamically from pyproject.toml  
- ✅ No hardcoded version numbers
- ✅ All linting passes (trunk check)

## Test Plan

- [ ] Verify GitHub Actions Docker build job succeeds on next release tag
- [ ] Confirm GHCR packages appear at `ghcr.io/trivoallan/regis:vX.Y.Z`
- [ ] Verify published image works with `docker run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)