### PR TITLE
feat(report)!: add required report schemaVersion (dashboard-decouple Phase 0)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase0-schemaversion.md
+++ b/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase0-schemaversion.md
@@ -1,0 +1,476 @@
+# Dashboard Decouple — Phase 0: report `schemaVersion` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a required integer `schemaVersion` field to the regis `report.json` envelope so a future standalone `regis-dashboard` can detect compatibility at runtime.
+
+**Architecture:** Add `schemaVersion` (integer, ≥1) to the report JSON Schema as a required property. Stamp every freshly-produced report with `REPORT_SCHEMA_VERSION = 1`. Backfill the field on the two paths that load pre-existing reports (`--rerun` and `evaluate`) so legacy reports still validate. Ship a versioned contract fixture (`tests/fixtures/report.v1.json`) that the future dashboard repo's CI will fetch and render-test.
+
+**Tech Stack:** Python 3.10+, Click, `jsonschema` + `referencing`, pytest. This is the non-breaking core prerequisite (Phase 0) from `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`. Phases 1–3 (new repo, core removal, docs) get their own plans.
+
+---
+
+## Scope & boundaries
+
+This plan covers **only Phase 0** of the full-decouple design. It is intentionally non-breaking: it adds a field, it removes nothing. It does **not** touch the dashboard, `ToolFetcher`, `tools/manifest.yaml`, or any CLI surface that will later be deleted.
+
+**Distinct fields — do not conflate:**
+
+- `version` — existing, string-or-null, the regis package version / snapshot date. **Unchanged.**
+- `snapshot_date` — existing, ISO date. **Unchanged.**
+- `schemaVersion` — **new**, integer ≥1, the report-structure contract version. This plan adds only this.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `regis/schemas/report/report.schema.json` | Report envelope JSON Schema | Modify — add `schemaVersion` property + mark required |
+| `regis/utils/report.py` | Report helpers (`validate_report`, etc.) | Modify — add `REPORT_SCHEMA_VERSION` constant + `ensure_schema_version()` helper |
+| `regis/commands/analyze.py` | `analyze` / `evaluate` commands; the report producer | Modify — stamp producer + backfill the two load paths |
+| `tests/test_report_schema_version.py` | Schema + helper unit tests | Create |
+| `tests/fixtures/report.v1.json` | Cross-repo contract fixture (consumed by future `regis-dashboard` CI) | Create |
+| `tests/test_analyze_rerun.py` | Existing rerun integration tests | Modify — add a real-validation backfill test |
+
+The root of `report.schema.json` is `"additionalProperties": false`, so the schema change (Task 1) is a hard prerequisite for the producer change — a report stamped with `schemaVersion` will **fail** validation until the schema permits the field. TDD order below respects this.
+
+---
+
+### Task 1: Add `schemaVersion` to the report schema
+
+**Files:**
+- Modify: `regis/schemas/report/report.schema.json` (root `properties` ~line 8, root `required` line 7)
+- Test: `tests/test_report_schema_version.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_report_schema_version.py`:
+
+```python
+"""Schema and helper tests for the report schemaVersion contract (Phase 0)."""
+
+import importlib.resources
+import json
+
+import jsonschema
+import pytest
+
+
+def _report_schema() -> dict:
+    text = (
+        importlib.resources.files("regis.schemas.report")
+        .joinpath("report.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(text)
+
+
+def _minimal_report(**overrides) -> dict:
+    """A report with no playbooks/rules so no $ref resolution is triggered."""
+    report = {
+        "schemaVersion": 1,
+        "version": "0.33.0",
+        "request": {
+            "url": "registry-1.docker.io/library/nginx:latest",
+            "registry": "registry-1.docker.io",
+            "repository": "library/nginx",
+            "tag": "latest",
+            "analyzers": ["metadata"],
+            "timestamp": "2026-05-31T00:00:00+00:00",
+        },
+        "results": {"metadata": {}},
+    }
+    report.update(overrides)
+    return report
+
+
+class TestReportSchemaVersion:
+    def test_accepts_report_with_schema_version(self):
+        jsonschema.validate(instance=_minimal_report(), schema=_report_schema())
+
+    def test_rejects_report_missing_schema_version(self):
+        report = _minimal_report()
+        del report["schemaVersion"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=report, schema=_report_schema())
+
+    def test_rejects_non_integer_schema_version(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                instance=_minimal_report(schemaVersion="1"),
+                schema=_report_schema(),
+            )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py -v --no-cov`
+Expected: `test_accepts_report_with_schema_version` FAILS (schema's `additionalProperties: false` rejects the unknown `schemaVersion` key); the two rejection tests may pass for the wrong reason. All three must pass after Step 3.
+
+- [ ] **Step 3: Edit the schema**
+
+In `regis/schemas/report/report.schema.json`, change the root `required` array (currently line 7):
+
+```json
+  "required": ["schemaVersion", "request", "results", "version"],
+```
+
+Add the `schemaVersion` property as the first entry of the root `properties` object (before `"version"` at line 9):
+
+```json
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Report-structure contract version. Consumers (e.g. the standalone dashboard) gate rendering on this. Distinct from `version` (package/snapshot)."
+    },
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py -v --no-cov`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regis/schemas/report/report.schema.json tests/test_report_schema_version.py
+git commit -m "feat(schema)!: require schemaVersion on report envelope"
+```
+
+---
+
+### Task 2: Add the `REPORT_SCHEMA_VERSION` constant and `ensure_schema_version()` helper
+
+**Files:**
+- Modify: `regis/utils/report.py` (add constant near the top of the module, after imports; add helper near `validate_report` at line 235)
+- Test: `tests/test_report_schema_version.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_report_schema_version.py`:
+
+```python
+class TestEnsureSchemaVersion:
+    def test_constant_is_one(self):
+        from regis.utils.report import REPORT_SCHEMA_VERSION
+
+        assert REPORT_SCHEMA_VERSION == 1
+
+    def test_sets_when_missing(self):
+        from regis.utils.report import REPORT_SCHEMA_VERSION, ensure_schema_version
+
+        report = {"request": {}, "results": {}}
+        result = ensure_schema_version(report)
+
+        assert result is report  # mutates in place and returns it
+        assert report["schemaVersion"] == REPORT_SCHEMA_VERSION
+
+    def test_preserves_existing_value(self):
+        from regis.utils.report import ensure_schema_version
+
+        report = {"schemaVersion": 7, "request": {}, "results": {}}
+        ensure_schema_version(report)
+
+        assert report["schemaVersion"] == 7
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py::TestEnsureSchemaVersion -v --no-cov`
+Expected: FAIL with `ImportError: cannot import name 'REPORT_SCHEMA_VERSION'`.
+
+- [ ] **Step 3: Add the constant and helper**
+
+In `regis/utils/report.py`, add the constant after the module imports (before the first function, `format_output_path` at line 19):
+
+```python
+REPORT_SCHEMA_VERSION = 1
+"""Current report-structure contract version (see report.schema.json)."""
+```
+
+Add the helper immediately before `def validate_report(` (line 235):
+
+```python
+def ensure_schema_version(report: dict[str, Any]) -> dict[str, Any]:
+    """Stamp `schemaVersion` on a report if absent. Backfills legacy reports.
+
+    Mutates `report` in place and returns it. Existing values are preserved so a
+    future report carrying a higher version is never silently downgraded.
+    """
+    report.setdefault("schemaVersion", REPORT_SCHEMA_VERSION)
+    return report
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py::TestEnsureSchemaVersion -v --no-cov`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regis/utils/report.py tests/test_report_schema_version.py
+git commit -m "feat(report): add REPORT_SCHEMA_VERSION constant and ensure_schema_version helper"
+```
+
+---
+
+### Task 3: Stamp the producer and backfill the two load paths
+
+**Files:**
+- Modify: `regis/commands/analyze.py` (producer ~line 611; rerun load ~line 393; evaluate load ~line 797)
+- Test: `tests/test_analyze_rerun.py` (append a real-validation backfill test)
+
+**Context — three sites in `analyze.py`:**
+
+1. **Producer** (~line 611) builds a fresh report dict literal starting with `"version": version("regis")`. Add `schemaVersion` here.
+2. **Rerun load** (~line 393): an existing `report.json` is read from disk, mutated (`existing_report.setdefault("results", {})[rerun] = result`), then `validate_report(rerun_report)` runs at ~line 408. A legacy report lacking `schemaVersion` would now fail that validation — backfill first.
+3. **Evaluate load** (~line 797): `if "results" in data: analysis_report = data` reads an existing report, then `validate_report(final_report)` runs at ~line 814. Same backfill need.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_analyze_rerun.py` (this test does **not** mock `validate_report` — it proves backfill lets a legacy report survive real validation):
+
+```python
+class TestRerunBackfillsSchemaVersion:
+    """A legacy report (no schemaVersion) flows through --rerun under real validation."""
+
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_rerun_backfills_schema_version(self, mock_discover):
+        mock_discover.return_value = {"metadata": MetadataAnalyzer}
+
+        legacy_report = {
+            "version": "0.1.0",
+            "request": {
+                "url": "r/repo:latest",
+                "registry": "r",
+                "repository": "repo",
+                "tag": "latest",
+                "analyzers": ["metadata"],
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "results": {},
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            report_dir = Path("my_report")
+            report_dir.mkdir()
+            (report_dir / "report.json").write_text(
+                json.dumps(legacy_report), encoding="utf-8"
+            )
+
+            result = runner.invoke(
+                main,
+                ["analyze", "--rerun", "metadata", "--report", str(report_dir),
+                 "-m", "PROJECT_ID=PROJ-42"],
+            )
+
+            assert result.exit_code == 0, result.output
+            updated = json.loads(
+                (report_dir / "report.json").read_text(encoding="utf-8")
+            )
+            assert updated["schemaVersion"] == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pipenv run pytest tests/test_analyze_rerun.py::TestRerunBackfillsSchemaVersion -v --no-cov`
+Expected: FAIL — either `validate_report` raises (missing required `schemaVersion`) giving a non-zero exit, or `updated["schemaVersion"]` raises `KeyError`.
+
+- [ ] **Step 3: Stamp the producer**
+
+In `regis/commands/analyze.py`, add `schemaVersion` as the first key of the producer dict (~line 611, currently `analysis_report = {` followed by `"version": version("regis"),`):
+
+```python
+        analysis_report = {
+            "schemaVersion": REPORT_SCHEMA_VERSION,
+            "version": version("regis"),
+            "request": {
+```
+
+- [ ] **Step 4: Backfill the two load paths**
+
+Update the existing `from regis.utils.report import (...)` block (line 24) to add the two new names. The resulting block (ruff will finalize member ordering on `ruff format`):
+
+```python
+from regis.utils.report import (
+    REPORT_SCHEMA_VERSION,
+    ensure_schema_version,
+    format_output_path,
+    render_and_save_reports,
+    render_mr_templates,
+    run_playbooks,
+    set_nested_value,
+    validate_report,
+)
+```
+
+In the **rerun** path, the report read from disk is built into `rerun_report` by `run_playbooks(...)` (~line 404-406). Insert the backfill on the line **between** that assignment and `validate_report(rerun_report)` (~line 408):
+
+```python
+        rerun_report = run_playbooks(
+            playbook_paths, existing_report, formats, show_rules=evaluate
+        )
+        ensure_schema_version(rerun_report)
+        validate_report(rerun_report)
+```
+
+In the **evaluate** path, insert the backfill immediately after `analysis_report = data` (~line 798). `run_playbooks` shallow-copies `analysis_report` into `final_report`, so the stamped key flows through to `validate_report(final_report)` at ~line 814:
+
+```python
+    if "results" in data:
+        analysis_report = data
+        ensure_schema_version(analysis_report)
+    else:
+```
+
+- [ ] **Step 5: Run the new test and the full rerun suite**
+
+Run: `pipenv run pytest tests/test_analyze_rerun.py -v --no-cov`
+Expected: all pass, including `TestRerunBackfillsSchemaVersion`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add regis/commands/analyze.py tests/test_analyze_rerun.py
+git commit -m "feat(report): stamp schemaVersion on produced reports and backfill on load"
+```
+
+---
+
+### Task 4: Ship the cross-repo contract fixture
+
+**Files:**
+- Create: `tests/fixtures/report.v1.json`
+- Test: `tests/test_report_schema_version.py` (append)
+
+This fixture is the **only file-level dependency** the future `regis-dashboard` repo will have on the core: its CI fetches this pinned file and asserts the dashboard renders it. It must be a realistic, schema-valid report at `schemaVersion: 1`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_report_schema_version.py`:
+
+```python
+class TestContractFixture:
+    def test_fixture_validates_against_real_validator(self):
+        import json
+        from pathlib import Path
+
+        from regis.utils.report import validate_report
+
+        fixture = Path(__file__).parent / "fixtures" / "report.v1.json"
+        report = json.loads(fixture.read_text(encoding="utf-8"))
+
+        assert report["schemaVersion"] == 1
+        validate_report(report)  # must not raise
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py::TestContractFixture -v --no-cov`
+Expected: FAIL — `FileNotFoundError` (fixture does not exist yet).
+
+- [ ] **Step 3: Create the fixture**
+
+Create `tests/fixtures/report.v1.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "version": "0.33.0",
+  "snapshot_date": "2026-05-31",
+  "tier": "Gold",
+  "request": {
+    "url": "registry-1.docker.io/library/nginx:1.27",
+    "registry": "registry-1.docker.io",
+    "repository": "library/nginx",
+    "tag": "1.27",
+    "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "analyzers": ["metadata", "cve"],
+    "timestamp": "2026-05-31T12:00:00+00:00"
+  },
+  "results": {
+    "metadata": {"created": "2026-05-20T00:00:00+00:00"},
+    "cve": {"critical": 0, "high": 1, "medium": 4, "low": 12}
+  },
+  "rules": [
+    {
+      "slug": "no-critical-cve",
+      "description": "No critical CVEs",
+      "level": "Gold",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "0 critical vulnerabilities found",
+      "analyzers": ["cve"]
+    }
+  ],
+  "rules_summary": {
+    "score": 100,
+    "total": ["no-critical-cve"],
+    "passed": ["no-critical-cve"],
+    "by_tag": {
+      "security": {
+        "rules": ["no-critical-cve"],
+        "passed_rules": ["no-critical-cve"],
+        "score": 100
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pipenv run pytest tests/test_report_schema_version.py::TestContractFixture -v --no-cov`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/report.v1.json tests/test_report_schema_version.py
+git commit -m "test(report): add report.v1 cross-repo contract fixture"
+```
+
+---
+
+### Task 5: Full-suite verification and coverage gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full suite with coverage**
+
+Run: `pipenv run pytest`
+Expected: all tests pass; coverage ≥ 90% (the project gate). The new constant/helper/producer lines are all exercised by Tasks 1–4.
+
+- [ ] **Step 2: Lint and format**
+
+Run: `pipenv run ruff check . && pipenv run ruff format --check .`
+Expected: no errors.
+
+- [ ] **Step 3: If anything fails, fix and re-run**
+
+Diagnose with `superpowers:systematic-debugging` if a failure is non-obvious. Common surprise: an unrelated existing test asserts on a full report dict and now sees an extra `schemaVersion` key — update that assertion to include it. Do **not** weaken the schema or remove the field.
+
+- [ ] **Step 4: Final commit (only if Step 3 made changes)**
+
+```bash
+git add -A
+git commit -m "test(report): align existing assertions with schemaVersion field"
+```
+
+---
+
+## Self-review notes (already reconciled against the spec)
+
+- **Spec "Phase 0" bullet 1** (add `schemaVersion: 1` to schema + producers + tests) → Tasks 1, 2, 3.
+- **Spec "Phase 0" bullet 2** (version contract fixtures `tests/fixtures/report.v1.json`) → Task 4.
+- **Spec "distinct from `version`"** → enforced in Task 1 description and the fixture (both fields present, different values).
+- **Spec "schemaVersion absent → treat as 0" (dashboard-side)** → intentionally **not** in this plan; that logic lives in the future dashboard repo (Phase 1), not the core. The core *backfills to 1* on its own load paths (legacy reports it produced were structurally v1); it never emits 0.
+- **Breaking-change note:** making `schemaVersion` required is schema-breaking for any external consumer that validates its own `report.json` against `report.schema.json`, so Task 1 commits with `feat(schema)!` (matching the [#626](https://github.com/trivoallan/regis/pull/626) `feat(playbook)!: require schemaVersion` precedent). regis itself stays user-facing-compatible because every core path stamps or backfills the field. Release-mechanics consequence: with `bump-minor-pre-major: true`, this `!` cuts a **pre-major minor** bump (0.32 → 0.33) when Phase 0 merges. Phase 2's removal then becomes the next bump (→ 0.34). The design doc's "0.33" label refers to the overall effort; the actual numbers fall out of merge order.
+
+## Out of scope (later phases — do not implement here)
+
+- Removing `regis dashboard` / `--site` / `bootstrap archive` (Phase 2).
+- The new `regis-dashboard` repo, its CI, and the render-side compatibility check (Phase 1).
+- Adding a `decisionLog.md` entry and updating `activeContext.md` / `progress.md` (Phase 3 / Memory-Bank update).

--- a/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase0-schemaversion.md
+++ b/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase0-schemaversion.md
@@ -22,14 +22,14 @@ This plan covers **only Phase 0** of the full-decouple design. It is intentional
 
 ## File Structure
 
-| File | Responsibility | Action |
-| --- | --- | --- |
-| `regis/schemas/report/report.schema.json` | Report envelope JSON Schema | Modify — add `schemaVersion` property + mark required |
-| `regis/utils/report.py` | Report helpers (`validate_report`, etc.) | Modify — add `REPORT_SCHEMA_VERSION` constant + `ensure_schema_version()` helper |
-| `regis/commands/analyze.py` | `analyze` / `evaluate` commands; the report producer | Modify — stamp producer + backfill the two load paths |
-| `tests/test_report_schema_version.py` | Schema + helper unit tests | Create |
-| `tests/fixtures/report.v1.json` | Cross-repo contract fixture (consumed by future `regis-dashboard` CI) | Create |
-| `tests/test_analyze_rerun.py` | Existing rerun integration tests | Modify — add a real-validation backfill test |
+| File                                      | Responsibility                                                        | Action                                                                           |
+| ----------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `regis/schemas/report/report.schema.json` | Report envelope JSON Schema                                           | Modify — add `schemaVersion` property + mark required                            |
+| `regis/utils/report.py`                   | Report helpers (`validate_report`, etc.)                              | Modify — add `REPORT_SCHEMA_VERSION` constant + `ensure_schema_version()` helper |
+| `regis/commands/analyze.py`               | `analyze` / `evaluate` commands; the report producer                  | Modify — stamp producer + backfill the two load paths                            |
+| `tests/test_report_schema_version.py`     | Schema + helper unit tests                                            | Create                                                                           |
+| `tests/fixtures/report.v1.json`           | Cross-repo contract fixture (consumed by future `regis-dashboard` CI) | Create                                                                           |
+| `tests/test_analyze_rerun.py`             | Existing rerun integration tests                                      | Modify — add a real-validation backfill test                                     |
 
 The root of `report.schema.json` is `"additionalProperties": false`, so the schema change (Task 1) is a hard prerequisite for the producer change — a report stamped with `schemaVersion` will **fail** validation until the schema permits the field. TDD order below respects this.
 
@@ -38,6 +38,7 @@ The root of `report.schema.json` is `"additionalProperties": false`, so the sche
 ### Task 1: Add `schemaVersion` to the report schema
 
 **Files:**
+
 - Modify: `regis/schemas/report/report.schema.json` (root `properties` ~line 8, root `required` line 7)
 - Test: `tests/test_report_schema_version.py` (create)
 
@@ -141,6 +142,7 @@ git commit -m "feat(schema)!: require schemaVersion on report envelope"
 ### Task 2: Add the `REPORT_SCHEMA_VERSION` constant and `ensure_schema_version()` helper
 
 **Files:**
+
 - Modify: `regis/utils/report.py` (add constant near the top of the module, after imports; add helper near `validate_report` at line 235)
 - Test: `tests/test_report_schema_version.py` (append)
 
@@ -217,6 +219,7 @@ git commit -m "feat(report): add REPORT_SCHEMA_VERSION constant and ensure_schem
 ### Task 3: Stamp the producer and backfill the two load paths
 
 **Files:**
+
 - Modify: `regis/commands/analyze.py` (producer ~line 611; rerun load ~line 393; evaluate load ~line 797)
 - Test: `tests/test_analyze_rerun.py` (append a real-validation backfill test)
 
@@ -341,6 +344,7 @@ git commit -m "feat(report): stamp schemaVersion on produced reports and backfil
 ### Task 4: Ship the cross-repo contract fixture
 
 **Files:**
+
 - Create: `tests/fixtures/report.v1.json`
 - Test: `tests/test_report_schema_version.py` (append)
 
@@ -390,8 +394,8 @@ Create `tests/fixtures/report.v1.json`:
     "timestamp": "2026-05-31T12:00:00+00:00"
   },
   "results": {
-    "metadata": {"created": "2026-05-20T00:00:00+00:00"},
-    "cve": {"critical": 0, "high": 1, "medium": 4, "low": 12}
+    "metadata": { "created": "2026-05-20T00:00:00+00:00" },
+    "cve": { "critical": 0, "high": 1, "medium": 4, "low": 12 }
   },
   "rules": [
     {
@@ -466,7 +470,7 @@ git commit -m "test(report): align existing assertions with schemaVersion field"
 - **Spec "Phase 0" bullet 1** (add `schemaVersion: 1` to schema + producers + tests) → Tasks 1, 2, 3.
 - **Spec "Phase 0" bullet 2** (version contract fixtures `tests/fixtures/report.v1.json`) → Task 4.
 - **Spec "distinct from `version`"** → enforced in Task 1 description and the fixture (both fields present, different values).
-- **Spec "schemaVersion absent → treat as 0" (dashboard-side)** → intentionally **not** in this plan; that logic lives in the future dashboard repo (Phase 1), not the core. The core *backfills to 1* on its own load paths (legacy reports it produced were structurally v1); it never emits 0.
+- **Spec "schemaVersion absent → treat as 0" (dashboard-side)** → intentionally **not** in this plan; that logic lives in the future dashboard repo (Phase 1), not the core. The core _backfills to 1_ on its own load paths (legacy reports it produced were structurally v1); it never emits 0.
 - **Breaking-change note:** making `schemaVersion` required is schema-breaking for any external consumer that validates its own `report.json` against `report.schema.json`, so Task 1 commits with `feat(schema)!` (matching the [#626](https://github.com/trivoallan/regis/pull/626) `feat(playbook)!: require schemaVersion` precedent). regis itself stays user-facing-compatible because every core path stamps or backfills the field. Release-mechanics consequence: with `bump-minor-pre-major: true`, this `!` cuts a **pre-major minor** bump (0.32 → 0.33) when Phase 0 merges. Phase 2's removal then becomes the next bump (→ 0.34). The design doc's "0.33" label refers to the overall effort; the actual numbers fall out of merge order.
 
 ## Out of scope (later phases — do not implement here)
@@ -474,3 +478,13 @@ git commit -m "test(report): align existing assertions with schemaVersion field"
 - Removing `regis dashboard` / `--site` / `bootstrap archive` (Phase 2).
 - The new `regis-dashboard` repo, its CI, and the render-side compatibility check (Phase 1).
 - Adding a `decisionLog.md` entry and updating `activeContext.md` / `progress.md` (Phase 3 / Memory-Bank update).
+
+## Implementation deviations (recorded post-execution, 2026-05-31)
+
+Two justified departures from the literal plan surfaced during subagent-driven execution and code review:
+
+1. **Three report-load paths, not two.** Task 3 as written named the `--rerun` and `evaluate` load paths. A **third** path exists: the **cache-hit** path in `analyze.py` (`final_report = json.loads(cache_path.read_text(...))` inside `if cache_path.exists():`), which feeds `validate_report` at the main call site. A legacy cached `report.json` would have failed the now-required field. `ensure_schema_version(final_report)` was added there too. A code-reviewer grep confirmed `validate_report` has exactly three call sites and all are now covered; the other report readers (`commands/archive.py`, `rules.py`, the gh/gitlab CLIs) never validate, so they are not gaps.
+
+2. **Contract fixture made schema-honest.** The plan's `tests/fixtures/report.v1.json` used invented `results.metadata` / `results.cve` payloads. Because this fixture is the cross-repo render contract, the blobs were replaced with minimal payloads that validate against the real `regis/schemas/analyzer/oci.schema.json` and `cve.schema.json` (slugs `oci` + `cve`, `request.analyzers: ["cve", "oci"]`), and `TestContractFixture` gained `test_analyzer_blobs_match_their_schemas` to lock that honesty against drift.
+
+**Final state:** 5 task commits on the branch; full suite `626 passed`, coverage `91.18%`; `trunk check` reports no new issues on all changed files. Pre-existing, unrelated lint in untouched files (`regis/report/html.py` unused `json`; `ruff format` drift in two test files) was deliberately left out of scope.

--- a/docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md
+++ b/docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md
@@ -1,0 +1,319 @@
+# Dashboard Full Decouple — Design
+
+> **Date**: 2026-05-31
+> **Status**: Design approved, pending implementation plan
+> **Supersedes**: the OCI/`ToolFetcher` build-time-pin design captured in
+> `docs/memory-bank/plans/2026-05-31-dashboard-repo-split-plan.md` (PR #628).
+
+## Why this supersedes PR #628
+
+PR #628 split `apps/dashboard` into a dedicated repo but kept the core **consuming**
+the dashboard: a versioned OCI artifact fetched at build-time via the existing
+`ToolFetcher`, bundled into every wheel and image, with a build-time `schemaVersion`
+compatibility pin.
+
+Stress-testing that design surfaced that the `ToolFetcher` reuse was thin — the
+dashboard is a static, arch-independent, eagerly-bundled asset, while `ToolFetcher`
+exists for lazy, per-arch, runtime-fetched binaries. Four of its five reasons to
+exist (lazy slim, mirror, offline, doctor integration) were explicitly opted out.
+What remained was "uses `regctl`", i.e. "uses ghcr".
+
+This design takes the more decisive move: **the core stops shipping the dashboard
+entirely.** This removes more complexity than the split adds — no `assets:` section,
+no `ToolFetcher` extension, no `REGIS_DASHBOARD_DIR`, no build-time pin to enforce.
+
+## Decision
+
+`apps/dashboard` becomes a fully independent project in a new `regis-dashboard`
+repository. The two projects are linked by a **single versioned contract**:
+`report.json` + a new integer `schemaVersion` field. The core knows nothing about
+the dashboard.
+
+### Drivers (validated)
+
+1. **Decoupled release cadences** — release the dashboard independently of the CLI.
+2. **Lighten the core** — remove Node/pnpm/Docusaurus from the **Python package
+   build path** (wheel + Docker image).
+
+The radical cut also yields a third benefit not available to the PR #628 design:
+the core's build path gains **zero new external dependencies** (no ghcr fetch in
+the wheel/image build), because there is nothing to fetch.
+
+Explicitly out of scope as drivers: standalone product reuse, separate front/back
+governance.
+
+## Architecture
+
+```text
+┌──────────────────────────────────────────┐         ┌──────────────────────────────────────────┐
+│ regis (core, this repo)                  │         │ regis-dashboard (new repo)               │
+│                                          │         │                                          │
+│  • analyzers                             │         │  • Docusaurus + Tremor SPA               │
+│  • playbook / rules / registry           │         │  • Multi-archive config UI               │
+│  • CLI: analyze, evaluate, check,        │         │  • CLI: render, serve, bootstrap         │
+│    doctor, playbook, rules,              │  ────►  │    archive, archive add/configure        │
+│    bootstrap {playbook, gitlab-ci,       │ report  │  • Autonomous release cycle              │
+│    tools}                                │  .json  │  • Own distribution (Docker primary)     │
+│  • `--html` format (Jinja2 self-cont.)   │         │  • Dedicated GitHub Pages                │
+│  • `--json` format (the contract)        │         │                                          │
+│                                          │         │  Declares the schemaVersion range        │
+│  Embeds NO dashboard asset.              │         │  each release supports.                  │
+│  No Node on the wheel/image build path.  │         │                                          │
+└──────────────────────────────────────────┘         └──────────────────────────────────────────┘
+        │                                                    ▲
+        │ report.json (schemaVersion: N)                    │
+        └────────────────────────────────────────────────────┘
+                       versioned runtime contract
+```
+
+### Removed from the core
+
+- `regis/commands/dashboard.py` (group `export`, `serve`)
+- `regis/commands/archive.py` (group `add`, `configure`)
+- `regis bootstrap archive` subcommand + `regis/cookiecutters/archive/`
+- `--site` flag on `analyze` / `evaluate`; the `html-site` format branch in
+  `regis/utils/report.py`
+- `regis/report/docusaurus.py`
+- `regis/server/` + the `[server]` optional extra (FastAPI, uvicorn)
+- `regis/dashboard_assets/` + its `pyproject.toml` package-data
+- `apps/dashboard/` + its entry in `pnpm-workspace.yaml`
+- `cd-dashboard.yml` workflow
+
+### Retained in the core (visualization)
+
+- `regis analyze --html` — Jinja2 single-file, self-contained (created 2026-04-25,
+  already decoupled from `dashboard_assets`).
+- `regis analyze --json` — the machine contract.
+
+### Decision: archive bootstrap moves entirely to regis-dashboard (option α)
+
+`regis bootstrap archive`, `regis archive add`, and `regis archive configure` all
+serve the dashboard exclusively. They move **in full** to `regis-dashboard`
+(`regis-dashboard bootstrap archive`, etc.). The core keeps no archive cookiecutter.
+
+Trade-off accepted: the core loses a customer-facing entry point and some
+discoverability, in exchange for a clean "core = analyzer + self-contained format"
+boundary. Mitigated by the post-analyze message (see Distribution & DX).
+
+## The contract: `report.json` + `schemaVersion`
+
+This is the only thing linking the two repos, so it is specified precisely.
+
+### Field shape
+
+`schemaVersion` is an **integer** at the root of `report.json` (mirrors the
+playbook `schemaVersion: 1` pattern). It is **distinct** from the existing `version`
+field (the snapshot date). Added to `regis/schemas/report/report.schema.json` as
+`required`.
+
+```jsonc
+{
+  "schemaVersion": 1,          // NEW: integer, required. The contract.
+  "version": "2026-05-31",     // EXISTING: snapshot date. Unchanged.
+  "playbook_name": "...",
+  "analyzers": { ... }
+}
+```
+
+### Bump policy
+
+- `schemaVersion` increments **only** on a breaking structural change (field
+  removed/renamed, semantics changed). Adding an optional field is **not** a bump.
+- Every bump → core changelog entry + migration note.
+
+### Compatibility ownership & enforcement
+
+- **The dashboard declares** the `schemaVersion` range each release can render as
+  an inclusive `[min, max]` integer pair (e.g. `supports: { min: 1, max: 2 }`
+  renders schemaVersion 1 and 2). The core declares nothing about the dashboard.
+- **Enforcement is 100% runtime, dashboard-side**, when the dashboard loads a
+  `report.json`. There is no build-time pin and no compat logic in the core.
+- The core has **zero compatibility logic**. It simply emits the current
+  `schemaVersion` it knows. All verification lives in the dashboard.
+
+Rationale for runtime-only: with the radical cut the core never pins a dashboard
+build, so there is no "build moment" to check. The only place a `report.json` meets
+a given dashboard is when a user points a dashboard at a report — that is where the
+check belongs. Bonus: it also covers the old-dashboard / new-report case that a
+build-time pin never saw.
+
+### Error behavior (dashboard-side)
+
+- **schemaVersion out of range** → explicit message, never a silently broken render:
+  `This report uses schemaVersion 3; this dashboard supports 1–2. Upgrade with: <instruction>`
+- **`schemaVersion` absent** (pre-split report) → treat as `schemaVersion: 0` and
+  show "report predates schema versioning, best-effort support" rather than crash.
+
+### Cross-repo contract test
+
+The only file-level dependency between the repos:
+
+- The core versions fixtures: `tests/fixtures/report.v1.json` (one per
+  `schemaVersion`).
+- `regis-dashboard` CI fetches these fixtures (raw GitHub URL pinned to a tag) and
+  asserts the render works.
+- This is a **versioned-file** dependency, not a pipeline dependency — no cadence
+  coupling.
+
+## History migration & new repo
+
+### Extraction
+
+`git filter-repo --path apps/dashboard/ --path-rename apps/dashboard/:` on a fresh
+clone of the core → new `regis-dashboard` repo with the `apps/dashboard` history
+preserved, re-rooted.
+
+`filter-repo` moves **only** `apps/dashboard/`. The Python that _served_ the
+dashboard (`regis/server/`, `regis/report/docusaurus.py`,
+`regis/commands/dashboard.py`, `regis/commands/archive.py`, the `archive`
+cookiecutter) is **deleted from the core and rewritten from scratch** in the new
+repo (JS-first: Docusaurus already has `build` + `serve`). We discard ~15 KB of
+tested Python to avoid a polyglot repo; its history stays visible in the core's
+pre-deletion log.
+
+### Accepted extraction costs
+
+- `git blame` from the core no longer follows into dashboard history.
+- PR cross-references (`#NNN`) in migrated commits point at core issues/PRs — dead
+  links in the new repo. Acceptable for archived history.
+- Cross-cutting commits (one commit touching both core + dashboard, e.g. the
+  2026-03-21 Tremor overhaul) appear duplicated in both histories. Inevitable,
+  benign.
+
+### New repo bootstrap
+
+- `release-please` + Conventional Commits (same discipline as the core).
+- CI: `pnpm build` → primary Docker image (`ghcr.io/trivoallan/regis-dashboard`) +
+  dedicated GitHub Pages + optional npm/pip asset publication.
+- Settings App for GitHub config (same pattern as the core).
+- **No Memory Bank** — a `README.md` + `CONTRIBUTING.md` suffice for a
+  single-responsibility front-end project.
+
+### Ordering guard
+
+Extraction (Phase 1) happens **before** core deletion (Phase 2). The core deletes
+nothing until the new repo has a working `render`, a published image, and a green
+contract test. This avoids any window where users cannot visualize a report.
+
+## Distribution, DX & error handling
+
+### Distribution of regis-dashboard (Docker-primary)
+
+- `docker run --rm -v $PWD:/data ghcr.io/trivoallan/regis-dashboard render /data/report.json`
+  → writes a static site.
+- `docker run ... serve /data/report.json` → live preview.
+- npm (`npx @regis/dashboard render …`) and/or pip are optional overlays, not the
+  canonical path.
+
+### User journeys (before → after)
+
+| Need                    | Before (monorepo)         | After (split)                                                    |
+| ----------------------- | ------------------------- | ---------------------------------------------------------------- |
+| One-shot email share    | `regis analyze --html`    | **unchanged**                                                    |
+| Machine data            | `regis analyze --json`    | **unchanged**                                                    |
+| Interactive exploration | `regis analyze --site`    | `regis analyze --json` then `regis-dashboard render report.json` |
+| Live preview            | `regis dashboard serve`   | `regis-dashboard serve report.json`                              |
+| CI archive deliverable  | `regis bootstrap archive` | `regis-dashboard bootstrap archive`                              |
+
+### Discoverability mitigation
+
+The core no longer mentions the dashboard in `--help`. Countered by a post-`analyze`
+message (when `--json` is produced without `--html`):
+
+```text
+Report written to ./out/report.json
+  • Share a single file:    regis analyze --html
+  • Explore interactively:   https://github.com/trivoallan/regis-dashboard
+```
+
+Plus: core README + doc-site landing point to `regis-dashboard`. `--html` remains
+the "works with nothing installed" path.
+
+### New failure points
+
+1. **schemaVersion out of range** → explicit dashboard-side message (see Contract).
+2. **Malformed / missing `schemaVersion`** → treated as `schemaVersion: 0`,
+   best-effort message.
+3. **User runs `regis dashboard …` / `regis analyze --site` post-removal** → not a
+   bare "unknown command". Leave a **temporary redirect stub** that errors with:
+   ```text
+   'regis dashboard' moved to a separate tool in v0.33.
+   → https://github.com/trivoallan/regis-dashboard
+   ```
+   Stub removed after one release cycle (e.g. v0.34). This is the artifact with a
+   future obligation — its removal can be scheduled.
+
+### Core versioning
+
+Breaking change (`--site`, `dashboard`, `archive`, `bootstrap archive` all leave).
+Bump 0.32 → **0.33** (pre-v1 semver, consistent with recent breaks). Strong
+changelog + migration section.
+
+### GitLab CI guide (Sprint 1, in progress)
+
+Must be written **for the post-split world directly** — documenting
+`regis analyze --json` + a separate dashboard job (`regis-dashboard render`), not
+the old `bootstrap archive`. Otherwise it documents an interface that breaks within
+the sprint.
+
+### Test surface
+
+The ~30% of integration tests covering site/dashboard/server **leave** the core.
+New core tests: the post-analyze message, the redirect stubs, `schemaVersion`
+emission. Core coverage must stay ≥ 90% after removal (watch the ratio — removing
+tested code can move it either way).
+
+## Phasing (before v1.0.0-alpha)
+
+### Phase 0 — Core prerequisite (pre-split, non-breaking for users)
+
+- [ ] Add `schemaVersion: 1` to `regis/schemas/report/report.schema.json`
+      (+ producers in `regis/report/*`, + tests). Distinct from `version`.
+- [ ] Version contract fixtures `tests/fixtures/report.v1.json`.
+
+### Phase 1 — New regis-dashboard repo
+
+- [ ] `git filter-repo` of `apps/dashboard` → new repo, history preserved.
+- [ ] Rewrite `render` / `serve` / `bootstrap archive` / `archive add|configure`
+      JS-first in the new repo.
+- [ ] New-repo CI: `pnpm build` → push Docker image + deploy dedicated GitHub Pages.
+- [ ] release-please + Conventional Commits in the new repo.
+- [ ] Dashboard declares the supported `report.schemaVersion` range per release.
+- [ ] Cross-repo contract test green (new-repo CI fetches core fixtures).
+
+### Phase 2 — Core removal (only after Phase 1 is fully green)
+
+- [ ] Delete `regis/commands/dashboard.py`, `regis/commands/archive.py`,
+      `regis/report/docusaurus.py`, `regis/server/`, `regis/dashboard_assets/`,
+      `regis/cookiecutters/archive/`.
+- [ ] Remove `--site` flag + `html-site` branch from `regis/utils/report.py` and
+      `regis/commands/analyze.py`.
+- [ ] Remove `[server]` extra + `dashboard_assets` package-data from
+      `pyproject.toml`.
+- [ ] Remove `apps/dashboard` from `pnpm-workspace.yaml`; delete `cd-dashboard.yml`.
+- [ ] Add temporary redirect stubs for `regis dashboard` and `regis analyze --site`.
+- [ ] Add post-analyze discoverability message.
+- [ ] Bump 0.32 → 0.33 with changelog + migration notes.
+
+### Phase 3 — Docs & cleanup
+
+- [ ] GitLab CI guide written for the post-split world.
+- [ ] Core README + doc-site landing point to `regis-dashboard`.
+- [ ] Update `activeContext.md` + `progress.md`; close "Monorepo vs split".
+- [ ] Schedule redirect-stub removal for the next release cycle (e.g. v0.34).
+
+## Risks / watch-points
+
+- **`docs/website` stays** in the core's pnpm workspace (also Docusaurus) → Node is
+  **not** eradicated from the repo, only from the wheel/image build path. Packaging
+  goal met; stated explicitly.
+- **Contract drift**: without `schemaVersion` discipline, decoupled cadences = silent
+  breakage. Phase 0 is blocking. The runtime check + cross-repo contract test are
+  the safety net.
+- **Coverage dip**: removing tested code in Phase 2 can move the 90% ratio either
+  way — verify before merging.
+- **DX downgrade**: interactive exploration goes from one command to two tools. This
+  is the one genuine deficit; `--html` covers the simple case, the post-analyze
+  message covers discovery.
+- **decisionLog.md**: PR #628's body claimed a `decisionLog.md` entry that the diff
+  never added. This design must actually add the entry.

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -18,6 +18,8 @@ from regis.analyzers.discovery import discover_analyzers
 from regis.registry.client import RegistryClient, RegistryError
 from regis.registry.parser import parse_image_url
 from regis.utils.report import (
+    REPORT_SCHEMA_VERSION,
+    ensure_schema_version,
     format_output_path,
     render_and_save_reports,
     render_mr_templates,
@@ -405,6 +407,7 @@ def analyze(
         rerun_report = run_playbooks(
             playbook_paths, existing_report, formats, show_rules=evaluate
         )
+        ensure_schema_version(rerun_report)
         validate_report(rerun_report)
 
         indent = 2 if pretty else None
@@ -485,6 +488,7 @@ def analyze(
             if cache_path.exists():
                 _info(f"  Using cached report from {cache_path}", quiet=quiet)
                 final_report = json.loads(cache_path.read_text(encoding="utf-8"))
+                ensure_schema_version(final_report)
         except Exception as exc:
             logger.debug("Cache lookup failed: %s", exc)
 
@@ -609,6 +613,7 @@ def analyze(
         metadata_dict = _parse_meta(meta)
 
         analysis_report = {
+            "schemaVersion": REPORT_SCHEMA_VERSION,
             "version": version("regis"),
             "request": {
                 "url": url,
@@ -796,6 +801,7 @@ def evaluate_cmd(
 
     if "results" in data:
         analysis_report = data
+        ensure_schema_version(analysis_report)
     else:
         raise click.ClickException(
             "Input file does not appear to be a regis report (missing 'results' key)."

--- a/regis/schemas/report/report.schema.json
+++ b/regis/schemas/report/report.schema.json
@@ -4,8 +4,13 @@
   "title": "report",
   "description": "Final report envelope produced by regis, containing request metadata and analyzer results.",
   "type": "object",
-  "required": ["request", "results", "version"],
+  "required": ["schemaVersion", "request", "results", "version"],
   "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Report-structure contract version. Consumers (e.g. the standalone dashboard) gate rendering on this. Distinct from `version` (package/snapshot)."
+    },
     "version": {
       "type": ["string", "null"],
       "description": "Version of regis that generated this report."

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -15,6 +15,9 @@ import jsonschema
 
 logger = logging.getLogger(__name__)
 
+REPORT_SCHEMA_VERSION = 1
+"""Current report-structure contract version (see report.schema.json)."""
+
 
 def format_output_path(template: str, report: dict[str, Any], fmt: str) -> Path:
     """Format an output path template using data from the report."""
@@ -230,6 +233,16 @@ def run_playbooks(
         final_report["links"] = all_links
 
     return final_report
+
+
+def ensure_schema_version(report: dict[str, Any]) -> dict[str, Any]:
+    """Stamp `schemaVersion` on a report if absent. Backfills legacy reports.
+
+    Mutates `report` in place and returns it. Existing values are preserved so a
+    future report carrying a higher version is never silently downgraded.
+    """
+    report.setdefault("schemaVersion", REPORT_SCHEMA_VERSION)
+    return report
 
 
 def validate_report(report: dict[str, Any]) -> None:

--- a/tests/fixtures/report.v1.json
+++ b/tests/fixtures/report.v1.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "version": "0.33.0",
+  "snapshot_date": "2026-05-31",
+  "tier": "Gold",
+  "request": {
+    "url": "registry-1.docker.io/library/nginx:1.27",
+    "registry": "registry-1.docker.io",
+    "repository": "library/nginx",
+    "tag": "1.27",
+    "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "analyzers": ["cve", "oci"],
+    "timestamp": "2026-05-31T12:00:00+00:00"
+  },
+  "results": {
+    "oci": {
+      "analyzer": "oci",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "platforms": [{ "architecture": "amd64", "os": "linux" }]
+    },
+    "cve": {
+      "analyzer": "cve",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "scanner_version": "0.74.1",
+      "vulnerability_count": 17,
+      "critical_count": 0,
+      "high_count": 1,
+      "medium_count": 4,
+      "low_count": 12,
+      "negligible_count": 0,
+      "unknown_count": 0,
+      "fixed_count": 5,
+      "targets": []
+    }
+  },
+  "rules": [
+    {
+      "slug": "no-critical-cve",
+      "description": "No critical CVEs",
+      "level": "Gold",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "0 critical vulnerabilities found",
+      "analyzers": ["cve"]
+    }
+  ],
+  "rules_summary": {
+    "score": 100,
+    "total": ["no-critical-cve"],
+    "passed": ["no-critical-cve"],
+    "by_tag": {
+      "security": {
+        "rules": ["no-critical-cve"],
+        "passed_rules": ["no-critical-cve"],
+        "score": 100
+      }
+    }
+  }
+}

--- a/tests/test_analyze_rerun.py
+++ b/tests/test_analyze_rerun.py
@@ -335,8 +335,15 @@ class TestRerunBackfillsSchemaVersion:
 
             result = runner.invoke(
                 main,
-                ["analyze", "--rerun", "metadata", "--report", str(report_dir),
-                 "-m", "PROJECT_ID=PROJ-42"],
+                [
+                    "analyze",
+                    "--rerun",
+                    "metadata",
+                    "--report",
+                    str(report_dir),
+                    "-m",
+                    "PROJECT_ID=PROJ-42",
+                ],
             )
 
             assert result.exit_code == 0, result.output

--- a/tests/test_analyze_rerun.py
+++ b/tests/test_analyze_rerun.py
@@ -303,3 +303,44 @@ class TestRerunMergeMeta:
             )
             assert "EXISTING_KEY" not in updated["metadata"]
             assert updated["metadata"]["NEW_KEY"] == "only"
+
+
+class TestRerunBackfillsSchemaVersion:
+    """A legacy report (no schemaVersion) flows through --rerun under real validation."""
+
+    @patch("regis.commands.analyze._discover_analyzers")
+    def test_rerun_backfills_schema_version(self, mock_discover):
+        mock_discover.return_value = {"metadata": MetadataAnalyzer}
+
+        legacy_report = {
+            "version": "0.1.0",
+            "request": {
+                "url": "r/repo:latest",
+                "registry": "r",
+                "repository": "repo",
+                "tag": "latest",
+                "analyzers": ["metadata"],
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "results": {},
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            report_dir = Path("my_report")
+            report_dir.mkdir()
+            (report_dir / "report.json").write_text(
+                json.dumps(legacy_report), encoding="utf-8"
+            )
+
+            result = runner.invoke(
+                main,
+                ["analyze", "--rerun", "metadata", "--report", str(report_dir),
+                 "-m", "PROJECT_ID=PROJ-42"],
+            )
+
+            assert result.exit_code == 0, result.output
+            updated = json.loads(
+                (report_dir / "report.json").read_text(encoding="utf-8")
+            )
+            assert updated["schemaVersion"] == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,8 +406,13 @@ class TestAnalyzeCacheAndFail:
 
             result = runner.invoke(main, ["analyze", "nginx:latest", "--cache"])
 
-        assert result.exit_code == 0
-        assert "cached" in result.output
+            assert result.exit_code == 0
+            assert "cached" in result.output
+            # The legacy cached report had no schemaVersion; the cache-hit load
+            # path must backfill it before validation, and the saved report
+            # carries it.
+            saved = json.loads((cache_dir / "report.json").read_text(encoding="utf-8"))
+            assert saved["schemaVersion"] == 1
 
     @patch("regis.commands.analyze.render_mr_templates")
     @patch("regis.commands.analyze.render_and_save_reports")

--- a/tests/test_report_schema_version.py
+++ b/tests/test_report_schema_version.py
@@ -58,3 +58,28 @@ class TestReportSchemaVersion:
                 instance=_minimal_report(schemaVersion=0),
                 schema=_report_schema(),
             )
+
+
+class TestEnsureSchemaVersion:
+    def test_constant_is_one(self):
+        from regis.utils.report import REPORT_SCHEMA_VERSION
+
+        assert REPORT_SCHEMA_VERSION == 1
+
+    def test_sets_when_missing(self):
+        from regis.utils.report import REPORT_SCHEMA_VERSION, ensure_schema_version
+
+        report = {"request": {}, "results": {}}
+        result = ensure_schema_version(report)
+
+        assert result is report  # mutates in place and returns it
+        assert report["schemaVersion"] == REPORT_SCHEMA_VERSION
+
+    def test_preserves_existing_value(self):
+        from regis.utils.report import ensure_schema_version
+
+        report = {"schemaVersion": 7, "request": {}, "results": {}}
+        result = ensure_schema_version(report)
+
+        assert result is report
+        assert report["schemaVersion"] == 7

--- a/tests/test_report_schema_version.py
+++ b/tests/test_report_schema_version.py
@@ -1,0 +1,60 @@
+"""Schema and helper tests for the report schemaVersion contract (Phase 0)."""
+
+import importlib.resources
+import json
+
+import jsonschema
+import pytest
+
+
+def _report_schema() -> dict:
+    text = (
+        importlib.resources.files("regis.schemas.report")
+        .joinpath("report.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(text)
+
+
+def _minimal_report(**overrides) -> dict:
+    """A report with no playbooks/rules so no $ref resolution is triggered."""
+    report = {
+        "schemaVersion": 1,
+        "version": "0.33.0",
+        "request": {
+            "url": "registry-1.docker.io/library/nginx:latest",
+            "registry": "registry-1.docker.io",
+            "repository": "library/nginx",
+            "tag": "latest",
+            "analyzers": ["metadata"],
+            "timestamp": "2026-05-31T00:00:00+00:00",
+        },
+        "results": {"metadata": {}},
+    }
+    report.update(overrides)
+    return report
+
+
+class TestReportSchemaVersion:
+    def test_accepts_report_with_schema_version(self):
+        jsonschema.validate(instance=_minimal_report(), schema=_report_schema())
+
+    def test_rejects_report_missing_schema_version(self):
+        report = _minimal_report()
+        del report["schemaVersion"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=report, schema=_report_schema())
+
+    def test_rejects_non_integer_schema_version(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                instance=_minimal_report(schemaVersion="1"),
+                schema=_report_schema(),
+            )
+
+    def test_rejects_zero_schema_version(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                instance=_minimal_report(schemaVersion=0),
+                schema=_report_schema(),
+            )

--- a/tests/test_report_schema_version.py
+++ b/tests/test_report_schema_version.py
@@ -83,3 +83,33 @@ class TestEnsureSchemaVersion:
 
         assert result is report
         assert report["schemaVersion"] == 7
+
+
+class TestContractFixture:
+    def test_fixture_validates_against_real_validator(self):
+        import json
+        from pathlib import Path
+
+        from regis.utils.report import validate_report
+
+        fixture = Path(__file__).parent / "fixtures" / "report.v1.json"
+        report = json.loads(fixture.read_text(encoding="utf-8"))
+
+        assert report["schemaVersion"] == 1
+        validate_report(report)  # must not raise
+
+    def test_analyzer_blobs_match_their_schemas(self):
+        import json
+        from pathlib import Path
+
+        import jsonschema
+
+        fixtures = Path(__file__).parent / "fixtures" / "report.v1.json"
+        report = json.loads(fixtures.read_text(encoding="utf-8"))
+
+        schema_dir = importlib.resources.files("regis.schemas.analyzer")
+        for slug in ("cve", "oci"):
+            schema = json.loads(
+                schema_dir.joinpath(f"{slug}.schema.json").read_text(encoding="utf-8")
+            )
+            jsonschema.validate(instance=report["results"][slug], schema=schema)


### PR DESCRIPTION
## Summary

- Adds a required integer `schemaVersion` (currently `1`, `minimum: 1`) to the `report.json` envelope schema — the runtime contract a future standalone `regis-dashboard` will gate rendering on. Distinct from the existing `version` (package/snapshot) field.
- Single source of truth `REPORT_SCHEMA_VERSION` + an `ensure_schema_version()` backfill helper in `regis/utils/report.py`.
- The report producer stamps it; **all three** report-load paths (`--rerun`, `evaluate`, and the cache-hit path) backfill legacy reports before validation, so existing on-disk `report.json` files keep working.
- Ships `tests/fixtures/report.v1.json` — the cross-repo **contract fixture** (schema-honest `oci` + `cve` blobs) that the future dashboard repo's CI will fetch and render-test.

This is **Phase 0** of the dashboard full-decouple design (which **supersedes #628**). It is non-breaking for regis users (every path stamps or backfills the field); it is schema-breaking only for external consumers validating their own `report.json`, hence `feat(...)!` → Release Please pre-major minor bump (0.32 → 0.33).

Design + plan on the branch:
- `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`
- `docs/superpowers/plans/2026-05-31-dashboard-decouple-phase0-schemaversion.md`

## Test Plan

- [x] Full suite: **626 passed**, coverage **91.18%** (gate 90%)
- [x] `trunk check` — no new issues on all changed files
- [x] New tests: schema requires + min-bounds `schemaVersion`; helper backfill semantics (sets-when-missing, never-downgrade, in-place identity); `--rerun` and cache-hit backfill under **real** (un-mocked) validation; contract fixture validates against the envelope schema **and** the per-analyzer `oci`/`cve` schemas
- [x] Rebased on latest `main`; suite green post-rebase

## Follow-ups (not in this PR)

- Close or repoint the superseded #628
- Phase 1 (new `regis-dashboard` repo + render-side compat check), Phase 2 (core removal), Phase 3 (docs) — each gets its own plan
- Add the `decisionLog.md` entry + `activeContext.md`/`progress.md` memory-bank update

🤖 Generated with [Claude Code](https://claude.com/claude-code)