### PR TITLE
ci(docs): harden deployment with environment gate, npm audit and build artifact

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -22,7 +22,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: docs-publish-main
@@ -31,8 +30,10 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: docs-production
     permissions:
       contents: write
+      pages: write
       pull-requests: write
     steps:
       - name: Generate GitHub App token
@@ -148,6 +149,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit Node dependencies (HIGH/CRITICAL gate)
+        run: |
+          set +e
+          pnpm audit --audit-level=high --json > npm-audit-report.json 2>&1
+          audit_exit_code=$?
+          set -e
+          if [ "$audit_exit_code" -ne 0 ]; then
+            echo "pnpm audit found HIGH or CRITICAL vulnerabilities — failing build"
+            cat npm-audit-report.json
+            exit 1
+          fi
+
+      - name: Upload npm-audit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-audit-report
+          path: npm-audit-report.json
+          retention-days: 14
+          if-no-files-found: warn
+
       - name: Generate Schema Docs
         if: steps.changes.outputs.generate_reference == 'true'
         run: |
@@ -210,6 +232,14 @@ jobs:
       - name: Docusaurus build
         run: pnpm run build
         working-directory: docs/website
+
+      - name: Upload Docusaurus build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-build-${{ github.sha }}
+          path: docs/website/build
+          retention-days: 30
+          if-no-files-found: error
 
       - name: Create Pull Request for documentation updates
         if: steps.changes.outputs.generate_reference == 'true' || steps.changes.outputs.refresh_badge == 'true'


### PR DESCRIPTION
## Summary

Closes #485

Hardens the `cd-docs.yml` deployment workflow by adding the missing security controls identified in #485.

## Changes

**1. Protected environment `docs-production`**
- Added `environment: docs-production` to the `build-and-deploy` job.
- Once the environment is created in GitHub Settings with required reviewers, every documentation deploy to GitHub Pages will require manual approval before proceeding.

**2. Node dependency audit gate (HIGH/CRITICAL)**
- Added a `pnpm audit --audit-level=high` step before the Docusaurus build.
- Blocks the deployment if any HIGH or CRITICAL vulnerability is found in the Node dependency tree.
- Uploads the JSON audit report as a workflow artifact for traceability (mirrors the existing `pip-audit` gate in `ci-security.yml`).

**3. Docusaurus build artifact upload**
- The compiled `docs/website/build` directory is now uploaded as `docs-build-<sha>` after every successful build.
- Retention: 30 days. Allows post-deploy inspection and rollback reference.

**4. `pages: write` permission scoped to the job**
- Added `pages: write` to the job-level permissions block for clarity (the workflow-level block remains `contents: read`).

## What still needs to be done manually (cannot be done via file)

- **Create the `docs-production` environment** in _Settings → Environments_ with at least one required reviewer and a deployment branch rule limited to `main`.
- **Enable branch protection on `main`**: require PR review, require status checks (`build-and-deploy`), disallow force-push.
- **Verify secrets** (`REGIS_CI_APP_ID`, `REGIS_CI_APP_PRIVATE_KEY`) are configured at environment scope (not just repo scope) once the environment exists.