### PR TITLE
fix(ci): add .dockerignore to fix dubious ownership error in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.claude
+.omc
+.trunk
+.venv
+__pycache__
+*.pyc
+*.egg-info
+dist
+build
+node_modules
+.pytest_cache
+.ruff_cache


### PR DESCRIPTION
## Summary

Companion fix to #380. The `SETUPTOOLS_SCM_PRETEND_VERSION` fix alone was insufficient because setuptools-scm still attempted git introspection on the `.git` directory copied into the container, failing with "dubious ownership".

Adding a `.dockerignore` that excludes `.git` (and other unnecessary files) prevents setuptools-scm from finding a git repo at all, making the `PRETEND_VERSION` variable sufficient.

## Test Plan

- [x] Docker image builds successfully locally
- [x] `docker run --rm regis-test:latest --help` works
- [ ] CI Docker workflow passes on next release tag