### PR TITLE
feat(cli): add `regis playbook validate` command

### DIFF
--- a/regis/cli.py
+++ b/regis/cli.py
@@ -14,6 +14,7 @@ from regis.commands.bootstrap import bootstrap
 from regis.commands.check import check, version_cmd
 from regis.commands.dashboard import dashboard_group
 from regis.commands.doctor import doctor
+from regis.commands.playbook import playbook_group
 from regis.commands.rules import rules_group
 from regis.github_cli import github_cmd
 from regis.gitlab_cli import gitlab_cmd
@@ -73,6 +74,7 @@ main.add_command(version_cmd, name="version")
 main.add_command(rules_group, name="rules")
 main.add_command(dashboard_group, name="dashboard")
 main.add_command(doctor)
+main.add_command(playbook_group, name="playbook")
 
 
 if __name__ == "__main__":

--- a/regis/commands/playbook.py
+++ b/regis/commands/playbook.py
@@ -1,0 +1,67 @@
+"""playbook command group."""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from pathlib import Path
+
+import click
+
+
+def _format_validation_error(error) -> str:
+    """Render a jsonschema ValidationError as a single human-readable line."""
+    if error.absolute_path:
+        location = ".".join(str(p) for p in error.absolute_path)
+    else:
+        location = "<root>"
+    return f"{location}: {error.message}"
+
+
+@click.group(name="playbook")
+def playbook_group() -> None:
+    """Inspect and validate playbooks."""
+
+
+@playbook_group.command(name="validate")
+@click.argument("path", type=click.Path(exists=True, dir_okay=True, path_type=Path))
+def validate_playbook(path: Path) -> None:
+    """Validate a playbook YAML/JSON file (or bundle directory) against the schema."""
+    import jsonschema
+
+    from regis.playbook.loader import load_playbook
+
+    try:
+        playbook = load_playbook(path)
+    except Exception as exc:
+        raise click.ClickException(f"Failed to load playbook: {exc}") from exc
+
+    schema_pkg = files("regis.schemas.playbook")
+    schema = json.loads(
+        schema_pkg.joinpath("definition.schema.json").read_text(encoding="utf-8")
+    )
+    jsonlogic_schema = json.loads(
+        schema_pkg.joinpath("jsonlogic.schema.json").read_text(encoding="utf-8")
+    )
+
+    from referencing import Registry, Resource
+
+    registry = Registry().with_resources(
+        [
+            (schema.get("$id", ""), Resource.from_contents(schema)),
+            (jsonlogic_schema.get("$id", ""), Resource.from_contents(jsonlogic_schema)),
+            # Allow $ref to bare filename (definition.schema.json references jsonlogic.schema.json relatively)
+            ("jsonlogic.schema.json", Resource.from_contents(jsonlogic_schema)),
+        ]
+    )
+
+    validator = jsonschema.Draft202012Validator(schema, registry=registry)
+    errors = sorted(validator.iter_errors(playbook), key=lambda e: list(e.absolute_path))
+
+    if errors:
+        click.echo(f"  ✗ {path} is invalid:", err=True)
+        for err in errors:
+            click.echo(f"    - {_format_validation_error(err)}", err=True)
+        raise click.exceptions.Exit(1)
+
+    click.echo(f"  ✓ {path} is valid.")

--- a/tests/commands/test_playbook_validate.py
+++ b/tests/commands/test_playbook_validate.py
@@ -1,0 +1,67 @@
+"""Tests for `regis playbook validate` (issue #589)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from regis.cli import main
+
+
+class TestPlaybookValidate:
+    def test_validate_built_in_default_bundle(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["playbook", "validate", "regis/playbooks/default"])
+        assert result.exit_code == 0
+        assert "is valid" in result.output
+
+    def test_validate_missing_required_name_field(self, tmp_path: Path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("description: missing-name\n", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, ["playbook", "validate", str(bad)])
+        assert result.exit_code == 1
+        assert "is invalid" in result.output
+        assert "'name' is a required property" in result.output
+
+    def test_validate_additional_property_rejected(self, tmp_path: Path):
+        bad = tmp_path / "extra.yaml"
+        bad.write_text(
+            textwrap.dedent(
+                """
+                name: with-extras
+                foo: bar
+                """
+            ).strip(),
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["playbook", "validate", str(bad)])
+        assert result.exit_code == 1
+        assert "Additional properties" in result.output
+
+    def test_validate_nonexistent_file(self, tmp_path: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["playbook", "validate", str(tmp_path / "ghost.yaml")]
+        )
+        # Click rejects the missing path before our callback runs
+        assert result.exit_code != 0
+
+    def test_validate_unparseable_yaml(self, tmp_path: Path):
+        bad = tmp_path / "broken.yaml"
+        bad.write_text(":\ninvalid:\n  - yaml: [unclosed", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, ["playbook", "validate", str(bad)])
+        assert result.exit_code != 0
+        assert "Failed to load playbook" in result.output
+
+    def test_validate_minimal_valid_playbook(self, tmp_path: Path):
+        ok = tmp_path / "min.yaml"
+        ok.write_text("name: minimal\n", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(main, ["playbook", "validate", str(ok)])
+        assert result.exit_code == 0
+        assert "is valid" in result.output


### PR DESCRIPTION
## Summary

- New top-level `regis playbook` group with a single `validate <path>` subcommand.
- Accepts a YAML/JSON file or a bundle directory; loads via `regis.playbook.loader.load_playbook` for parity with `regis analyze`.
- Validates against `regis/schemas/playbook/definition.schema.json`. The referenced `jsonlogic.schema.json` is preloaded into a `referencing.Registry`, so the command works fully offline.
- Each schema violation is rendered as `<json-path>: <message>` on stderr; exit code 0 on success, 1 on failure.

Closes #589

## Test plan
- [x] Built-in `regis/playbooks/default` validates clean
- [x] Missing required `name` → exit 1
- [x] Additional unexpected property → exit 1
- [x] Non-existent file → Click rejects upfront
- [x] Unparseable YAML → clean `Failed to load playbook` error
- [x] Minimal `name:` only document validates

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_