### PR TITLE
feat(cli): show per-analyzer progress with timing during `regis analyze`

### DIFF
--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -480,24 +480,31 @@ def analyze(
         name_width = max((len(n) for n in selected), default=12)
         start_times: dict[str, float] = {}
         reports: dict[str, Any] = {}
+
+        def _timed_run(name: str, cls: type[BaseAnalyzer]) -> tuple[str, dict[str, Any]]:
+            # Capture start time *inside* the worker thread so queued analyzers
+            # don't inherit the wait-in-pool delay.
+            start_times[name] = time.monotonic()
+            return _run_analyzer(
+                cls,
+                ref.registry,
+                ref.repository,
+                ref.tag,
+                username,
+                password,
+                platform,
+            )
+
         with ThreadPoolExecutor(max_workers=effective_workers) as executor:
-            futures = {}
-            for name, cls in selected.items():
-                start_times[name] = time.monotonic()
-                fut = executor.submit(
-                    _run_analyzer,
-                    cls,
-                    ref.registry,
-                    ref.repository,
-                    ref.tag,
-                    username,
-                    password,
-                    platform,
-                )
-                futures[fut] = name
+            futures = {
+                executor.submit(_timed_run, name, cls): name
+                for name, cls in selected.items()
+            }
             for future in as_completed(futures):
                 name = futures[future]
-                elapsed = time.monotonic() - start_times[name]
+                # start_times may be missing if the worker raised before the
+                # first statement — fall back to "0.0s" rather than crashing.
+                elapsed = time.monotonic() - start_times.get(name, time.monotonic())
                 timing = f"({elapsed:.1f}s)"
                 try:
                     _, report = future.result()

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -477,10 +477,14 @@ def analyze(
             f"  Running {len(selected)} analyzer(s) with {effective_workers} worker(s)...",
             quiet=quiet,
         )
+        name_width = max((len(n) for n in selected), default=12)
+        start_times: dict[str, float] = {}
         reports: dict[str, Any] = {}
         with ThreadPoolExecutor(max_workers=effective_workers) as executor:
-            futures = {
-                executor.submit(
+            futures = {}
+            for name, cls in selected.items():
+                start_times[name] = time.monotonic()
+                fut = executor.submit(
                     _run_analyzer,
                     cls,
                     ref.registry,
@@ -489,29 +493,51 @@ def analyze(
                     username,
                     password,
                     platform,
-                ): name
-                for name, cls in selected.items()
-            }
+                )
+                futures[fut] = name
             for future in as_completed(futures):
                 name = futures[future]
+                elapsed = time.monotonic() - start_times[name]
+                timing = f"({elapsed:.1f}s)"
                 try:
                     _, report = future.result()
                     reports[name] = report
-                    _info(f"  ✓ {name}", quiet=quiet)
+                    _info(
+                        f"  ✓ {name:<{name_width}}  {timing}",
+                        quiet=quiet,
+                    )
                 except RegistryError as exc:
-                    click.echo(f"  ✗ {name}: registry error — {exc}", err=True)
+                    click.echo(
+                        click.style(
+                            f"  ✗ {name:<{name_width}}  {timing}  registry error — {exc}",
+                            fg="red",
+                        ),
+                        err=True,
+                    )
                     reports[name] = {
                         "analyzer": name,
                         "error": {"type": "registry", "message": str(exc)},
                     }
                 except AnalyzerError as exc:
-                    click.echo(f"  ✗ {name}: analysis error — {exc}", err=True)
+                    click.echo(
+                        click.style(
+                            f"  ✗ {name:<{name_width}}  {timing}  analysis error — {exc}",
+                            fg="red",
+                        ),
+                        err=True,
+                    )
                     reports[name] = {
                         "analyzer": name,
                         "error": {"type": "analysis", "message": str(exc)},
                     }
                 except Exception as exc:
-                    click.echo(f"  ✗ {name}: unexpected error — {exc}", err=True)
+                    click.echo(
+                        click.style(
+                            f"  ✗ {name:<{name_width}}  {timing}  unexpected error — {exc}",
+                            fg="red",
+                        ),
+                        err=True,
+                    )
                     reports[name] = {
                         "analyzer": name,
                         "error": {"type": "unexpected", "message": str(exc)},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -762,3 +762,78 @@ class TestQuietFlag:
         assert "✗ failing" in result.output
         assert "Running" not in result.output
         assert "Analyzing" not in result.output
+
+
+class TestAnalyzerProgressFeedback:
+    """Per-analyzer progress with timing (issue #581)."""
+
+    def _make_dummy_analyzer(self, name: str):
+        from regis.analyzers.base import BaseAnalyzer
+
+        class DummyAnalyzer(BaseAnalyzer):
+            analyzer_name = name
+
+            def analyze(self, client, repo, tag, platform=None):
+                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+
+            def validate(self, report):
+                pass
+
+        DummyAnalyzer.name = name
+        return DummyAnalyzer
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_success_lines_include_timing(self, mock_discover, mock_client):
+        mock_discover.return_value = {
+            "alpha": self._make_dummy_analyzer("alpha"),
+            "bravo": self._make_dummy_analyzer("bravo"),
+        }
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest"])
+        assert result.exit_code == 0
+        success_lines = [line for line in result.output.splitlines() if "✓" in line]
+        assert len(success_lines) == 2
+        for line in success_lines:
+            assert re.search(r"\(\d+\.\d+s\)", line)
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_running_banner_present(self, mock_discover, mock_client):
+        mock_discover.return_value = {"dummy": self._make_dummy_analyzer("dummy")}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest"])
+        assert result.exit_code == 0
+        assert "Running 1 analyzer(s)" in result.output
+
+    @patch("regis.commands.analyze.RegistryClient")
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_failure_line_also_shows_timing(self, mock_discover, mock_client):
+        from regis.analyzers.base import AnalyzerError, BaseAnalyzer
+
+        class FailingAnalyzer(BaseAnalyzer):
+            name = "failing"
+
+            def analyze(self, client, repo, tag, platform=None):
+                raise AnalyzerError("boom")
+
+            def validate(self, report):
+                pass
+
+        mock_discover.return_value = {"failing": FailingAnalyzer}
+        mock_client.return_value.get_digest.return_value = None
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(main, ["analyze", "nginx:latest"])
+        failing_lines = [
+            line for line in result.output.splitlines() if "✗ failing" in line
+        ]
+        assert len(failing_lines) == 1
+        assert re.search(r"\(\d+\.\d+s\)", failing_lines[0])


### PR DESCRIPTION
## Summary

- Per-analyzer completion lines now report `(<elapsed>s)` next to the analyzer name.
- Names are left-padded to the widest selected analyzer for clean columns.
- Failure lines (`✗ name (Xs) <error>`) are styled red via `click.style` so they pop in interactive terminals.
- Existing banner (`Running N analyzer(s) with M worker(s)...`) is unchanged.
- All output remains on stderr.

Closes #581

## Test plan
- [x] Success lines contain a `(\d+\.\d+s)` timing parenthetical
- [x] `Running N analyzer(s)` banner still present
- [x] Failure lines also carry the timing parenthetical

https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjZQAwq2gT4yCQnsaN1hc7)_