### PR TITLE
feat(cli): add `--format yaml` to `regis rules show`

### DIFF
--- a/regis/commands/rules.py
+++ b/regis/commands/rules.py
@@ -255,7 +255,15 @@ def list_rules(
     "rules_path",
     help="Path to an optional rules.yaml file to merge overrides.",
 )
-def show_rule(slug: str, rules_path: str | None) -> None:
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "yaml"], case_sensitive=False),
+    default="json",
+    help="Output format (default: json).",
+)
+def show_rule(slug: str, rules_path: str | None, output_format: str) -> None:
     """Display the full definition of a specific rule."""
     import yaml
 
@@ -277,7 +285,13 @@ def show_rule(slug: str, rules_path: str | None) -> None:
     if not matching_rule:
         raise click.ClickException(f"Rule '{slug}' not found.")
 
-    click.echo(json.dumps(matching_rule, indent=2))
+    if output_format.lower() == "yaml":
+        click.echo(
+            yaml.dump(matching_rule, default_flow_style=False, allow_unicode=True),
+            nl=False,
+        )
+    else:
+        click.echo(json.dumps(matching_rule, indent=2))
 
 
 @rules_group.command(name="evaluate")

--- a/regis/commands/rules.py
+++ b/regis/commands/rules.py
@@ -287,7 +287,7 @@ def show_rule(slug: str, rules_path: str | None, output_format: str) -> None:
 
     if output_format.lower() == "yaml":
         click.echo(
-            yaml.dump(matching_rule, default_flow_style=False, allow_unicode=True),
+            yaml.safe_dump(matching_rule, default_flow_style=False, allow_unicode=True),
             nl=False,
         )
     else:

--- a/tests/test_rules_command.py
+++ b/tests/test_rules_command.py
@@ -50,14 +50,6 @@ class TestRulesShow:
         # Should still work — missing file is silently ignored
         assert result.exit_code == 0
 
-    def test_show_default_format_is_json(self):
-        runner = CliRunner()
-        result = runner.invoke(main, ["rules", "show", "registry-domain-whitelist"])
-        assert result.exit_code == 0
-        # JSON output is parseable
-        data = json.loads(result.output)
-        assert data["slug"] == "registry-domain-whitelist"
-
     def test_show_yaml_format(self):
         import yaml
 

--- a/tests/test_rules_command.py
+++ b/tests/test_rules_command.py
@@ -50,6 +50,49 @@ class TestRulesShow:
         # Should still work — missing file is silently ignored
         assert result.exit_code == 0
 
+    def test_show_default_format_is_json(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "show", "registry-domain-whitelist"])
+        assert result.exit_code == 0
+        # JSON output is parseable
+        data = json.loads(result.output)
+        assert data["slug"] == "registry-domain-whitelist"
+
+    def test_show_yaml_format(self):
+        import yaml
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "show", "registry-domain-whitelist", "--format", "yaml"],
+        )
+        assert result.exit_code == 0
+        data = yaml.safe_load(result.output)
+        assert data["slug"] == "registry-domain-whitelist"
+        assert data["level"] == "critical"
+        # YAML formatting hints: no JSON braces around the top-level
+        assert not result.output.lstrip().startswith("{")
+
+    def test_show_yaml_format_short_flag(self):
+        import yaml
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "show", "registry-domain-whitelist", "-f", "yaml"],
+        )
+        assert result.exit_code == 0
+        data = yaml.safe_load(result.output)
+        assert data["slug"] == "registry-domain-whitelist"
+
+    def test_show_invalid_format_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["rules", "show", "registry-domain-whitelist", "--format", "toml"],
+        )
+        assert result.exit_code != 0
+
 
 class TestRulesList:
     def test_markdown_with_params_shows_options(self):


### PR DESCRIPTION
## Summary

- Add `-f` / `--format` option (`json` default, `yaml`) to `regis rules show`.
- YAML is rendered via `yaml.dump(..., default_flow_style=False, allow_unicode=True)`.
- Default stays `json` — no breaking change.

Closes #587

## Test plan
- [x] `test_show_default_format_is_json`
- [x] `test_show_yaml_format` / `test_show_yaml_format_short_flag`
- [x] `test_show_invalid_format_rejected`

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_