### PR TITLE
feat(cli): add `--skip` flag to `regis analyze` to exclude analyzers

### DIFF
--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -96,7 +96,10 @@ def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
     "--skip",
     "skip_analyzers",
     multiple=True,
-    help="Exclude the specified analyzer(s) from the run. Can be repeated.",
+    help=(
+        "Exclude the specified analyzer(s) from the run. Can be repeated. "
+        "Run `regis list` to see available analyzer names."
+    ),
 )
 @click.option(
     "-p",
@@ -439,7 +442,7 @@ def analyze(
         for skip_name in skip_analyzers:
             if skip_name not in all_analyzers:
                 click.echo(
-                    f"  ! warning: --skip references unknown analyzer '{skip_name}'",
+                    f"  Warning: --skip references unknown analyzer '{skip_name}'",
                     err=True,
                 )
                 continue

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -93,6 +93,12 @@ def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
     help="Run only the specified analyzer(s). Can be repeated. Default: all.",
 )
 @click.option(
+    "--skip",
+    "skip_analyzers",
+    multiple=True,
+    help="Exclude the specified analyzer(s) from the run. Can be repeated.",
+)
+@click.option(
     "-p",
     "--playbook",
     "playbook_paths",
@@ -231,6 +237,7 @@ def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
 def analyze(
     url: str,
     analyzer_names: tuple[str, ...],
+    skip_analyzers: tuple[str, ...],
     playbook_paths: tuple[str, ...],
     output_template: str | None,
     output_dir_template: str | None,
@@ -427,7 +434,21 @@ def analyze(
                     )
                 selected[name] = all_analyzers[name]
         else:
-            selected = all_analyzers
+            selected = dict(all_analyzers)
+
+        for skip_name in skip_analyzers:
+            if skip_name not in all_analyzers:
+                click.echo(
+                    f"  ! warning: --skip references unknown analyzer '{skip_name}'",
+                    err=True,
+                )
+                continue
+            selected.pop(skip_name, None)
+
+        if not selected:
+            raise click.ClickException(
+                "All analyzers were skipped — nothing to run."
+            )
 
         effective_workers = min(max_workers, len(selected))
         click.echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -460,6 +460,8 @@ class TestAnalyzeCacheAndFail:
         assert "rule breaches" in result.output
 
 
+
+
 class TestAnalyzerTiming:
     """Per-analyzer timing in DEBUG logs (issue #588)."""
 
@@ -521,3 +523,85 @@ class TestAnalyzerTiming:
             if "boom" in r.getMessage() and "finished in" in r.getMessage()
         ]
         assert len(timing_records) == 1
+
+
+class TestAnalyzeSkip:
+    """--skip option on regis analyze (issue #582)."""
+
+    def _make_dummy_analyzer(self, name: str):
+        from regis.analyzers.base import BaseAnalyzer
+
+        class DummyAnalyzer(BaseAnalyzer):
+            analyzer_name = name
+
+            def analyze(self, client, repo, tag, platform=None):
+                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+
+            def validate(self, report):
+                pass
+
+        DummyAnalyzer.name = name
+        return DummyAnalyzer
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_skip_excludes_named_analyzer(self, mock_discover, mock_client):
+        mock_discover.return_value = {
+            "a": self._make_dummy_analyzer("a"),
+            "b": self._make_dummy_analyzer("b"),
+            "c": self._make_dummy_analyzer("c"),
+        }
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest", "--skip", "b"])
+        assert result.exit_code == 0
+        completed = [
+            line for line in result.output.splitlines() if line.startswith("  ✓ ")
+        ]
+        completed_names = [line.split()[-1] for line in completed]
+        assert "b" not in completed_names
+        assert "a" in completed_names and "c" in completed_names
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_skip_repeatable(self, mock_discover, mock_client):
+        mock_discover.return_value = {
+            "a": self._make_dummy_analyzer("a"),
+            "b": self._make_dummy_analyzer("b"),
+            "c": self._make_dummy_analyzer("c"),
+        }
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                main, ["analyze", "nginx:latest", "--skip", "a", "--skip", "c"]
+            )
+        assert result.exit_code == 0
+        assert "Running 1 analyzer(s)" in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_skip_unknown_warns_but_succeeds(self, mock_discover, mock_client):
+        mock_discover.return_value = {"a": self._make_dummy_analyzer("a")}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest", "--skip", "nope"])
+        assert result.exit_code == 0
+        assert "unknown analyzer 'nope'" in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_skip_all_fails(self, mock_discover, mock_client):
+        mock_discover.return_value = {"a": self._make_dummy_analyzer("a")}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest", "--skip", "a"])
+        assert result.exit_code != 0
+        assert "All analyzers were skipped" in result.output


### PR DESCRIPTION
## Summary

- `--skip <name>` (repeatable) excludes one or more analyzers from a run.
- Unknown names → warning on stderr, run continues with the remaining set.
- All analyzers skipped → fails with a clear message instead of producing an empty report.
- Works with or without `--analyzer`: `--skip` is applied after the explicit selection.

Closes #582

## Test plan
- [x] `test_skip_excludes_named_analyzer`
- [x] `test_skip_repeatable`
- [x] `test_skip_unknown_warns_but_succeeds`
- [x] `test_skip_all_fails`

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_