### PR TITLE
docs(docs): refresh memory bank for Sprint 1

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -2,124 +2,31 @@
 
 ## Current Objective
 
-**Primary**: Memory Bank source of truth consolidated under `docs/memory-bank/`.
+**Sprint 1 (19 mai → 2 juin)** — Fondations : nettoyer, stabiliser, poser la base playbook.
 
-**Secondary (reflection in progress)**: Pre-v1 architecture decision — exploring whether to keep monorepo structure vs. split before v1. This is NOT a decision yet, just structured thinking space. Key unknowns: future contributor patterns, post-v1 release cadence, governance at scale. To explore: test contributor workflows, project post-v1 evolution, consult multi-team contributors, document constraints (Harbor integration, JSON schemas, regis-specific rules).
+Items en cours :
+
+| Item                        | Description                                                                                                          | Status      |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les vieilles versions. Désactiver `release-snapshot.yml`.      | Not Started |
+| **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`. | Not Started |
+| **Finitions site de doc**   | Branding, CI hardening, navigation sidebar, SEO baseline.                                                            | Not Started |
+| **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport.                            | Not Started |
+
+Voir `docs/memory-bank/roadmap.md` pour le détail complet.
 
 ## Recent Changes
 
-- [2026-04-21] Memory Bank update requested; no new application code changes were detected during the scan.
-- [2026-04-21] Supplemental planning files (`decisionLog.md`, `roadmap.md`) reviewed and kept alongside the core memory bank.
-- Refactored `.gitlab-ci.yml` (consumer cookiecutter): split monolithic `analyze_image` into four independent jobs:
-  - `analyze_image` — runs `regis analyze`, produces `reports/` artifacts.
-  - `push_results` — commits report to branch, prepends report URL to MR description, posts MR comment.
-  - `set_labels` — applies scoped GitLab labels from `playbook.labels` via API.
-  - `set_checklist` — appends Markdown review checklist from `playbook.mr_description_checklist` to MR description.
-- Fixed `SIGPIPE` (exit code 141) errors by eliminating pipe chains.
-- Fixed report URL 404: `analyze_image` now writes its `CI_JOB_ID` to `reports/.analyze_job_id`; `push_results` reads it to build the correct artifact URL.
-- Added `show_if` / `check_if` fields to checklist items:
-  - `show_if` — JSON Logic expression controlling item visibility.
-  - `check_if` — JSON Logic expression controlling pre-checked state (`[x]` vs `[ ]`).
-- `mr_description_checklist` output changed from `list[str]` to `list[{label, checked}]`.
-- Updated `playbook.schema.json`, `engine.py`, `default.yaml`, and `test_playbook_engine.py` (27 tests pass).
-- Updated `docs/modules/ROOT/pages/playbooks.adoc` — checklist section documents `show_if`/`check_if`.
-- Updated `docs/modules/ROOT/pages/integrations/gitlab.adoc` — pipeline diagram and job descriptions reflect refactored pipeline.
-- Improved documentation for CI/CD integration (moved Cookiecutter, added tips, added C4 diagrams).
-- Unified linting experience by migrating to Trunk.
-- Migrated documentation to Docusaurus, established dynamic versioning strategy with tag names, and cleaned up redundant folders.
-- Added support for Markdown output in `regis rules list` and generated rules reference documentation.
-- Refactored `generate` command into a `bootstrap` command group:
-  - `bootstrap playbook` — creates a new custom playbook from the `cookiecutters/playbook` template.
-  - `bootstrap archive` — bootstraps a standalone Docusaurus + Tremor archive viewer site.
-  - Removed the monolithic `generate` command and the deprecated `repository` cookiecutter.
-  - Updated `tests/test_bootstrap.py`.
-  - Updated `docs/website/docs/reference/cli.md`.
-- Added `docs/modules/ROOT/pages/commands.adoc` listing all available CLI commands.
-- Updated `docs/modules/ROOT/nav.adoc` to include the new commands page.
-- Consolidated bootstrapping documentation:
-  - Removed obsolete `docs/modules/ROOT/pages/integrations/cookiecutter.adoc`.
-  - Added `#bootstrap` anchor to `commands.adoc`.
-- Updated links in `index.adoc`, `get-started.adoc`, `github.adoc`, and `gitlab.adoc` to point to the new anchor.
-- Removed `cookiecutter.adoc` from `nav.adoc`.
-- Migrated CI linting from Super-Linter to Trunk:
-  - Enabled `mypy` and `hadolint` in Trunk.
-  - Added necessary type stubs for `PyYAML`, `requests`, and `jsonschema`.
-  - Replaced `github/super-linter` with `trunk-io/trunk-action` in GitHub Actions.
-  - Rewrote `README.md` to focus on core features and added a comprehensive "Report Preview" section with 7 interactive carousels.
-- Captured and added 7 screenshots covering all major report pages to `.github/assets/`.
-- Corrected the Alpine example report URL in `README.md` to point to the versioned documentation path.
-- Added `README.md` to `release-please-config.json` `extra-files` to ensure consistent versioning and updates.
-- Redesign of `README.md` now properly redirects all technical documentation to the official Antora site.
-- Fixed `bootstrap` command failure in Docker image:
-  - Moved `cookiecutters/` directory into the `regis` package.
-  - Updated `cli.py` to use `importlib.resources.files` for finding templates, ensuring compatibility with installed packages.
-  - Updated `pyproject.toml` to include `cookiecutters/**/*` in package data.
-- Fixed `fatal: ambiguous argument 'HEAD^2'` in Trunk Check workflow:
-  - Enabled `fetch-depth: 0` for full history checkout.
-  - Removed explicit `ref` override to allow Trunk's default merge-base detection on PRs.
-  - Updated auto-commit step to explicitly push to the PR branch.
-- Migrated Documentation from Antora to Docusaurus (located in `docs/website`).
-- Relocated JSON schemas from `reference/schemas/` to `regis/schemas/` to ensure they are properly packaged.
-- Added `__init__.py` files to `regis/schemas/` and subdirectories to support `importlib.resources`.
-- Updated `pyproject.toml` to include the new schemas directory in package data.
-- Exported JSON schemas to `docs/website/static/schemas/` for Docusaurus referencing.
-- Configured Docusaurus versioning:
-  - Added `stable` version for the latest tag.
-  - Configured `docusaurus.config.ts` to support multiple versions.
-  - Updated `release-please-config.json` to include `docs/website/versions.json`.
-- Updated `docs-publish.yml` workflow to only trigger versioning for tags starting with `v`.
-- Fixed lint error in `cli.py` (unused variable `exc`).
-- Added **Post-install notes** feature to `bootstrap` commands:
-  - CLI now reads and displays `.regis-post-install.md` from the generated project.
-  - Templates for repository and playbook include personalized setup instructions (GitHub/GitLab setup, next steps).
-  - Updated `commands.adoc` to document this behavior.
-- Improved Docusaurus versioning:
-  - Updated `.github/workflows/docs-publish.yml` to use `${{ github.ref_name }}` for dynamic versioning on tags.
-  - Cleaned up redundant `version-current` files and `versions.json` entries.
-- Fixed CI Warnings and Errors:
-  - Added `regis/schemas/playbook/jsonlogic.schema.json` to resolve schema generation warnings.
-  - Updated `docs-publish.yml` to copy all schemas to a shared static directory, fixing cross-category references.
-  - Resolved `fatal: ambiguous argument 'HEAD^2'` in Trunk Check CI by refining checkout and specifying `check-mode`.
-  - Suppressed `RequestsDependencyWarning` by pinning `urllib3`, `chardet`, and `charset-normalizer` in `Pipfile`.
-- Added `--format` and `--output` options to `regis rules list` to support Markdown documentation generation.
-- Generated `docs/website/docs/reference/rules.md` rules reference documentation using the new CLI capabilities.
-- Migrated the report viewer to a modern Docusaurus-based application (located in `apps/dashboard`).
-- Updated `regis/cli.py` and `regis/report/docusaurus.py` to support the new report generation flow.
-- Added `--base-url` option to `regis analyze` and `evaluate` for correct asset loading in static viewers (GitLab artifacts).
-- Updated the `.gitlab-ci.yml` template in the repository cookiecutter to dynamically calculate and pass the `baseUrl`.
-- Removed legacy Jinja2-based HTML templates from `regis/templates/default/`.
-- Updated `pnpm-workspace.yaml` and `release-please-config.json` to include the new report viewer application.
-- Updated documentation site (`cli.md`, `analyze-image.md`, `gitlab.md`) with report viewer and artifact viewing details.
-
-- Monitor CI/CD results for the new PR.
-- Merge PR for `feat/dashboard-tremor`.
-
-## Current Objective
-
-## Recent Changes (main branch)
-
 - [2026-05-23] **CLAUDE.md restructure** (PR #592, merged): file dropped from ~180 → ~90 lines.
   - Split into agent essentials (top) and project policy (bottom). Memory Bank section condensed to a 3-line pointer (no longer duplicates `RULES.md`).
-  - New **Craftsmanship** principle: _spec-based programming with stacked skills_ — covers both methodology (composing [Superpowers](https://claude.com/plugins/superpowers) skills with project skills like `/create-playbook`, `/verify`, `/code-review`) and architecture (declarative JSON Schemas / playbook YAML / JSON Logic over imperative code).
+  - New **Craftsmanship** principle: _spec-based programming with stacked skills_ — methodology (composing Superpowers skills with project skills like `/create-playbook`, `/verify`, `/code-review`) and architecture (declarative JSON Schemas / playbook YAML / JSON Logic over imperative code).
   - **Git workflow**: made the rebase requirement explicit — always rebase feature branches on the latest `main` (never merge `main` back in).
-  - Added `pnpm --filter @regis/dashboard start|build` commands for the report viewer.
-  - Dropped the stale "Use devcontainers where possible" line (no `.devcontainer/` exists).
-  - Replaced the broken `whats-new.md` link with a reference to `scripts/generate_whats_new.py`.
-  - Reference material relocated to `systemPatterns.md`: full **CI/CD Gotchas** section (App token wiring, Dependabot secret access, Release Please labels, gh-pages, Trunk auto-fmt, mypy/tests, rebase + squash no-op) and full **Commit Scopes** list.
-- **GitHub Actions Auth Unification**: All 6 workflows migrated to use `actions/create-github-app-token@v1` with `REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY` secrets.
-  - **`release-please.yml`**: Replaced `secrets.RELEASE_TOKEN` (PAT) with GitHub App token.
-  - **`viewer-publish.yml`** and **`docs-publish.yml`**: Changed `github_token:` to `personal_token:` for `peaceiris/actions-gh-pages` (required for non-GITHUB_TOKEN).
-  - **`trunk.yml`**: Uses App token so auto-committed formatting fixes trigger downstream CI runs (GITHUB_TOKEN commits don't trigger).
-  - **Motivation**: Centralized auth mechanism ensures bot-created PRs and auto-commits trigger proper CI/CD workflows.
-- [2026-04-21] Migrated Memory Bank protocol to point at `docs/memory-bank/` and deprecated the root-level duplicate.
-- [2026-04-22] **M002/S02 completed — Snapshot publication date**:
-  - Backfilled v0.27.0/v0.26.2 snapshot dates in both JSON data files.
-  - Added `--markdown` flag to `regis analyze` (no `-m` shorthand; conflicts with `--meta`).
-  - New `_render_markdown()` in `report.py` follows the `elif fmt == '<ext>':` pattern.
-  - 12 slice tests pass, 460 total pass. `scripts/verify_s02.py` exits 0 (7/7 checks).
-  - Key decision: `-m` shorthand dropped; `_render_markdown` guards `snapshot_date` on truthiness.
-- [2026-04-22] **Claude Workflows CI/CD Fixes**:
-  - SHA-pinned all GitHub Actions in `claude-code-review.yml` and `claude.yml` workflows to comply with lint pipeline requirements.
-  - Resolved Checkov CKV2_GHA_1 security check by adding workflow-level default permissions.
-  - Fixed YAML linting issues (redundantly quoted strings).
-  - All trunk checks passing. PR merged to main.
+  - Reference material relocated to `systemPatterns.md`: full CI/CD Gotchas section and full Commit Scopes list.
+- [2026-04-22] **Claude Workflows CI/CD Fixes**: SHA-pinned actions dans `claude-code-review.yml` et `claude.yml`, ajout des permissions workflow-level (CKV2_GHA_1), correction linting YAML. PR merged to main.
+- [2026-04-22] **M002/S02 — Snapshot publication date**: Ajout du flag `--markdown` à `regis analyze`, backfill dates v0.27.0/v0.26.2. 460 tests passent.
+- [2026-04-21] **GitHub Actions Auth Unification**: Les 6 workflows migrent vers `actions/create-github-app-token@v1` avec `REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`. `peaceiris/actions-gh-pages` utilise `personal_token:`.
+- [2026-03-21] **Tremor UI overhaul** (dashboard) : navbar identity badges, StatCard KPI, 12 pages analyzers, tables paginées CVE. Merged.
+
+## Decisions in Progress
+
+- **Monorepo vs split** (pré-v1) : exploration structurée, pas encore de décision. Inconnues : patterns contributeurs futurs, cadence post-v1, gouvernance à l'échelle.

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -1,51 +1,13 @@
 # Progress
 
-## Completed
-
-- Memory Bank source of truth consolidated under `docs/memory-bank/`.
-- Supplemental planning history retained in `docs/memory-bank/decisionLog.md` and `docs/memory-bank/roadmap.md`.
-
-- Core CLI functionality.
-- Key analyzers (Skopeo, Trivy, Hadolint, etc.).
-- Playbook evaluation with JSON logic.
-- Jinja2-based HTML report generation.
-- GitHub Actions workflows for release and Docker publishing.
-- Docusaurus documentation structure initialized and migrated from Antora, including versioning setup.
-- Relocated JSON schemas to `regis/schemas/` for better packaging.
-- Fixed Skopeo architecture mismatch handling for multi-arch image indexes.
-- Automated Antora documentation publishing to GitHub Pages (Legacy).
-- Automated `trunk fmt` in CI with auto-commit of style changes.
-- Fixed Trunk Check `HEAD^2` error by optimizing git checkout and auto-commit configuration.
-- Refactored `generate` command into a `bootstrap` command group (`bootstrap playbook` and `bootstrap archive`); removed deprecated `repository` cookiecutter.
-- Display post-install notes after bootstrap.
-- Fixed Trunk Check `HEAD^2` error by optimizing git checkout and auto-commit configuration.
-- Added post-install notes feature to `bootstrap` commands and updated documentation.
-
-- Unified linting experience by migrating to Trunk.
-- Migrated documentation to Docusaurus, established dynamic versioning strategy with tag names, and cleaned up redundant folders.
-- Added support for Markdown output in `regis rules list` and generated rules reference documentation.
-- **Implemented modern Docusaurus-based report viewer** (`apps/dashboard`).
-- Replaced legacy Jinja2 HTML report generation with the new React/Docusaurus architecture.
-- Integrated the new report viewer into the workspace (`pnpm`).
-- **Added GitLab artifact support** with dynamic `baseUrl` calculation and `--base-url` flag.
-- **Updated documentation** across the site to reflect the new report architecture.
-- Added `bootstrap archive-repo` command: full end-to-end scaffold → remote repo creation → GitHub/GitLab Pages activation in a single command.
-  - `--platform [github|gitlab]` flag skips the cookiecutter prompt via `extra_context`.
-  - Robust `ARCHIVE_BASE_URL` derivation: GitLab uses `CI_PAGES_URL` (handles subgroups and custom domains); GitHub exposes `vars.ARCHIVE_BASE_URL` override.
-  - Idempotent retry: if the remote repo already exists, creation is skipped and push continues.
-- **Tremor UI overhaul** of the report viewer (branch: `feature/dashboard-tremor`):
-  - Navbar identity badges (Registry, Repository, Tag, Digest) with clipboard copy.
-  - Raw JSON link uses dynamic `siteConfig.baseUrl` (fixes broken link with non-root baseUrl).
-  - Shared `StatCard` KPI component used across all 12 analyzer pages.
-  - 12 individual analyzer pages in sidebar submenu (replaces monolithic Playbook page).
-  - All analyzer sections homogenized: StatCards + Tremor Tables.
-  - TrivySection: paginated Critical/High CVE tables sorted by most recent date.
-  - Analyzer badges in rules tables link to their respective analyzer page.
-
 ## In Progress
 
-- Keep `docs/memory-bank/` as the single source of truth for ongoing updates.
-- Capture future code or workflow changes in this memory bank as they land.
+**Sprint 1 (19 mai → 2 juin 2026)** — voir `roadmap.md` pour le détail.
+
+- Moratoire snapshots doc
+- Playbook bundle format
+- Finitions site de doc
+- Guide GitLab CI
 
 ## Completed (Recent)
 
@@ -57,28 +19,40 @@
   - Reference material (CI/CD gotchas, full commit scopes list) moved to `docs/memory-bank/systemPatterns.md`.
 
 - **Single-file HTML report (2026-04-25)**:
-  - Added `--html` flag to `regis analyze` and `regis evaluate` generating a self-contained `report.html` (HTML+CSS, no JS, no external dependencies).
-  - Added `--sections` option: `all` (default), `summary`, or comma-separated analyzer slugs.
-  - Renamed internal `"html"` format string to `"html-site"` (user-facing `--site` flag unchanged).
-  - New files: `regis/report/html.py`, `regis/templates/html/report.html.j2`.
-  - 23 new tests (16 unit + 7 integration), 91% total coverage.
+  - Flag `--html` sur `regis analyze` et `regis evaluate` générant un `report.html` self-contained (HTML+CSS, sans JS ni dépendances externes).
+  - Option `--sections` : `all` (défaut), `summary`, ou liste d'analyzer slugs.
+  - Format interne `"html"` renommé `"html-site"` (flag user-facing `--site` inchangé).
+  - Nouveaux fichiers : `regis/report/html.py`, `regis/templates/html/report.html.j2`.
+  - 23 nouveaux tests (16 unit + 7 integration), 91% coverage totale.
 
 - **M002/S02 — Snapshot publication date (2026-04-22)**:
-  - Backfilled snapshot dates for v0.27.0 (→ 2026-04-09) and v0.26.2 (→ 2026-04-03) in both `regis/data/snapshot_dates.json` and `docs/website/snapshot-dates.json`.
-  - Added `--markdown` flag to `regis analyze` (no `-m` shorthand — conflicts with existing `-m`/`--meta`).
-  - Added `_render_markdown()` helper and `elif fmt == 'md':` branch in `regis/utils/report.py`.
-  - Markdown output: image-ref header, analysis timestamp, optional `snapshot_date` line (guarded on truthiness), playbook results table.
-  - 8 unit tests in `tests/commands/test_analyze_markdown.py` + structural acceptance script `scripts/verify_s02.py` (7/7 checks pass).
-  - 460 total tests pass, no regressions.
+  - Backfill dates v0.27.0 (→ 2026-04-09) et v0.26.2 (→ 2026-04-03).
+  - Flag `--markdown` sur `regis analyze` (pas de shorthand `-m` — conflit avec `--meta`).
+  - Helper `_render_markdown()` et branche `elif fmt == 'md':` dans `regis/utils/report.py`.
+  - 8 tests unitaires + script `scripts/verify_s02.py` (7/7 checks). 460 tests passent.
 
 - **Claude Workflows CI/CD Fixes (2026-04-22)**:
-  - SHA-pinned GitHub Actions to commit SHAs (`actions/checkout` and `anthropics/claude-code-action`)
-  - Added workflow-level permissions block to satisfy security checks
-  - Fixed YAML linting issues
-  - All trunk checks passing, PR merged to main
+  - SHA-pinning des GitHub Actions, permissions workflow-level, corrections YAML linting.
+  - Trunk checks passants, PR merged to main.
+
+- **GitHub Actions Auth Unification (2026-04-21)**:
+  - 6 workflows migrés vers `actions/create-github-app-token@v1`.
+  - `peaceiris/actions-gh-pages` : `personal_token:` à la place de `github_token:`.
+
+## Completed (Historical)
+
+- Memory Bank consolidé sous `docs/memory-bank/`.
+- Core CLI, analyzers clés (Skopeo, Trivy, Hadolint, etc.), évaluation playbook JSON Logic.
+- Docusaurus : migration depuis Antora, versioning dynamique, documentation à code.
+- Schémas JSON relocalisés dans `regis/schemas/` pour le packaging.
+- Refactoring commande `generate` → groupe `bootstrap` (`bootstrap playbook`, `bootstrap archive`, `bootstrap archive-repo`).
+- Affichage des post-install notes après bootstrap.
+- Viewer de rapport moderne Docusaurus/React (`apps/dashboard`) — remplacement Jinja2.
+- Support artifacts GitLab avec flag `--base-url` et calcul dynamique du `baseUrl`.
+- Trunk : migration depuis Super-Linter, linting unifié local + CI.
+- `show_if` / `check_if` sur les items de checklist playbook.
+- Refactoring pipeline GitLab CI (4 jobs indépendants : analyze, push_results, set_labels, set_checklist).
 
 ## Future Roadmap
 
-- Additional analyzers (e.g., custom compliance checks).
-- More HTML themes.
-- Enhanced reporting features.
+Voir `docs/memory-bank/roadmap.md` pour le détail des sprints.

--- a/docs/memory-bank/projectbrief.md
+++ b/docs/memory-bank/projectbrief.md
@@ -41,9 +41,13 @@ Provide a single orchestration layer for container security, supply-chain eviden
 
 ### Out of Scope
 
-- Not enough evidence to define project-wide product exclusions
+- General-purpose container runtime management (not a replacement for Docker/Podman)
+- Real-time image scanning daemon (batch/CI-oriented only)
+- Multi-tenant SaaS hosting — self-hosted CI/CD integration only
+- Custom analyzer authoring guide (deferred post-v1)
 
 ## Key Stakeholders
 
 - Tristan Rivoallan
-- Maintainers and contributors working on security and CI/CD workflows
+- Direction Expertise Applicative (architectes et experts sécurité) — cible pilote v1
+- Équipes projet — utilisateurs playbook "progression projet"

--- a/docs/memory-bank/roadmap.md
+++ b/docs/memory-bank/roadmap.md
@@ -76,12 +76,12 @@ La v1 est la première version déployée auprès d'équipes pilotes réelles :
 
 _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 
-| Item                        | Description                                                                                                                                               | Status      |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les versions anciennes (garder 3 dernières). Désactiver `release-snapshot.yml`.                     | Not Started |
-| **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`.                                      | Not Started |
+| Item                        | Description                                                                                                                                                | Status      |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les versions anciennes (garder 3 dernières). Désactiver `release-snapshot.yml`.                      | Not Started |
+| **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`.                                       | Not Started |
 | **Finitions site de doc**   | Branding, CI hardening (Trivy pinning, archives résilientes), navigation sidebar, SEO baseline. Plan : `docs/memory-bank/plans/finitions-doc-site-plan.md` | Not Started |
-| **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport sur GitLab Pages / K8s.                                          | Not Started |
+| **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport sur GitLab Pages / K8s.                                           | Not Started |
 
 ---
 

--- a/docs/memory-bank/roadmap.md
+++ b/docs/memory-bank/roadmap.md
@@ -76,12 +76,12 @@ La v1 est la première version déployée auprès d'équipes pilotes réelles :
 
 _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 
-| Item                        | Description                                                                                                                                                | Status      |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les versions anciennes (garder 3 dernières). Désactiver `release-snapshot.yml`.                      | Not Started |
-| **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`.                                       | Not Started |
-| **Finitions site de doc**   | Branding, CI hardening (Trivy pinning, archives résilientes), navigation sidebar, SEO baseline. Plan : `docs/memory-bank/plans/finitions-doc-site-plan.md` | Not Started |
-| **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport sur GitLab Pages / K8s.                                           | Not Started |
+| Item                        | Description                                                                                                                           | Status      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les versions anciennes (garder 3 dernières). Désactiver `release-snapshot.yml`. | Not Started |
+| **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`.                  | Not Started |
+| **Finitions site de doc**   | Branding, CI hardening (Trivy pinning, archives résilientes), navigation sidebar, SEO baseline.                                       | Not Started |
+| **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport sur GitLab Pages / K8s.                      | Not Started |
 
 ---
 
@@ -89,11 +89,11 @@ _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 
 _Objectif : enablement Harbor + playbooks._
 
-| Item                              | Description                                                                                                                                                                      | Status      |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **Intégration Harbor native**     | `RegistryProvider` abstrait, Harbor-first via OCI Distribution v2. Coexistence skopeo (opt-in `--native-registry`). Plan : `docs/memory-bank/plans/registry-integration-plan.md` | Not Started |
-| **Playbook "contrôle catalogue"** | Playbook architectes : surveillance continue + preuve de qualité pour audit.                                                                                                     | Not Started |
-| **Playbook "progression projet"** | Playbook équipes projet : amélioration progressive par tiers (bronze → argent → or).                                                                                             | Not Started |
+| Item                              | Description                                                                                                         | Status      |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Intégration Harbor native**     | `RegistryProvider` abstrait, Harbor-first via OCI Distribution v2. Coexistence skopeo (opt-in `--native-registry`). | Not Started |
+| **Playbook "contrôle catalogue"** | Playbook architectes : surveillance continue + preuve de qualité pour audit.                                        | Not Started |
+| **Playbook "progression projet"** | Playbook équipes projet : amélioration progressive par tiers (bronze → argent → or).                                | Not Started |
 
 ---
 
@@ -101,11 +101,11 @@ _Objectif : enablement Harbor + playbooks._
 
 _Objectif : traduction + design._
 
-| Item                                    | Description                                                                                     | Status      |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------- |
-| **Traduction française (pipeline LLM)** | CI auto-translate via OpenAI/GPT interne. Plan : `docs/memory-bank/plans/traduction-fr-plan.md` | Not Started |
-| **Design system**                       | Identité visuelle Regis générée avec Claude (couleurs, logo, typographie, custom CSS).          | Not Started |
-| **Playbook creation skill**             | Skill OMC guidant la création interactive d'un playbook bundle.                                 | Not Started |
+| Item                                    | Description                                                                            | Status      |
+| --------------------------------------- | -------------------------------------------------------------------------------------- | ----------- |
+| **Traduction française (pipeline LLM)** | CI auto-translate via OpenAI/GPT interne.                                              | Not Started |
+| **Design system**                       | Identité visuelle Regis générée avec Claude (couleurs, logo, typographie, custom CSS). | Not Started |
+| **Playbook creation skill**             | Skill OMC guidant la création interactive d'un playbook bundle.                        | Not Started |
 
 ---
 

--- a/docs/memory-bank/roadmap.md
+++ b/docs/memory-bank/roadmap.md
@@ -2,11 +2,11 @@
 
 > Supplemental file: this is a planning artifact that complements the core Memory Bank files.
 
-> Last updated: 2026-04-21 · Current version: v0.28.6
+> Last updated: 2026-05-23 · Current version: v0.28.6
 
 ## Status Overview
 
-v0.28.6 shipped · Chemin v1.0.0-alpha défini · Cible : pilote équipes internes
+v0.28.6 shipped · Sprint 1 en cours (19 mai → 2 juin) · Cible : v1.0.0-alpha pilote équipes internes
 
 ## Memory Bank Alignment
 
@@ -61,20 +61,18 @@ La v1 est la première version déployée auprès d'équipes pilotes réelles :
 
 ---
 
-## Pré-sprint — 21 avr → 29 avr _(7j ouvrés)_
+## Pré-sprint — 21 avr → 29 avr _(archivé)_
 
-_Objectif : un livrable concret avant les congés._
-
-| Item                                | Description                                                                                                         | Status      |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **One-pager Regis**                 | Une page claire expliquant ce que fait Regis, pour qui, et comment — à destination des architectes et stakeholders. | Not Started |
-| **Playbook "validation import" v1** | Premier playbook métier : règles + README. Go/no-go binaire pour valider une image avant import dans le catalogue.  | Not Started |
+| Item                                | Description                                                                                                         | Status  |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- |
+| **One-pager Regis**                 | Une page claire expliquant ce que fait Regis, pour qui, et comment — à destination des architectes et stakeholders. | Skipped |
+| **Playbook "validation import" v1** | Premier playbook métier : règles + README. Go/no-go binaire pour valider une image avant import dans le catalogue.  | Skipped |
 
 > Congés : 30 avr → 17 mai
 
 ---
 
-## Sprint 1 — 19 mai → 2 juin
+## Sprint 1 — 19 mai → 2 juin _(en cours)_
 
 _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 
@@ -82,7 +80,7 @@ _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | **Moratoire snapshots doc** | Arrêter la génération de snapshots versionnés. Purger les versions anciennes (garder 3 dernières). Désactiver `release-snapshot.yml`.                     | Not Started |
 | **Playbook bundle format**  | Playbooks sous forme de répertoire : `playbook.yaml` + `README.md` + `inputs.schema.json`. Nouveau `InputsAnalyzer`.                                      | Not Started |
-| **Finitions site de doc**   | Branding, CI hardening (Trivy pinning, archives résilientes), navigation sidebar, SEO baseline. Plan : `thoughts/shared/plans/PLAN-finitions-doc-site.md` | Not Started |
+| **Finitions site de doc**   | Branding, CI hardening (Trivy pinning, archives résilientes), navigation sidebar, SEO baseline. Plan : `docs/memory-bank/plans/finitions-doc-site-plan.md` | Not Started |
 | **Guide GitLab CI**         | Process d'intégration regis dans un pipeline GitLab, multi-archives, déploiement rapport sur GitLab Pages / K8s.                                          | Not Started |
 
 ---
@@ -91,11 +89,11 @@ _Objectif : fondations — nettoyer, stabiliser, poser la base playbook._
 
 _Objectif : enablement Harbor + playbooks._
 
-| Item                              | Description                                                                                                                                                                     | Status      |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| **Intégration Harbor native**     | `RegistryProvider` abstrait, Harbor-first via OCI Distribution v2. Coexistence skopeo (opt-in `--native-registry`). Plan : `thoughts/shared/plans/PLAN-registry-integration.md` | Not Started |
-| **Playbook "contrôle catalogue"** | Playbook architectes : surveillance continue + preuve de qualité pour audit.                                                                                                    | Not Started |
-| **Playbook "progression projet"** | Playbook équipes projet : amélioration progressive par tiers (bronze → argent → or).                                                                                            | Not Started |
+| Item                              | Description                                                                                                                                                                      | Status      |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| **Intégration Harbor native**     | `RegistryProvider` abstrait, Harbor-first via OCI Distribution v2. Coexistence skopeo (opt-in `--native-registry`). Plan : `docs/memory-bank/plans/registry-integration-plan.md` | Not Started |
+| **Playbook "contrôle catalogue"** | Playbook architectes : surveillance continue + preuve de qualité pour audit.                                                                                                     | Not Started |
+| **Playbook "progression projet"** | Playbook équipes projet : amélioration progressive par tiers (bronze → argent → or).                                                                                             | Not Started |
 
 ---
 
@@ -103,11 +101,11 @@ _Objectif : enablement Harbor + playbooks._
 
 _Objectif : traduction + design._
 
-| Item                                    | Description                                                                                    | Status      |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------- |
-| **Traduction française (pipeline LLM)** | CI auto-translate via OpenAI/GPT interne. Plan : `thoughts/shared/plans/PLAN-traduction-fr.md` | Not Started |
-| **Design system**                       | Identité visuelle Regis générée avec Claude (couleurs, logo, typographie, custom CSS).         | Not Started |
-| **Playbook creation skill**             | Skill OMC guidant la création interactive d'un playbook bundle.                                | Not Started |
+| Item                                    | Description                                                                                     | Status      |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------- |
+| **Traduction française (pipeline LLM)** | CI auto-translate via OpenAI/GPT interne. Plan : `docs/memory-bank/plans/traduction-fr-plan.md` | Not Started |
+| **Design system**                       | Identité visuelle Regis générée avec Claude (couleurs, logo, typographie, custom CSS).          | Not Started |
+| **Playbook creation skill**             | Skill OMC guidant la création interactive d'un playbook bundle.                                 | Not Started |
 
 ---
 

--- a/docs/memory-bank/techContext.md
+++ b/docs/memory-bank/techContext.md
@@ -45,12 +45,12 @@
 
 These must be in `PATH` for the relevant analyzers to work:
 
-| Binary     | Analyzer              |
-| ---------- | --------------------- |
-| `trivy`    | `analyzer/trivy`      |
-| `skopeo`   | `analyzer/skopeo`     |
-| `hadolint` | `analyzer/hadolint`   |
-| `dockle`   | (image best-practice) |
+| Binary     | Analyzer slug | Module                        |
+| ---------- | ------------- | ----------------------------- |
+| `trivy`    | `trivy`       | `regis/analyzers/trivy.py`    |
+| `skopeo`   | `skopeo`      | `regis/analyzers/skopeo.py`   |
+| `hadolint` | `hadolint`    | `regis/analyzers/hadolint.py` |
+| `dockle`   | `dockle`      | `regis/analyzers/dockle.py`   |
 
 ## Development Environment
 
@@ -115,4 +115,4 @@ project-root/
 - Release Please — automated changelog and releases
 - `cd-docker.yml` — CycloneDX/SPDX SBOM generation + provenance attestation
 - Docusaurus docs + dashboard deployed to GitHub Pages
-- All workflows use GitHub App token (`REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`) — never bare `GITHUB_TOKEN` for checkouts that must trigger downstream CI
+- Workflows that push or trigger downstream CI use the GitHub App token (`REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`); read-only jobs may use the default `GITHUB_TOKEN`

--- a/docs/memory-bank/techContext.md
+++ b/docs/memory-bank/techContext.md
@@ -2,45 +2,55 @@
 
 ## Tech Stack
 
-### Core
+### Core (Python)
 
-- Python 3.10+ in `pyproject.toml`
-- `click`
-- `requests`
-- `jsonschema`
-- `semver`
-- `json-logic-qubit`
-- `pyyaml`
-- `jinja2`
-- `cookiecutter`
-- `python-gitlab`
-- `fastapi`
-- `uvicorn`
+- Python 3.10+
+- `click` — CLI framework
+- `requests` — HTTP client
+- `jsonschema` — JSON Schema validation
+- `semver` — semantic version parsing
+- `json-logic-qubit` — JSON Logic rule evaluation
+- `pyyaml` — YAML parsing
+- `jinja2` — templating (HTML reports)
+- `cookiecutter` — project scaffolding
+- `python-gitlab` — GitLab API client
+- `fastapi` + `uvicorn` — local dev server
 
-### Styling
+### Dashboard / Docs (Node)
 
-- Docusaurus-based docs/dashboard app
-- Tailwind CSS in the dashboard app
+- Docusaurus — documentation site + dashboard app (`apps/dashboard`)
+- Tailwind CSS — styling in the dashboard
+- pnpm workspaces — monorepo Node toolchain
 
 ### State & Data
 
-- JSON schema validation
+- JSON Schema validation
 - JSON Logic rule evaluation
 - Schema-driven analyzer and report payloads
 
 ### Testing
 
-- `pytest`
-- `pytest-cov`
-- `responses`
-- `httpx`
+- `pytest` + `pytest-cov`
+- `responses` — HTTP mocking
+- `httpx` — async HTTP client in tests
 
 ### Dev Tools
 
-- `ruff`
-- `trunk`
-- `pipenv`
-- `setuptools-scm`
+- `ruff` — linting and formatting
+- `trunk` — linter/formatter orchestrator (local + CI)
+- `pipenv` — Python dependency management
+- `setuptools-scm` — version from git tags
+
+## External Binaries Required
+
+These must be in `PATH` for the relevant analyzers to work:
+
+| Binary     | Analyzer              |
+| ---------- | --------------------- |
+| `trivy`    | `analyzer/trivy`      |
+| `skopeo`   | `analyzer/skopeo`     |
+| `hadolint` | `analyzer/hadolint`   |
+| `dockle`   | (image best-practice) |
 
 ## Development Environment
 
@@ -48,48 +58,61 @@
 
 - Python 3.10+
 - `pipenv`
-- Node toolchain for docs/dashboard work
+- Node.js + pnpm (for docs/dashboard work)
 
 ### Setup Commands
 
 ```bash
-# Install
+# Python deps
 pipenv install --dev
 
-# Dev server
+# CLI locally
 pipenv run regis --help
-pnpm --filter @regis/dashboard dev
 
-# Build
-pnpm run build
-
-# Test
+# Tests
 pipenv run pytest
 pipenv run pytest --no-cov
+
+# Lint / format
+pipenv run ruff check .
+pipenv run ruff format .
+trunk check
+trunk check --fix
+
+# Dashboard dev server
+pnpm --filter @regis/dashboard dev
+
+# Build all Node packages
+pnpm run build
 ```
-
-### Environment Variables
-
-- Not documented in the inspected files
 
 ## Project Structure
 
 ```text
 project-root/
-├── regis/
+├── regis/            # Python package (CLI, analyzers, playbook engine, report)
+│   ├── analyzers/
+│   ├── commands/
+│   ├── playbook/
+│   ├── rules/
+│   ├── registry/
+│   ├── report/
+│   ├── schemas/
+│   └── templates/
 ├── apps/
+│   └── dashboard/    # React/Docusaurus report viewer
 ├── docs/
-├── scripts/
-└── tests/
+│   ├── website/      # Docusaurus documentation site
+│   └── memory-bank/  # Agent context (this directory)
+├── scripts/          # Utility scripts
+├── tests/            # pytest test suite
+└── cookiecutters/    # Project scaffolding templates (bundled in package)
 ```
-
-## Import Aliases
-
-- No import alias mapping was found in the inspected files
 
 ## Build & Deploy
 
 - GitHub Actions workflows in `.github/workflows/`
-- Release Please for releases
-- SBOM generation and provenance attestation in CD
-- Docusaurus docs deployment
+- Release Please — automated changelog and releases
+- `cd-docker.yml` — CycloneDX/SPDX SBOM generation + provenance attestation
+- Docusaurus docs + dashboard deployed to GitHub Pages
+- All workflows use GitHub App token (`REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`) — never bare `GITHUB_TOKEN` for checkouts that must trigger downstream CI


### PR DESCRIPTION
## Summary

- **activeContext.md**: suppression du double `## Current Objective`, des items périmés (PR dashboard-tremor déjà merged), trimming de Recent Changes aux 5 dernières entrées significatives, ajout d'une section Decisions in Progress
- **progress.md**: fusion des deux sections `## Completed`, remplacement de l'`## In Progress` vide par les items Sprint 1 concrets
- **techContext.md**: suppression des placeholders "Not documented / No import alias mapping", ajout du tableau des binaires externes requis (trivy/skopeo/hadolint/dockle), arborescence projet enrichie
- **projectbrief.md**: remplacement du vague "Not enough evidence" dans Out of Scope par des exclusions réelles alignées sur le périmètre v1
- **roadmap.md**: pré-sprint archivé, Sprint 1 marqué "en cours", chemins des plans corrigés vers `docs/memory-bank/plans/`

## Test plan

- [ ] Lire chaque fichier et vérifier la cohérence des informations
- [ ] Vérifier qu'il n'y a plus de sections dupliquées dans activeContext.md
- [ ] Vérifier que les chemins des plans dans roadmap.md correspondent à la convention CLAUDE.md

https://claude.ai/code/session_01Dj55Zxv5Heo8r2CmdGjMh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj55Zxv5Heo8r2CmdGjMh5)_