### PR TITLE
feat(cli): add `regis doctor` command

### DIFF
--- a/regis/cli.py
+++ b/regis/cli.py
@@ -13,6 +13,7 @@ from regis.commands.archive import archive
 from regis.commands.bootstrap import bootstrap
 from regis.commands.check import check, version_cmd
 from regis.commands.dashboard import dashboard_group
+from regis.commands.doctor import doctor
 from regis.commands.rules import rules_group
 from regis.github_cli import github_cmd
 from regis.gitlab_cli import gitlab_cmd
@@ -71,6 +72,7 @@ main.add_command(check)
 main.add_command(version_cmd, name="version")
 main.add_command(rules_group, name="rules")
 main.add_command(dashboard_group, name="dashboard")
+main.add_command(doctor)
 
 
 if __name__ == "__main__":

--- a/regis/commands/doctor.py
+++ b/regis/commands/doctor.py
@@ -1,0 +1,50 @@
+"""doctor command — check external tool availability and versions."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404
+
+import click
+
+# Tools required by regis analyzers, in display order.
+_REQUIRED_TOOLS: list[tuple[str, str]] = [
+    ("trivy", "--version"),
+    ("skopeo", "--version"),
+    ("hadolint", "--version"),
+    ("dockle", "--version"),
+]
+
+
+def _get_version(tool: str, version_flag: str) -> str | None:
+    """Return the first line of `tool <version_flag>` output, or None on failure."""
+    try:
+        result = subprocess.run(  # nosec B603
+            [tool, version_flag],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        output = (result.stdout or result.stderr).strip()
+        return output.splitlines()[0] if output else None
+    except Exception:
+        return None
+
+
+@click.command(name="doctor")
+def doctor() -> None:
+    """Check that all required external tools are installed and show their versions."""
+    all_ok = True
+
+    for tool, version_flag in _REQUIRED_TOOLS:
+        path = shutil.which(tool)
+        if path:
+            version_line = _get_version(tool, version_flag) or "(version unknown)"
+            click.echo(f"  ✓ {tool:<12} {version_line}")
+        else:
+            click.echo(f"  ✗ {tool:<12} not found in PATH", err=False)
+            all_ok = False
+
+    if not all_ok:
+        raise SystemExit(1)

--- a/regis/commands/doctor.py
+++ b/regis/commands/doctor.py
@@ -16,11 +16,11 @@ _REQUIRED_TOOLS: list[tuple[str, str]] = [
 ]
 
 
-def _get_version(tool: str, version_flag: str) -> str | None:
-    """Return the first line of `tool <version_flag>` output, or None on failure."""
+def _get_version(path: str, version_flag: str) -> str | None:
+    """Return the first line of `path <version_flag>` output, or None on failure."""
     try:
         result = subprocess.run(  # nosec B603
-            [tool, version_flag],
+            [path, version_flag],
             capture_output=True,
             text=True,
             check=False,
@@ -28,7 +28,7 @@ def _get_version(tool: str, version_flag: str) -> str | None:
         )
         output = (result.stdout or result.stderr).strip()
         return output.splitlines()[0] if output else None
-    except Exception:
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
 
 
@@ -40,7 +40,7 @@ def doctor() -> None:
     for tool, version_flag in _REQUIRED_TOOLS:
         path = shutil.which(tool)
         if path:
-            version_line = _get_version(tool, version_flag) or "(version unknown)"
+            version_line = _get_version(path, version_flag) or "(version unknown)"
             click.echo(f"  ✓ {tool:<12} {version_line}")
         else:
             click.echo(f"  ✗ {tool:<12} not found in PATH", err=False)

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -52,7 +52,7 @@ def test_missing_tool_exits_nonzero():
         patch("regis.commands.doctor._get_version", return_value=None),
     ):
         result = runner.invoke(doctor)
-    assert result.exit_code != 0
+    assert result.exit_code == 1
 
 
 def test_missing_tool_shows_cross():
@@ -78,7 +78,7 @@ def test_partial_tools_missing_exits_nonzero():
         ),
     ):
         result = runner.invoke(doctor)
-    assert result.exit_code != 0
+    assert result.exit_code == 1
     assert "✓" in result.output
     assert "✗" in result.output
 

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -1,0 +1,94 @@
+"""Tests for `regis doctor` command."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from regis.commands.doctor import doctor
+
+
+def _which_all(name: str) -> str:
+    return f"/usr/bin/{name}"
+
+
+def _which_none(_name: str) -> None:
+    return None
+
+
+def test_all_tools_present_exits_zero():
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_all),
+        patch(
+            "regis.commands.doctor._get_version",
+            return_value="Version: 1.0.0",
+        ),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code == 0
+    assert "✓" in result.output
+
+
+def test_all_tools_present_shows_each_tool():
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_all),
+        patch(
+            "regis.commands.doctor._get_version",
+            return_value="Version: 1.0.0",
+        ),
+    ):
+        result = runner.invoke(doctor)
+    for tool in ("trivy", "skopeo", "hadolint", "dockle"):
+        assert tool in result.output
+
+
+def test_missing_tool_exits_nonzero():
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_none),
+        patch("regis.commands.doctor._get_version", return_value=None),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code != 0
+
+
+def test_missing_tool_shows_cross():
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_none),
+        patch("regis.commands.doctor._get_version", return_value=None),
+    ):
+        result = runner.invoke(doctor)
+    assert "✗" in result.output
+
+
+def test_partial_tools_missing_exits_nonzero():
+    def which_partial(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in ("trivy", "skopeo") else None
+
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=which_partial),
+        patch(
+            "regis.commands.doctor._get_version",
+            return_value="Version: 1.0.0",
+        ),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code != 0
+    assert "✓" in result.output
+    assert "✗" in result.output
+
+
+def test_version_unknown_when_subprocess_returns_nothing():
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_all),
+        patch("regis.commands.doctor._get_version", return_value=None),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code == 0
+    assert "version unknown" in result.output


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `regis doctor`, a new top-level command that checks whether all required external binaries (`trivy`, `skopeo`, `hadolint`, `dockle`) are available in `PATH` and prints their version strings.
- Exit code `0` when all tools are found, `1` if any are missing.
- 6 unit tests covering all cases (all present, all missing, partial, version unknown).

## Example output

```
$ regis doctor
  ✓ trivy         Version: 0.50.1
  ✓ skopeo        skopeo version 1.14.0
  ✓ hadolint      Hadolint 2.12.0
  ✗ dockle        not found in PATH
```

## Test plan

- [ ] `regis doctor` passes when all tools are installed
- [ ] `regis doctor` exits 1 and shows `✗` for missing tools
- [ ] Unit tests pass: `pytest tests/commands/test_doctor.py`

Closes #580
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZinYziJ2cEimhbgqbirfg)_