### PR TITLE
ci(docs): separate latest docs deploy from release snapshots

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - docs/website/**
+      - tests/**
       - regis/**
       - scripts/generate_whats_new.py
       - CHANGELOG.md
@@ -24,7 +25,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: docs-publish-${{ github.ref }}
+  group: docs-publish-main
   cancel-in-progress: true
 
 jobs:
@@ -36,13 +37,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
           private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
           ref: main
@@ -65,20 +66,22 @@ jobs:
             refresh_badge=true
             refresh_archive=true
           else
-            CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")
-            printf '%s\n' "$CHANGED_FILES"
+            changed_files_file="$(mktemp)"
+            git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | tee "$changed_files_file"
 
-            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|scripts/generate_whats_new\.py$|CHANGELOG\.md$|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)'; then
+            if grep -Eq '^(regis/|scripts/generate_whats_new\.py$|CHANGELOG\.md$|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)' "$changed_files_file"; then
               generate_reference=true
             fi
 
-            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|tests/|Pipfile$|pyproject\.toml$|\.github/workflows/cd-docs\.yml$)'; then
+            if grep -Eq '^(regis/|tests/|Pipfile$|pyproject\.toml$|\.github/workflows/cd-docs\.yml$)' "$changed_files_file"; then
               refresh_badge=true
             fi
 
-            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)'; then
+            if grep -Eq '^(regis/|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)' "$changed_files_file"; then
               refresh_archive=true
             fi
+
+            rm -f "$changed_files_file"
           fi
 
           echo "generate_reference=$generate_reference" >> "$GITHUB_OUTPUT"
@@ -86,7 +89,7 @@ jobs:
           echo "refresh_archive=$refresh_archive" >> "$GITHUB_OUTPUT"
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: pipenv
@@ -119,12 +122,12 @@ jobs:
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6
         with:
           version: 10
           run_install: false
@@ -135,7 +138,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -212,7 +215,7 @@ jobs:
         if: steps.changes.outputs.generate_reference == 'true' || steps.changes.outputs.refresh_badge == 'true'
         id: cpr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ steps.generate-token.outputs.token }}
           commit-message: "docs: refresh generated latest documentation assets"
@@ -235,7 +238,7 @@ jobs:
             docs/website/static/schemas/**
 
       - name: Deploy docs to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           personal_token: ${{ steps.generate-token.outputs.token }}
           publish_dir: docs/website/build
@@ -246,7 +249,7 @@ jobs:
           commit_message: "ci(docs): deploy documentation"
 
       - name: Deploy root redirect to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           personal_token: ${{ steps.generate-token.outputs.token }}
           publish_dir: .github/pages-root

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -1,33 +1,38 @@
 name: CD / Docs
 
 on:
-  release:
-    types: [published]
   push:
     branches: [main]
     paths:
       - docs/website/**
+      - regis/**
+      - scripts/generate_whats_new.py
+      - CHANGELOG.md
+      - Pipfile
+      - pyproject.toml
+      - package.json
+      - pnpm-lock.yaml
+      - .github/pages-root/**
       - .github/workflows/cd-docs.yml
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  id-token: write
-  actions: write
 
 concurrency:
-  group: docs-publish
+  group: docs-publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
-      actions: write
     steps:
       - name: Generate GitHub App token
         id: generate-token
@@ -43,15 +48,53 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Classify docs work
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+        run: |
+          set -euo pipefail
+
+          generate_reference=false
+          refresh_badge=false
+          refresh_archive=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ -z "$BEFORE_SHA" ]; then
+            generate_reference=true
+            refresh_badge=true
+            refresh_archive=true
+          else
+            CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")
+            printf '%s\n' "$CHANGED_FILES"
+
+            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|scripts/generate_whats_new\.py$|CHANGELOG\.md$|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)'; then
+              generate_reference=true
+            fi
+
+            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|tests/|Pipfile$|pyproject\.toml$|\.github/workflows/cd-docs\.yml$)'; then
+              refresh_badge=true
+            fi
+
+            if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(regis/|Pipfile$|pyproject\.toml$|package\.json$|pnpm-lock\.yaml$|\.github/workflows/cd-docs\.yml$)'; then
+              refresh_archive=true
+            fi
+          fi
+
+          echo "generate_reference=$generate_reference" >> "$GITHUB_OUTPUT"
+          echo "refresh_badge=$refresh_badge" >> "$GITHUB_OUTPUT"
+          echo "refresh_archive=$refresh_archive" >> "$GITHUB_OUTPUT"
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - name: Install pipenv
-        run: pip install pipenv
+          cache: pipenv
 
       - name: Install Python dependencies
-        run: pipenv sync --dev
+        run: |
+          pip install pipenv
+          pipenv sync --dev
 
       - name: Install Hadolint
         run: |
@@ -100,9 +143,10 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Generate Schema Docs
+        if: steps.changes.outputs.generate_reference == 'true'
         run: |
           # Copy all schemas first to allow cross-category resolution
           mkdir -p docs/website/static/schemas
@@ -117,9 +161,11 @@ jobs:
           done
 
       - name: Generate Rules Reference
+        if: steps.changes.outputs.generate_reference == 'true'
         run: pipenv run regis rules list -f markdown -D docs/website/docs/reference/rules
 
       - name: Ensure whats-new label exists
+        if: steps.changes.outputs.generate_reference == 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
@@ -130,23 +176,27 @@ jobs:
             2>/dev/null || true
 
       - name: Generate What's New page
+        if: steps.changes.outputs.generate_reference == 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: python scripts/generate_whats_new.py
 
       - name: Generate coverage badge
+        if: steps.changes.outputs.refresh_badge == 'true'
         continue-on-error: true
         run: |
           pipenv run pytest --cov --cov-report=xml -q --no-header
           pipenv run genbadge coverage -i coverage.xml -o coverage-badge.svg
 
       - name: Generate Default Archive
+        if: steps.changes.outputs.refresh_archive == 'true'
         run: |
           mkdir -p docs/website/static/archives/default
           pipenv run regis analyze --evaluate alpine:latest -A docs/website/static/archives/default/
           pipenv run regis analyze --evaluate ghcr.io/trivoallan/regis:latest -A docs/website/static/archives/default/
 
       - name: Validate Default Archive
+        if: steps.changes.outputs.refresh_archive == 'true'
         run: |
           if [ ! -d "docs/website/static/archives/default" ] || [ -z "$(ls -A docs/website/static/archives/default)" ]; then
             echo "::error::Default archive directory is empty — archive generation failed"
@@ -159,23 +209,25 @@ jobs:
         working-directory: docs/website
 
       - name: Create Pull Request for documentation updates
+        if: steps.changes.outputs.generate_reference == 'true' || steps.changes.outputs.refresh_badge == 'true'
         id: cpr
         continue-on-error: true
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "docs: update documentation reference and snapshots"
+          commit-message: "docs: refresh generated latest documentation assets"
           author: regis-ci[bot] <regis-ci[bot]@users.noreply.github.com>
-          branch: docs/automated-updates
+          branch: docs/latest-generated
           delete-branch: true
-          title: "docs: update documentation reference and snapshots"
+          title: "docs: refresh generated latest documentation assets"
           body: |
-            Automated documentation updates:
-            - Generated latest JSON Schema reference
-            - Generated latest Rules reference
+            Automated latest-documentation updates:
+            - Generated the current JSON Schema reference when source inputs changed
+            - Generated the current Rules reference when source inputs changed
+            - Refreshed the repository coverage badge when test-affecting code changed
 
-            This PR ensures the documentation reflects the latest codebase.
-            What's New page is generated at deploy time only (not committed).
+            This PR keeps the mutable latest docs in sync with main.
+            Versioned Docusaurus snapshots are handled separately by the release-snapshot workflow.
           add-paths: |
             coverage-badge.svg
             docs/website/docs/reference/rules/**

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -9,8 +9,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-snapshot-${{ github.event.release.tag_name || github.ref || github.run_id }}
@@ -27,13 +26,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: ${{ secrets.REGIS_CI_APP_ID }}
           private-key: ${{ secrets.REGIS_CI_APP_PRIVATE_KEY }}
 
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
           ref: main
@@ -71,12 +70,12 @@ jobs:
           echo "Extracted version: v${VERSION}"
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6
         with:
           version: 10
           run_install: false
@@ -87,7 +86,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -9,8 +9,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
+
+concurrency:
+  group: release-snapshot-${{ github.event.release.tag_name || github.ref || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   snapshot-pending:
@@ -77,8 +81,21 @@ jobs:
           version: 10
           run_install: false
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install docs dependencies
-        run: pnpm install --filter docs
+        run: pnpm install --filter docs --frozen-lockfile
 
       - name: Create version snapshot
         working-directory: docs/website


### PR DESCRIPTION
## Summary

This refactors the docs delivery workflows so mutable latest docs and immutable Docusaurus release snapshots are handled by separate pipelines.

## What changed

- updates `.github/workflows/cd-docs.yml` to publish latest docs from `main` only
- removes the release trigger from the latest docs workflow
- expands push path filters in `cd-docs.yml` to include real docs source inputs
- adds a change classification step so schema docs, rules reference, coverage badge, and default archive are regenerated only when relevant inputs change
- reduces permissions in `cd-docs.yml` and enables Pipenv caching plus frozen pnpm installs
- keeps version snapshots in `.github/workflows/release-snapshot.yml` and adds dedicated concurrency, pnpm cache, and frozen lockfile install there

## Why

Previously the latest docs pipeline and the release snapshot workflow overlapped conceptually around release events. This made the responsibilities less clear and caused the docs pipeline to do expensive work even for simple documentation-only updates.

This change makes the split explicit:

- `cd-docs.yml` manages the mutable latest docs site
- `release-snapshot.yml` manages immutable versioned Docusaurus snapshots

## How to verify

- [ ] Push a docs-only change under `docs/website/` and confirm `cd-docs.yml` builds and deploys without regenerating schema docs, rules reference, coverage badge, or default archive
- [ ] Push a change affecting docs source generation, for example under `regis/`, and confirm `cd-docs.yml` regenerates the relevant latest-doc assets
- [ ] Publish a release and confirm `release-snapshot.yml` creates or updates the snapshot PR without involving the latest docs workflow
- [ ] Manually trigger both workflows and confirm each still executes its full intended path

## Risks

- the change classification in `cd-docs.yml` is now part of the workflow contract, so any future source path that should regenerate docs assets must be added to its filters
- workflows were not executed from this session
