### PR TITLE
Add Node.js runtime and pnpm to Docker image for bootstrap commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,12 @@ COPY --chown=regis:regis . .
 # Copy built dashboard assets from frontend stage
 COPY --from=frontend-builder --chown=regis:regis /app/apps/dashboard/build ./regis/dashboard_assets
 
+# Copy Node.js runtime and pnpm from the frontend builder stage
+# Required by `regis bootstrap archive --repo` and `--dev` at runtime
+COPY --from=frontend-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=frontend-builder /usr/local/lib/node_modules/pnpm /usr/local/lib/node_modules/pnpm
+RUN ln -s /usr/local/lib/node_modules/pnpm/bin/pnpm.cjs /usr/local/bin/pnpm
+
 # Install regis
 # Use SETUPTOOLS_SCM_PRETEND_VERSION to avoid git operations inside container
 # Extract version from pyproject.toml (e.g., version = "0.28.3" -> 0.28.3)


### PR DESCRIPTION
## Summary
This change adds Node.js runtime and pnpm package manager to the production Docker image by copying them from the frontend builder stage. This enables the `regis bootstrap archive` command to function with the `--repo` and `--dev` flags at runtime.

## Key Changes
- Copy Node.js binary from frontend builder stage to `/usr/local/bin/node`
- Copy pnpm package manager from frontend builder stage to `/usr/local/lib/node_modules/pnpm`
- Create a symlink for pnpm at `/usr/local/bin/pnpm` to make it available in the PATH

## Implementation Details
The Node.js runtime and pnpm are copied from the existing `frontend-builder` stage rather than installing them separately, which keeps the Docker image lean by reusing already-built artifacts. The symlink ensures pnpm is accessible as a command-line tool without requiring additional PATH configuration.

https://claude.ai/code/session_01Ptm7ZjvJNoc6TpnYy4V5Dh