### PR TITLE
feat(cli): add `--filter-level` and `--filter-provider` to `regis rules list`

### DIFF
--- a/regis/commands/rules.py
+++ b/regis/commands/rules.py
@@ -136,12 +136,27 @@ def rules_group():
     default=False,
     help="Generate an index.md file in the output directory (default: off).",
 )
+@click.option(
+    "--filter-level",
+    "filter_level",
+    type=click.Choice(["info", "warning", "critical"], case_sensitive=False),
+    default=None,
+    help="Keep only rules at this level.",
+)
+@click.option(
+    "--filter-provider",
+    "filter_provider",
+    default=None,
+    help="Keep only rules whose provider matches (e.g. trivy, hadolint).",
+)
 def list_rules(
     rules_path: str | None,
     output_format: str,
     output_file: str | None,
     output_dir: str | None = None,
     generate_index: bool = False,
+    filter_level: str | None = None,
+    filter_provider: str | None = None,
 ) -> None:
     """List all available default rules and any overrides."""
     import yaml
@@ -159,6 +174,17 @@ def list_rules(
             custom = data.get("rules", [])
 
     final_rules = merge_rules(defaults, custom)
+
+    if filter_level:
+        wanted_level = filter_level.lower()
+        final_rules = [
+            r for r in final_rules if r.get("level", "info").lower() == wanted_level
+        ]
+    if filter_provider:
+        final_rules = [
+            r for r in final_rules if r.get("provider") == filter_provider
+        ]
+
     final_rules.sort(key=lambda r: r.get("slug", ""))
 
     if not final_rules:

--- a/tests/test_cli_rules_list.py
+++ b/tests/test_cli_rules_list.py
@@ -93,3 +93,65 @@ class TestCliRulesList:
             )
             assert "| core | Critical | security |" in rule_content
             assert "## Condition" in rule_content
+
+
+class TestCliRulesListFilters:
+    """Filter options on 'rules list' (issue #586)."""
+
+    def test_filter_level_critical_only(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "list", "--filter-level", "critical"])
+        assert result.exit_code == 0
+        # registry-domain-whitelist is critical → kept
+        assert "registry-domain-whitelist" in result.output
+        # No info/warning lines
+        for line in result.output.splitlines():
+            if line.strip().startswith("[x]") or line.strip().startswith("[ ]"):
+                assert "info " not in line
+                assert "warning " not in line
+
+    def test_filter_level_no_match(self):
+        """A level with no rule yields the empty-set message."""
+        runner = CliRunner()
+        # 'warning' may have zero rules in defaults — accept either empty or filtered output
+        result = runner.invoke(
+            main, ["rules", "list", "--filter-level", "info", "--filter-provider", "nonexistent-provider"]
+        )
+        assert result.exit_code == 0
+        assert "No rules found." in result.output
+
+    def test_filter_provider_only(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "list", "--filter-provider", "core"])
+        assert result.exit_code == 0
+        assert "registry-domain-whitelist" in result.output
+
+    def test_filter_provider_unknown_yields_empty(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["rules", "list", "--filter-provider", "no-such-provider"]
+        )
+        assert result.exit_code == 0
+        assert "No rules found." in result.output
+
+    def test_filter_level_invalid_choice(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["rules", "list", "--filter-level", "bogus"])
+        assert result.exit_code != 0
+
+    def test_filters_combined(self):
+        """Both filters apply (AND)."""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "rules",
+                "list",
+                "--filter-level",
+                "critical",
+                "--filter-provider",
+                "core",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "registry-domain-whitelist" in result.output


### PR DESCRIPTION
## Summary

- `--filter-level {info|warning|critical}` and `--filter-provider <name>` on `regis rules list`.
- Both optional, combine with AND. Filtering happens after `merge_rules()`, before sort/render — so all output formats (text, markdown, output-dir) reflect the filtered set.
- Empty result → existing `No rules found.` message.

Closes #586

## Test plan
- [x] Single-filter level / provider
- [x] Combined filters
- [x] Invalid `--filter-level` rejected by Click
- [x] Empty result yields `No rules found.`

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_