### PR TITLE
ci(docker): publish image on every main commit

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -16,6 +16,12 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Coalesce rapid main pushes into a single build (cancel the in-flight one).
+# Tag/release builds get a per-ref group and are never cancelled.
+concurrency:
+  group: cd-docker-${{ github.ref_type == 'tag' && github.ref_name || 'main' }}
+  cancel-in-progress: ${{ github.ref_type == 'branch' }}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -2,6 +2,8 @@ name: CD / Docker
 
 on:
   push:
+    branches:
+      - main
     tags:
       - v*
   workflow_dispatch:
@@ -69,6 +71,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate CycloneDX SBOM
+        if: github.ref_type == 'tag'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -76,6 +79,7 @@ jobs:
           output-file: sbom.cyclonedx.json
 
       - name: Generate SPDX SBOM
+        if: github.ref_type == 'tag'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -83,6 +87,7 @@ jobs:
           output-file: sbom.spdx.json
 
       - name: Upload SBOM release artifacts
+        if: github.ref_type == 'tag'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ github.ref_name }}
@@ -91,6 +96,7 @@ jobs:
             sbom.spdx.json
 
       - name: Attest Docker image provenance
+        if: github.ref_type == 'tag'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary

- Trigger `cd-docker.yml` on push to `main` (in addition to `v*` tags + `workflow_dispatch`), so each merge to `main` produces a fresh GHCR image.
- Image tags on main pushes (via existing `metadata-action` config):
  - `ghcr.io/trivoallan/regis:main` — mobile tag pointing at the latest `main` commit.
  - `ghcr.io/trivoallan/regis:sha-<short>` — immutable per-commit tag.
- SBOM generation (CycloneDX + SPDX), artifact upload, and provenance attestation are gated to tag pushes via `if: github.ref_type == 'tag'`, keeping supply-chain artifacts tied to releases.
- Add a workflow-level `concurrency` group so rapid main pushes coalesce — the in-flight build is cancelled in favour of the newest commit (no concurrent double-push of the mobile `:main` tag). Tag/release builds use a per-ref group with `cancel-in-progress: false`, so concurrent releases are never interrupted.
- Tag-release behavior is otherwise unchanged.

## Why

Until now Docker images were only published on release tags. Producing an image per `main` commit gives users (and downstream pipelines) a way to consume the bleeding-edge build without waiting for the next release, while leaving the signed/SBOM'd release flow intact.

## Concurrency

```yaml
concurrency:
  group: cd-docker-${{ github.ref_type == 'tag' && github.ref_name || 'main' }}
  cancel-in-progress: ${{ github.ref_type == 'branch' }}
```

- Push to `main` → group `cd-docker-main`, `cancel-in-progress: true` (coalesce).
- Push of `v*` tag → per-tag group, `cancel-in-progress: false` (never cancelled).

## Test plan

- [ ] Merge → confirm a build runs on the merge commit and pushes `:main` + `:sha-<short>` to `ghcr.io/trivoallan/regis`.
- [ ] Confirm the SBOM/attestation steps are skipped on the main run (job summary).
- [ ] Push two commits to `main` back-to-back → confirm the first build is cancelled and only the latest completes.
- [ ] On the next `v*` tag, confirm SBOM artifacts and provenance attestation still appear, and the build is not cancellable.
- [ ] Confirm `ci-image-size.yml` still gates the build (220 MB ceiling unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
