### PR TITLE
feat(cli): add `--quiet` / `-q` flag to suppress non-essential output

### DIFF
--- a/regis/cli.py
+++ b/regis/cli.py
@@ -52,14 +52,30 @@ _render_mr_templates = render_mr_templates
     default=False,
     help="Enable verbose (DEBUG) logging.",
 )
-def main(verbose: bool) -> None:
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress non-essential output. Errors and explicit results still print.",
+)
+@click.pass_context
+def main(ctx: click.Context, verbose: bool, quiet: bool) -> None:
     """Regis — Registry Scores CLI."""
-    level = logging.DEBUG if verbose else logging.WARNING
+    if quiet:
+        level = logging.ERROR
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
     logging.basicConfig(
         level=level,
         format="%(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
+    ctx.ensure_object(dict)
+    ctx.obj["quiet"] = quiet
+    ctx.obj["verbose"] = verbose
 
 
 main.add_command(github_cmd, name="github")

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -59,6 +59,12 @@ def _run_analyzer(
         logger.debug("analyzer %s finished in %.2fs", name, time.monotonic() - start)
 
 
+def _info(msg: str, *, quiet: bool, err: bool = True) -> None:
+    """Print informational output to stderr unless quiet mode is active."""
+    if not quiet:
+        click.echo(msg, err=err)
+
+
 def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for item in meta:
@@ -247,7 +253,9 @@ def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
     default=False,
     help="Merge --meta values into existing metadata instead of replacing (only with --rerun).",
 )
+@click.pass_context
 def analyze(
+    ctx: click.Context,
     url: str,
     analyzer_names: tuple[str, ...],
     skip_analyzers: tuple[str, ...],
@@ -282,6 +290,7 @@ def analyze(
 
     Runs analyzers and evaluates one or more playbooks against the results.
     """
+    quiet = bool(ctx.obj and ctx.obj.get("quiet"))
     # --rerun / --report mutual dependency validation
     if rerun and not report_dir:
         raise click.UsageError("--rerun requires --report")
@@ -352,7 +361,7 @@ def analyze(
             json.dumps(rerun_report, indent=indent, ensure_ascii=False),
             encoding="utf-8",
         )
-        click.echo(f"  Report updated at {report_path}", err=True)
+        _info(f"  Report updated at {report_path}", quiet=quiet)
         return
 
     # Normal analysis flow requires a URL
@@ -364,9 +373,9 @@ def analyze(
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(
+    _info(
         f"Analyzing {ref.repository}:{ref.tag} on {ref.registry}",
-        err=True,
+        quiet=quiet,
     )
 
     from regis.registry.auth import resolve_credentials
@@ -400,7 +409,7 @@ def analyze(
         formats.append("md")
 
     if sections != "all" and not html_single:
-        click.echo("  Warning: --sections has no effect without --html.", err=True)
+        _info("  Warning: --sections has no effect without --html.", quiet=quiet)
 
     dir_tmpl = output_dir_template or "reports/{registry}/{repository}/{digest}"
     file_tmpl = output_template or "report.{format}"
@@ -423,7 +432,7 @@ def analyze(
             cache_path = cache_dir / cache_file
 
             if cache_path.exists():
-                click.echo(f"  Using cached report from {cache_path}", err=True)
+                _info(f"  Using cached report from {cache_path}", quiet=quiet)
                 final_report = json.loads(cache_path.read_text(encoding="utf-8"))
         except Exception as exc:
             logger.debug("Cache lookup failed: %s", exc)
@@ -464,9 +473,9 @@ def analyze(
             )
 
         effective_workers = min(max_workers, len(selected))
-        click.echo(
+        _info(
             f"  Running {len(selected)} analyzer(s) with {effective_workers} worker(s)...",
-            err=True,
+            quiet=quiet,
         )
         reports: dict[str, Any] = {}
         with ThreadPoolExecutor(max_workers=effective_workers) as executor:
@@ -488,7 +497,7 @@ def analyze(
                 try:
                     _, report = future.result()
                     reports[name] = report
-                    click.echo(f"  ✓ {name}", err=True)
+                    _info(f"  ✓ {name}", quiet=quiet)
                 except RegistryError as exc:
                     click.echo(f"  ✗ {name}: registry error — {exc}", err=True)
                     reports[name] = {
@@ -563,7 +572,7 @@ def analyze(
     validate_report(final_report)
 
     if final_report.get("snapshot_date"):
-        click.echo(f"  Snapshot date: {final_report['snapshot_date']}", err=True)
+        _info(f"  Snapshot date: {final_report['snapshot_date']}", quiet=quiet)
 
     if archive_dir:
         from regis.archive.store import add_to_archive

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -51,6 +51,18 @@ def format_output_path(template: str, report: dict[str, Any], fmt: str) -> Path:
     return Path(resolved)
 
 
+def _quiet() -> bool:
+    """Return True when --quiet was set on the current Click context."""
+    ctx = click.get_current_context(silent=True)
+    return bool(ctx and ctx.obj and ctx.obj.get("quiet"))
+
+
+def _echo_info(msg: str, **kwargs) -> None:
+    """click.echo wrapper that respects the active --quiet flag."""
+    if not _quiet():
+        click.echo(msg, **kwargs)
+
+
 def write_report(
     dir_tmpl: str,
     file_tmpl: str,
@@ -66,16 +78,17 @@ def write_report(
     try:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(rendered, encoding="utf-8")
-        click.echo(f"  Report ({fmt}) written to {out_path}", err=True)
+        _echo_info(f"  Report ({fmt}) written to {out_path}", err=True)
     except PermissionError as exc:
         fallback_path = Path.cwd() / f"report.{fmt}"
+        # Permission warning is non-fatal but actionable — keep it visible.
         click.echo(
             f"  Warning: Failed to write to {out_path} ({exc}). Trying fallback to {fallback_path}",
             err=True,
         )
         try:
             fallback_path.write_text(rendered, encoding="utf-8")
-            click.echo(f"  Report ({fmt}) written to {fallback_path}", err=True)
+            _echo_info(f"  Report ({fmt}) written to {fallback_path}", err=True)
         except PermissionError as inner_exc:
             raise click.ClickException(
                 f"Failed to write report: Permission denied for both {out_path} and fallback."
@@ -134,7 +147,7 @@ def evaluate_playbooks(
                 pb_path.startswith("http://") or pb_path.startswith("https://")
             )
             action = "Downloading" if is_remote else "Evaluating"
-            click.echo(f"  {action} playbook: {pb_path}...", err=True)
+            _echo_info(f"  {action} playbook: {pb_path}...", err=True)
             pb_def = load_playbook(pb_path)
             pb_result = evaluate(
                 pb_def, analysis_report, source_name=Path(pb_path).stem
@@ -162,7 +175,7 @@ def evaluate_playbooks(
                     len(total_rules) if isinstance(total_rules, list) else total_rules
                 )
                 rules_score = rs.get("score", pb_result["score"])
-                click.echo(
+                _echo_info(
                     f"    {summary_str} "
                     f"({passed_count}/{total_count} rules passed, "
                     f"{rules_score}%)\n",
@@ -170,13 +183,13 @@ def evaluate_playbooks(
                 )
 
                 if show_rules and pb_result.get("rules"):
-                    click.echo("    Rules Evaluation Summary:", err=True)
+                    _echo_info("    Rules Evaluation Summary:", err=True)
                     for r in pb_result["rules"]:
                         icon = "✅" if r["passed"] else "❌"
                         if r["status"] == "incomplete":
                             icon = "⚠️"
-                        click.echo(f"      {icon} [{r['slug']}] {r['message']}")
-                    click.echo("", err=True)
+                        _echo_info(f"      {icon} [{r['slug']}] {r['message']}")
+                    _echo_info("", err=True)
 
     return playbook_results
 
@@ -318,7 +331,7 @@ def render_and_save_reports(
             except RuntimeError as exc:
                 raise click.ClickException(str(exc)) from exc
 
-            click.echo(
+            _echo_info(
                 f"  Report site generated at {out_dir}",
                 err=True,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -686,3 +686,79 @@ class TestAnalyzeEnvVars:
             )
         assert result.exit_code == 0
         assert "1 worker(s)" in result.output
+
+
+class TestQuietFlag:
+    """Top-level --quiet / -q flag (issue #584)."""
+
+    def _make_dummy_analyzer(self, name: str):
+        from regis.analyzers.base import BaseAnalyzer
+
+        class DummyAnalyzer(BaseAnalyzer):
+            analyzer_name = name
+
+            def analyze(self, client, repo, tag, platform=None):
+                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+
+            def validate(self, report):
+                pass
+
+        DummyAnalyzer.name = name
+        return DummyAnalyzer
+
+    def test_help_advertises_quiet(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "--quiet" in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_quiet_suppresses_progress_lines(self, mock_discover, mock_client):
+        mock_discover.return_value = {"dummy": self._make_dummy_analyzer("dummy")}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["-q", "analyze", "nginx:latest"])
+        assert result.exit_code == 0
+        assert "Running" not in result.output
+        assert "✓ dummy" not in result.output
+        assert "Analyzing" not in result.output
+        assert "Report (json) written to" not in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_default_keeps_progress_lines(self, mock_discover, mock_client):
+        mock_discover.return_value = {"dummy": self._make_dummy_analyzer("dummy")}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest"])
+        assert result.exit_code == 0
+        assert "Analyzing" in result.output or "Running" in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_quiet_still_emits_analyzer_failure(self, mock_discover, mock_client):
+        from regis.analyzers.base import AnalyzerError, BaseAnalyzer
+
+        class FailingAnalyzer(BaseAnalyzer):
+            name = "failing"
+
+            def analyze(self, client, repo, tag, platform=None):
+                raise AnalyzerError("boom")
+
+            def validate(self, report):
+                pass
+
+        mock_discover.return_value = {"failing": FailingAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["-q", "analyze", "nginx:latest"])
+        assert "✗ failing" in result.output
+        assert "Running" not in result.output
+        assert "Analyzing" not in result.output


### PR DESCRIPTION
## Summary

- `-q` / `--quiet` is now a top-level option on the `regis` group (sibling of `-v`).
- When active, logging is clamped to `ERROR` and informational lines emitted by `regis analyze` and the playbook helpers are suppressed: `Analyzing X on Y`, per-analyzer `✓` ticks, `Running N analyzer(s)`, playbook `Evaluating ...` lines, the rules summary table, and `Report (json) written to ...` confirmations.
- Analyzer failure lines (`✗ name: ...`) and `Warning: Failed to write ...` keep printing — they're actionable.
- The flag is shared via `ctx.obj["quiet"]`, and `regis.utils.report` consults it through `click.get_current_context`, so threading the flag through every helper signature was unnecessary.

Closes #584

## Test plan
- [x] `-q analyze` suppresses the standard progress markers
- [x] Default mode keeps them
- [x] `--help` advertises `--quiet`
- [x] Analyzer failure `✗ name` lines still appear under `-q`

## Follow-up
Other subcommands (`archive`, `rules evaluate`, etc.) don't yet read `ctx.obj["quiet"]`. Easy to wire the same way when needed.

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_