### PR TITLE
ci(docker): cut GHCR versions-page noise with retention + leaner tags

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -73,11 +73,15 @@ jobs:
           # plain tags plus a :latest-slim alias on tag pushes.
           flavor: |
             suffix=${{ matrix.variant == 'full' && '-full' || '' }},onlatest=true
+          # Per-commit `sha-<short>` tags are emitted on tag builds only. On
+          # `main` pushes they accumulate one (×2 variants) per commit on the
+          # GHCR versions page with no cleanup, so the floating `main` tag plus
+          # the immutable `@sha256:` digest carry traceability there instead.
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=short
+            type=sha,format=short,enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest-slim,enable=${{ matrix.variant == 'slim' && github.ref_type == 'tag' }}
 
       - name: Build and push Docker image

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,52 @@
+name: Maintenance / GHCR cleanup
+
+# Prunes accumulated noise from the `regis` container package:
+#   - untagged manifests left behind when floating tags (`main`, `latest`,
+#     `latest-full`) are re-pointed at a new build;
+#   - ghost / partial multi-arch parents whose platform children are gone;
+#   - stale per-commit `sha-<short>` tags older than the retention window.
+# Release tags (`latest*`, semver) and the floating `main*` pointers are never
+# touched. Runs weekly and on demand.
+
+on:
+  schedule:
+    # Mondays 04:17 UTC — off-peak, avoids the top-of-hour cron stampede.
+    - cron: 17 4 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Never run two prunes against the same package at once.
+concurrency:
+  group: cleanup-ghcr
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Prune GHCR package versions
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: ${{ github.repository_owner }}
+          packages: regis
+          # Retire old per-commit sha tags; keep everything younger than the
+          # window so a freshly published build is never raced.
+          delete-tags: sha-*
+          older-than: 4 weeks
+          # Belt-and-suspenders: these are never deleted even if a future tag
+          # scheme makes them match a delete rule.
+          exclude-tags: latest,latest-slim,latest-full,main,main-full
+          delete-untagged: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          # Verify surviving multi-arch images still resolve after the prune.
+          validate: true


### PR DESCRIPTION
## Summary

The `regis` container package's [versions page](https://github.com/trivoallan/regis/pkgs/container/regis/versions) had accumulated a lot of noise. Two causes, two fixes:

- **Per-commit `sha-<short>` tags on every `main` push** (×2 variants since the slim/full split) — these piled up with no cleanup. Now gated to **tag builds only** in `cd-docker.yml`. Traceability for `main` builds stays available via the floating `main` tag and the immutable `@sha256:` digest.
- **No retention policy** — untagged manifests (orphaned when `main`/`latest*` re-point) and stale historical `sha-*` tags were never pruned. New scheduled workflow `cleanup-ghcr.yml` handles this.

### `cleanup-ghcr.yml`

Runs **weekly** (Mon 04:17 UTC) and on `workflow_dispatch`. Uses [`dataaxiom/ghcr-cleanup-action`](https://github.com/dataaxiom/ghcr-cleanup-action) (SHA-pinned to v1.2.1) to:

- delete untagged + ghost/partial multi-arch manifests,
- delete `sha-*` tags **older than 4 weeks** (recent ones kept so a fresh push is never raced),
- `validate: true` to confirm surviving multi-arch images still resolve.

**Never deleted:** `latest`, `latest-slim`, `latest-full`, `main`, `main-full`, and all semver tags (`exclude-tags` + they don't match `sha-*`).

## Test plan

- [x] `trunk check` (actionlint + yamllint) clean on both workflows.
- [ ] After merge: run `cleanup-ghcr.yml` once via **workflow_dispatch** to confirm `GITHUB_TOKEN` has delete rights on the user-owned package (if not, swap `token:` for the `REGIS_CI_APP` token or a PAT with `delete:packages`).

## Notes / tradeoffs

- Releases lose a short-SHA alias on `main` builds, but the digest is unchanged — nothing irreversible.
- `delete-tags`/`older-than` cleanups are not dry-runnable; the `exclude-tags` + age window are the safety net, hence the manual dispatch in the test plan before relying on the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)