### PR TITLE
feat(cli): log per-analyzer timing in debug mode

### DIFF
--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -41,16 +42,21 @@ def _run_analyzer(
     platform: str | None,
 ) -> tuple[str, dict[str, Any]]:
     """Run a single analyzer with its own registry client."""
-    client = RegistryClient(
-        registry=registry,
-        repository=repository,
-        username=username,
-        password=password,
-    )
     analyzer = analyzer_cls()
-    report = analyzer.analyze(client, repository, tag, platform=platform)
-    analyzer.validate(report)
-    return analyzer.name, report
+    name = analyzer.name
+    start = time.monotonic()
+    try:
+        client = RegistryClient(
+            registry=registry,
+            repository=repository,
+            username=username,
+            password=password,
+        )
+        report = analyzer.analyze(client, repository, tag, platform=platform)
+        analyzer.validate(report)
+        return name, report
+    finally:
+        logger.debug("analyzer %s finished in %.2fs", name, time.monotonic() - start)
 
 
 def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,10 @@
 """Tests for the CLI."""
 
 import json
+import logging
 import re
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -457,3 +458,62 @@ class TestAnalyzeCacheAndFail:
 
         assert result.exit_code == 1
         assert "rule breaches" in result.output
+
+
+class TestAnalyzerTiming:
+    """Per-analyzer timing in DEBUG logs (issue #588)."""
+
+    @patch("regis.commands.analyze.RegistryClient")
+    def test_run_analyzer_logs_debug_timing(self, mock_client, caplog):
+        from regis.analyzers.base import BaseAnalyzer
+        from regis.commands.analyze import _run_analyzer
+
+        class DummyAnalyzer(BaseAnalyzer):
+            name = "dummy-timed"
+
+            def analyze(self, client, repo, tag, platform=None):
+                return {"ok": True}
+
+            def validate(self, report):
+                pass
+
+        with caplog.at_level(logging.DEBUG, logger="regis.commands.analyze"):
+            name, _ = _run_analyzer(
+                DummyAnalyzer, "docker.io", "library/x", "latest", None, None, None
+            )
+
+        assert name == "dummy-timed"
+        timing_records = [
+            r for r in caplog.records if "dummy-timed" in r.getMessage() and "finished in" in r.getMessage()
+        ]
+        assert len(timing_records) == 1
+        assert timing_records[0].levelno == logging.DEBUG
+        assert re.search(r"finished in \d+\.\d{2}s", timing_records[0].getMessage())
+
+    @patch("regis.commands.analyze.RegistryClient")
+    def test_run_analyzer_logs_timing_on_failure(self, mock_client, caplog):
+        """Timing must be logged even when the analyzer raises."""
+        from regis.analyzers.base import AnalyzerError, BaseAnalyzer
+        from regis.commands.analyze import _run_analyzer
+
+        class BoomAnalyzer(BaseAnalyzer):
+            name = "boom"
+
+            def analyze(self, client, repo, tag, platform=None):
+                raise AnalyzerError("kaboom")
+
+            def validate(self, report):
+                pass
+
+        with caplog.at_level(logging.DEBUG, logger="regis.commands.analyze"):
+            try:
+                _run_analyzer(
+                    BoomAnalyzer, "docker.io", "library/x", "latest", None, None, None
+                )
+            except AnalyzerError:
+                pass
+
+        timing_records = [
+            r for r in caplog.records if "boom" in r.getMessage() and "finished in" in r.getMessage()
+        ]
+        assert len(timing_records) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -484,7 +484,9 @@ class TestAnalyzerTiming:
 
         assert name == "dummy-timed"
         timing_records = [
-            r for r in caplog.records if "dummy-timed" in r.getMessage() and "finished in" in r.getMessage()
+            r
+            for r in caplog.records
+            if "dummy-timed" in r.getMessage() and "finished in" in r.getMessage()
         ]
         assert len(timing_records) == 1
         assert timing_records[0].levelno == logging.DEBUG
@@ -514,6 +516,8 @@ class TestAnalyzerTiming:
                 pass
 
         timing_records = [
-            r for r in caplog.records if "boom" in r.getMessage() and "finished in" in r.getMessage()
+            r
+            for r in caplog.records
+            if "boom" in r.getMessage() and "finished in" in r.getMessage()
         ]
         assert len(timing_records) == 1


### PR DESCRIPTION
## Summary

- `_run_analyzer` now records `time.monotonic()` and logs `analyzer <name> finished in <elapsed>s` at DEBUG level on completion (success or failure).
- Visible when `regis analyze` runs with `--verbose`. No output change in default mode.

Closes #588

## Test plan
- [x] `TestAnalyzerTiming::test_run_analyzer_logs_debug_timing`
- [x] `TestAnalyzerTiming::test_run_analyzer_logs_timing_on_failure`

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_