### PR TITLE
docs: pre-v1 monorepo structure reflection

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -96,7 +96,6 @@
 
 ## Current Objective
 
-
 ## Recent Changes (main branch)
 
 - **GitHub Actions Auth Unification**: All 6 workflows migrated to use `actions/create-github-app-token@v1` with `REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY` secrets.

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -110,6 +110,7 @@ This is NOT a decision to make now — it's a structured reflection for later. K
 - **Trade-offs**: Atomicity vs. flexibility; shared tooling vs. polyglot overhead
 
 **To explore before deciding**:
+
 1. Test contributor workflows (naive PR on dashboard/docs)
 2. Project post-v1 evolution (dashboard vs. CLI cadence)
 3. Consult with potential multi-team contributors

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -2,11 +2,9 @@
 
 ## Current Objective
 
-Memory Bank source of truth moved to `docs/memory-bank/`.
+**Primary**: Memory Bank source of truth consolidated under `docs/memory-bank/`.
 
-Keep `docs/memory-bank/` as the single source of truth for cross-session context.
-
-Documentation update following the pipeline refactoring and checklist enhancement.
+**Secondary (reflection in progress)**: Pre-v1 architecture decision — exploring whether to keep monorepo structure vs. split before v1. This is NOT a decision yet, just structured thinking space. Key unknowns: future contributor patterns, post-v1 release cadence, governance at scale. To explore: test contributor workflows, project post-v1 evolution, consult multi-team contributors, document constraints (Harbor integration, JSON schemas, regis-specific rules).
 
 ## Recent Changes
 
@@ -98,29 +96,6 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 
 ## Current Objective
 
-**Pre-v1 Architecture Reflection: Monorepo Structure**
-
-Taking time to seriously consider whether to keep the current monorepo structure (regis CLI + dashboard + docs) vs. split before v1.
-
-This is NOT a decision to make now — it's a structured reflection for later. Key considerations:
-
-- **Current state**: Polyglot monorepo (Python + JavaScript/TypeScript, pnpm workspace, Release Please)
-- **Coupling**: Dashboard and docs tightly bound to regis version; shared schemas, rules, analyzers
-- **Unknowns**: Future contributor patterns, post-v1 release cadence, governance at scale
-- **Trade-offs**: Atomicity vs. flexibility; shared tooling vs. polyglot overhead
-
-**To explore before deciding**:
-
-1. Test contributor workflows (naive PR on dashboard/docs)
-2. Project post-v1 evolution (dashboard vs. CLI cadence)
-3. Consult with potential multi-team contributors
-4. Document constraints (Harbor integration, JSON schemas, regis-specific rules)
-
-**Next step**: Create a spike document under `docs/memory-bank/plans/` if deep analysis is needed, but no rush.
-
-## Current Objective
-
-GitHub Actions authentication centralization complete.
 
 ## Recent Changes (main branch)
 

--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -98,6 +98,27 @@ Documentation update following the pipeline refactoring and checklist enhancemen
 
 ## Current Objective
 
+**Pre-v1 Architecture Reflection: Monorepo Structure**
+
+Taking time to seriously consider whether to keep the current monorepo structure (regis CLI + dashboard + docs) vs. split before v1.
+
+This is NOT a decision to make now — it's a structured reflection for later. Key considerations:
+
+- **Current state**: Polyglot monorepo (Python + JavaScript/TypeScript, pnpm workspace, Release Please)
+- **Coupling**: Dashboard and docs tightly bound to regis version; shared schemas, rules, analyzers
+- **Unknowns**: Future contributor patterns, post-v1 release cadence, governance at scale
+- **Trade-offs**: Atomicity vs. flexibility; shared tooling vs. polyglot overhead
+
+**To explore before deciding**:
+1. Test contributor workflows (naive PR on dashboard/docs)
+2. Project post-v1 evolution (dashboard vs. CLI cadence)
+3. Consult with potential multi-team contributors
+4. Document constraints (Harbor integration, JSON schemas, regis-specific rules)
+
+**Next step**: Create a spike document under `docs/memory-bank/plans/` if deep analysis is needed, but no rush.
+
+## Current Objective
+
 GitHub Actions authentication centralization complete.
 
 ## Recent Changes (main branch)


### PR DESCRIPTION
## Summary

Structured pre-v1 reflection on monorepo architecture: keep current structure vs. split before v1.

This is **not a decision** — just documenting the thinking space for later consideration.

## Context

Current setup: polyglot monorepo (Python CLI + React dashboard + docs, pnpm workspace, Release Please)

**Key considerations**:
- Coupling: dashboard and docs tightly bound to regis version (shared schemas, rules, analyzers)
- Trade-offs: atomicity vs. flexibility; shared tooling vs. polyglot overhead
- Unknowns: future contributor patterns, post-v1 release cadence, governance at scale

## To Explore Before Deciding

1. Test contributor workflows (naive PR on dashboard/docs from external perspective)
2. Project post-v1 evolution (dashboard vs. CLI release cadence)
3. Consult with potential multi-team contributors
4. Document constraints (Harbor integration, JSON schemas, regis-specific rules)

**Next step**: Create a spike document if deep analysis is needed, but no rush — this reflection can marinate until v1 is closer to ship.