### PR TITLE
fix(ci): grant contents:write so release SBOMs attach

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -26,7 +26,11 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write is required so anchore/sbom-action can attach the
+      # generated SBOMs to the GitHub Release on tag builds. With contents:read
+      # that attach step fails ("Resource not accessible by integration") and
+      # releases ship without SBOM assets (regressed silently since v0.30.0).
+      contents: write
       packages: write
       attestations: write
       id-token: write


### PR DESCRIPTION
## Summary
- The `cd-docker` `build-and-push` job ran with `contents: read`, so `anchore/sbom-action` failed at its **"Attaching SBOMs to release"** step with `Resource not accessible by integration`.
- The Docker image still published (the `Build and push` step runs *before* SBOM generation), but **every tagged release since v0.30.0 silently shipped without its CycloneDX/SPDX SBOM assets** — `gh release view v0.32.0` shows zero assets.
- Elevated the job to `contents: write`, the minimum needed to attach release assets. SBOM generation and the workflow-artifact upload were already working; only the release attach was blocked.

## Evidence
- v0.32.0 cd-docker run failed only on `Generate CycloneDX SBOM`; image `0.32.0` + `latest` are published on GHCR.
- v0.31.0 and v0.30.0 cd-docker runs failed identically — confirms a long-standing, silent regression rather than a new break.

## Test plan
- [ ] Next tagged release: cd-docker completes green and the GitHub Release carries `sbom.cyclonedx.json` + `sbom.spdx.json` assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)