### PR TITLE
Auto-enable no-input mode for non-TTY stdin and fix template issues

### DIFF
--- a/regis/commands/bootstrap.py
+++ b/regis/commands/bootstrap.py
@@ -265,7 +265,9 @@ def bootstrap_archive(
         )
     except Exception as exc:
         detail = str(exc) or repr(exc)
-        raise click.ClickException(f"Failed to bootstrap archive site: {detail}") from exc
+        raise click.ClickException(
+            f"Failed to bootstrap archive site: {detail}"
+        ) from exc
 
     project_path = Path(project_dir)
     click.echo(f"  ✓ Site scaffolded at {project_path}.", err=True)

--- a/regis/commands/bootstrap.py
+++ b/regis/commands/bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess  # nosec B404
+import sys
 from pathlib import Path
 
 import click
@@ -242,17 +243,29 @@ def bootstrap_archive(
     else:
         extra_context = None
 
+    # When --repo-name is provided, use it as the project directory name so the
+    # scaffolded slug matches the remote repository name without requiring an
+    # extra interactive prompt.
+    if repo_name:
+        extra_context = extra_context or {}
+        extra_context.setdefault("project_slug", repo_name)
+
+    # Automatically skip prompts when stdin has no TTY (Docker without -it,
+    # CI pipelines, etc.).  Explicit --no-input always takes precedence.
+    effective_no_input = no_input or not sys.stdin.isatty()
+
     template_path = resources.files("regis") / "cookiecutters" / "archive"
     click.echo(f"\nScaffolding archive site into {output_dir}...", err=True)
     try:
         project_dir = cookiecutter(
             str(template_path),
-            no_input=no_input,
+            no_input=effective_no_input,
             output_dir=output_dir,
             extra_context=extra_context,
         )
     except Exception as exc:
-        raise click.ClickException(f"Failed to bootstrap archive site: {exc}") from exc
+        detail = str(exc) or repr(exc)
+        raise click.ClickException(f"Failed to bootstrap archive site: {detail}") from exc
 
     project_path = Path(project_dir)
     click.echo(f"  ✓ Site scaffolded at {project_path}.", err=True)

--- a/regis/cookiecutters/archive/{{cookiecutter.project_slug}}/.github/workflows/analyze.yml
+++ b/regis/cookiecutters/archive/{{cookiecutter.project_slug}}/.github/workflows/analyze.yml
@@ -40,7 +40,7 @@ jobs:
             analyze "{% raw %}${{ github.event.inputs.image }}{% endraw %}" \
             --evaluate \
             --meta "trigger.user= {% raw %}${{ github.actor }}{% endraw %}" \
-            --meta "trigger.url={% raw %}${{ github.server_url }}${{ github.repository }}/actions/runs/{% raw %}${{ github.run_id }}{% endraw %}" \
+            --meta "trigger.url={% raw %}${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}{% endraw %}" \
             --output-dir {% raw %}${{ github.run_id }}{% endraw %}
             {% raw %}${{ github.event.inputs.playbook && format('--playbook {0}', github.event.inputs.playbook) || '' }}{% endraw %}
 
@@ -61,6 +61,6 @@ jobs:
           body: |
             This PR adds a new security analysis report for **{% raw %}${{ github.event.inputs.image }}{% endraw %}** to the archive.
 
-            Triggered by: @{% raw %}${{ github.actor }}
+            Triggered by: @{% raw %}${{ github.actor }}{% endraw %}
             Run: {% raw %}${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}{% endraw %}
           base: main

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -346,6 +346,33 @@ class TestBootstrapArchiveRepo:
         assert result.exit_code != 0
         assert "permission denied" in result.output.lower()
 
+    @patch("regis.commands.bootstrap.sys.stdin.isatty", return_value=False)
+    @patch("regis.utils.process.shutil.which", return_value="/usr/bin/fake")
+    @patch("regis.utils.process.subprocess.run")
+    def test_non_tty_skips_prompts(self, mock_run, _mock_which, _mock_isatty):
+        """Without --no-input, non-TTY stdin should auto-enable no_input mode."""
+        mock_run.side_effect = _make_subprocess_mock(
+            '{"username":"myuser"}\n'
+        ).side_effect
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                main,
+                [
+                    "bootstrap",
+                    "archive",
+                    "test-repo",
+                    "--repo",
+                    "--platform",
+                    "gitlab",
+                    "--repo-name",
+                    "my-archive",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert Path("test-repo/my-archive").exists()
+        assert "gitlab.io" in result.output
+
     @patch("regis.utils.process.shutil.which", return_value="/usr/bin/fake")
     @patch("regis.utils.process.subprocess.run")
     def test_org_passed_to_gh(self, mock_run, _mock_which):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -370,8 +370,8 @@ class TestBootstrapArchiveRepo:
                     "my-archive",
                 ],
             )
-        assert result.exit_code == 0, result.output
-        assert Path("test-repo/my-archive").exists()
+            assert result.exit_code == 0, result.output
+            assert Path("test-repo/my-archive").exists()
         assert "gitlab.io" in result.output
 
     @patch("regis.utils.process.shutil.which", return_value="/usr/bin/fake")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -346,11 +346,12 @@ class TestBootstrapArchiveRepo:
         assert result.exit_code != 0
         assert "permission denied" in result.output.lower()
 
-    @patch("regis.commands.bootstrap.sys.stdin.isatty", return_value=False)
+    @patch("sys.stdin")
     @patch("regis.utils.process.shutil.which", return_value="/usr/bin/fake")
     @patch("regis.utils.process.subprocess.run")
-    def test_non_tty_skips_prompts(self, mock_run, _mock_which, _mock_isatty):
+    def test_non_tty_skips_prompts(self, mock_run, _mock_which, mock_stdin):
         """Without --no-input, non-TTY stdin should auto-enable no_input mode."""
+        mock_stdin.isatty.return_value = False
         mock_run.side_effect = _make_subprocess_mock(
             '{"username":"myuser"}\n'
         ).side_effect


### PR DESCRIPTION
## Summary
This PR improves the bootstrap command's handling of non-interactive environments and fixes several issues in the archive cookiecutter template.

## Key Changes

- **Auto-enable no-input mode for non-TTY stdin**: When stdin is not a TTY (Docker without `-it`, CI pipelines, etc.), the bootstrap command now automatically enables no-input mode to prevent hanging on prompts. The explicit `--no-input` flag still takes precedence.

- **Use `--repo-name` as project slug**: When `--repo-name` is provided, it's now automatically used as the `project_slug` in the cookiecutter context, eliminating the need for an extra interactive prompt and ensuring the scaffolded directory matches the remote repository name.

- **Improve error messages**: Enhanced exception handling in the bootstrap command to provide more informative error messages when cookiecutter fails.

- **Fix GitHub Actions workflow template issues**:
  - Fixed malformed Jinja2 template syntax in the `trigger.url` meta field (missing `/` separator and improper raw tag nesting)
  - Fixed incomplete raw tag in the "Triggered by" comment that was preventing proper variable substitution

## Implementation Details

The non-TTY detection uses `sys.stdin.isatty()` to determine if stdin is connected to a terminal. This allows the command to gracefully handle automated environments without requiring users to explicitly pass `--no-input` in CI/CD pipelines or containerized setups.

https://claude.ai/code/session_01255G2mQWn9LNRAmy4gsqnh