### PR TITLE
docs: Phase 1 implementation plans for the dashboard decouple

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -17,6 +17,11 @@ Voir `docs/memory-bank/roadmap.md` pour le détail complet.
 
 ## Recent Changes
 
+- [2026-06-01] **Dashboard full decouple — décision + Phase 0 livrée + Phase 1 planifiée**:
+  - **Décision** (voir `decisionLog.md`) : le cœur **arrête complètement de livrer la dashboard**. `apps/dashboard` est extrait dans un dépôt dédié `regis-dashboard`. Lien unique : contrat `report.json` + `schemaVersion` entier, vérifié **100 % au runtime côté dashboard** ; le cœur n'a **aucune** logique de compatibilité. **Supersède** l'approche OCI/`ToolFetcher` (PR #628, fermée).
+  - **Coupe radicale** : `serve` standalone = **static-preview-only**. Le backend GitLab proxy + webhooks/SSE (`regis/server/`) est abandonné, pas réécrit en Node ; `gitlab.tsx` + ses 3 composants exclusifs sont retirés à l'extraction.
+  - **Phase 0 livrée (PR #630)** : champ `schemaVersion` entier requis sur l'enveloppe `report.json` (`regis/schemas/report/report.schema.json`), constante `REPORT_SCHEMA_VERSION` + helper `ensure_schema_version()` dans `regis/utils/report.py`, producteur estampillé + backfill des **trois** chemins de chargement (rerun, evaluate, cache-hit) dans `regis/commands/analyze.py`, fixture contrat `tests/fixtures/report.v1.json`. Suite 626 PASS, couverture 91.18 %. Breaking (`feat(schema)!`) → bump pré-v1 0.32 → 0.33.
+  - **Phase 1 planifiée (PR #632)** : trois plans sous `docs/superpowers/plans/` — 1a extraction + bootstrap Pages, 1b CLI Node (render/serve/archive/bootstrap) + image Docker, 1c compat runtime + test de contrat cross-repo. Phase 2 (retrait du cœur) reste bloquée tant que Phase 1 n'est pas en ligne.
 - [2026-05-31] **Docker image size — round 3** (PR pending):
   - Lazy-loaded scanner binaries via new `regis.tools` package: manifest (`regis/tools/manifest.yaml` pins grype/syft/trufflehog/hadolint/dockle/regctl with sha256 per arch + optional cosign issuer), typed loader, `ToolFetcher` (cache, sha256, flock concurrency, mirror, cosign best-effort, fetch_all), `ensure_tool()` bridge in `regis/utils/process.py`.
   - Six analyzer/wrapper sites (`grype.py`, `syft.py`, `trufflehog.py`, `regctl.py`, `hadolint.py`, `dockle.py`) routed through `ensure_tool` — host PATH still short-circuits; manifest-listed tools fall back to the fetcher when absent.
@@ -69,4 +74,4 @@ Voir `docs/memory-bank/roadmap.md` pour le détail complet.
 
 ## Decisions in Progress
 
-- **Monorepo vs split** (pré-v1) : exploration structurée, pas encore de décision. Inconnues : patterns contributeurs futurs, cadence post-v1, gouvernance à l'échelle.
+- **Monorepo vs split** (pré-v1) : ✅ **résolu [2026-06-01]** — split décidé via la coupe radicale (le cœur n'embarque plus la dashboard). Détail dans `decisionLog.md` et l'entrée Recent Changes ci-dessus.

--- a/docs/memory-bank/decisionLog.md
+++ b/docs/memory-bank/decisionLog.md
@@ -2,6 +2,15 @@
 
 > Supplemental file: this records historical decisions that complement the core Memory Bank files.
 
+## 2026-06-01: Dashboard Full Decouple — Core Stops Shipping the Dashboard
+
+- **Decision**: Extract `apps/dashboard` into a standalone `regis-dashboard` repo. The core stops shipping the dashboard entirely; the two projects link only through a versioned `report.json` + integer `schemaVersion` contract, checked **100% at runtime, dashboard-side**. The core carries zero compatibility logic — it emits the current `schemaVersion` and never gates.
+- **Supersedes**: the OCI-artifact-via-`ToolFetcher` + build-time-pin approach (PR #628, closed). That reuse was thin — four of `ToolFetcher`'s five reasons to exist (lazy slim, mirror, offline, doctor integration) were opted out, leaving essentially "uses ghcr."
+- **Rationale**: decouple release cadences; remove Node/pnpm/Docusaurus from the Python wheel/image build path; the radical cut removes more complexity than the split adds.
+- **Scope decision**: standalone `serve` is **static-preview-only** — the `regis dashboard serve` GitLab MR proxy + webhook/SSE backend (`regis/server/`) is dropped, not reimplemented in Node; `gitlab.tsx` and its three exclusive components are removed during extraction.
+- **Sequencing**: Phase 0 (`schemaVersion` contract, shipped — PR #630) → Phase 1 (new repo: 1a extraction, 1b CLI+Docker, 1c runtime compat+contract — planned, PR #632) → Phase 2 (core removal, blocked until Phase 1 is live) → Phase 3 (docs). Phase 0 is a breaking schema change (`feat(schema)!`) → pre-major minor bump 0.32 → 0.33.
+- **References**: `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`; plans under `docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1{a,b,c}-*.md`; PRs #630, #632.
+
 ## 2026-04-21: Consolidate Memory Bank Under `docs/memory-bank/`
 
 - **Decision**: Keep `docs/memory-bank/` as the single source of truth for Memory Bank content.

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -12,6 +12,11 @@
 
 ## Completed (Recent)
 
+- **Dashboard decouple — Phase 0 : contrat `schemaVersion` (2026-06-01, PR #630)**:
+  - Champ entier `schemaVersion` requis sur l'enveloppe `report.json` ; constante `REPORT_SCHEMA_VERSION` + helper `ensure_schema_version()` ; producteur estampillé + backfill des trois chemins de chargement (rerun/evaluate/cache-hit).
+  - Fixture de contrat cross-repo `tests/fixtures/report.v1.json`. Suite 626 PASS, couverture 91.18 %. Breaking → 0.32 → 0.33.
+  - Décision globale (coupe radicale, static-preview-only) consignée dans `decisionLog.md` ; Phase 1 planifiée (PR #632) ; supersède PR #628 (fermée).
+
 - **Docker image size reduction — round 2 (2026-05-29)**:
   - Removed git/jq from runtime; FastAPI/Uvicorn → optional `[server]` extra; `--no-compile` venv + cache prune.
   - Measured arm64 tar 186 MB → 138 MB (round 2); 244 MB → 138 MB cumulative (~43 %). CI ceiling tightened 250 → 220 MB.

--- a/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1a-extraction.md
+++ b/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1a-extraction.md
@@ -1,0 +1,632 @@
+# Phase 1a — regis-dashboard Extraction & Standalone Bootstrap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `apps/dashboard` from the regis monorepo into a standalone `regis-dashboard` GitHub repo that builds and deploys to its own GitHub Pages on its own, with history preserved, release-please + Conventional Commits, and no Python / no Memory Bank.
+
+**Architecture:** `git filter-repo` re-roots `apps/dashboard/**` to the repo root with history. The Docusaurus SPA already reads `url`/`baseUrl` from env vars and fetches `report.json` at runtime, so it builds standalone with zero code changes to its data path. A committed demo `report.json` (the core's `report.v1.json` contract fixture) lets the deployed Pages site render real content. The dropped GitLab live-backend (decision: static-preview-only) means the `gitlab.tsx` page and its components are removed so the standalone bundle has no dead backend dependency.
+
+**Tech Stack:** Docusaurus 3.10, React 19, Tremor, TailwindCSS, pnpm, Node ≥18, GitHub Actions, release-please, GitHub Pages. No Python.
+
+---
+
+## Scope & boundaries
+
+This is **Phase 1a** of three Phase-1 sub-plans (see the full-decouple spec `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`):
+
+- **1a (this plan):** extraction + standalone repo that builds & deploys to Pages. Ships a working, deployable `regis-dashboard`.
+- **1b (next):** the Node CLI (`render` / `serve` / `archive add|configure` / `bootstrap archive`) + the published Docker image.
+- **1c:** runtime `schemaVersion` compatibility check in `ReportProvider` + cross-repo contract test (CI fetches the core's `report.v1.json`).
+
+**Out of scope for 1a:** the CLI, the Docker image, the runtime schemaVersion gate, the GitLab proxy/webhook backend (dropped — static-preview-only decision), and any change to the **core** repo. 1a touches only the new `regis-dashboard` repo.
+
+**Execution context:** Unlike the Phase 0 plan, this plan does **not** run in a core worktree. **Task 1 creates the working directory** (`~/src/regis-dashboard`) that every later task operates in. All paths from Task 2 onward are relative to that new repo root.
+
+## File Structure (new repo, after Task 1 extraction)
+
+```text
+regis-dashboard/                 # was apps/dashboard/
+  docusaurus.config.ts           # url/baseUrl from env (unchanged data path)
+  package.json                   # @regis/dashboard → standalone (Task 2)
+  tailwind.config.js
+  tsconfig.json
+  src/
+    components/                  # SummaryView, AnalyzerPage, ReportProvider, ArchiveView, …
+    pages/
+      index.tsx                  # ArchiveView host
+      gitlab.tsx                 # REMOVED in Task 6 (dropped feature)
+    theme/Root.tsx               # ReportProvider mount
+    css/
+  docs/                          # index.mdx, rules.mdx, analyzers/*.mdx
+  static/
+    report.json                 # demo report for Pages (Task 4)
+  README.md / CONTRIBUTING.md / LICENSE   # Task 5
+  release-please-config.json / .release-please-manifest.json   # Task 7
+  .github/workflows/ci.yml / cd-pages.yml / release-please.yml # Tasks 8-9
+```
+
+| File                                             | Responsibility                                                | Task |
+| ------------------------------------------------ | ------------------------------------------------------------- | ---- |
+| (whole tree)                                     | extracted, re-rooted, history preserved                       | 1    |
+| `package.json`                                   | standalone metadata, no workspace assumptions                 | 2    |
+| `docusaurus.config.ts`                           | GitHub-Pages `organizationName`/`projectName`/`trailingSlash` | 3    |
+| `static/report.json`                             | demo report so Pages renders                                  | 4    |
+| `README.md`, `CONTRIBUTING.md`, `LICENSE`        | repo docs (no Memory Bank)                                    | 5    |
+| `src/pages/gitlab.tsx` + gitlab components       | **deleted** (dropped backend feature)                         | 6    |
+| `release-please-config.json`, manifest           | release automation                                            | 7    |
+| `.github/workflows/cd-pages.yml`                 | build + deploy Pages                                          | 8    |
+| `.github/workflows/ci.yml`, `release-please.yml` | PR checks + releases                                          | 9    |
+
+---
+
+### Task 1: Extract `apps/dashboard` into a standalone repo with history
+
+**Files:** none in-repo yet — this task creates the repo.
+
+**Prerequisite:** `git-filter-repo` installed (`brew install git-filter-repo` or `pipx install git-filter-repo`). Verify: `git filter-repo --version` prints a version.
+
+- [ ] **Step 1: Fresh mirror clone of the core**
+
+```bash
+cd ~/src
+git clone https://github.com/trivoallan/regis.git regis-dashboard
+cd regis-dashboard
+```
+
+- [ ] **Step 2: Re-root apps/dashboard to the repo root, dropping all other history**
+
+```bash
+git filter-repo --path apps/dashboard/ --path-rename apps/dashboard/:
+```
+
+Expected: command completes; the working tree now has `docusaurus.config.ts`, `package.json`, `src/`, `docs/`, etc. at the **root** (no `apps/dashboard/` prefix).
+
+- [ ] **Step 3: Verify the re-root and that history survived**
+
+```bash
+ls package.json docusaurus.config.ts src docs        # all present at root
+git log --oneline -- docusaurus.config.ts | head -5  # shows historical commits
+test ! -d apps && echo "OK: no apps/ prefix remains"
+```
+
+Expected: files at root; `git log` lists multiple historical commits (history preserved); "OK" printed.
+
+- [ ] **Step 4: Reset the remote and create the GitHub repo**
+
+`filter-repo` removes `origin` by design. Create the new repo and point at it:
+
+```bash
+gh repo create trivoallan/regis-dashboard --public \
+  --description "Standalone interactive viewer for regis container-security reports" \
+  --disable-wiki
+git remote add origin https://github.com/trivoallan/regis-dashboard.git
+```
+
+Do **not** push yet — Tasks 2–9 prepare the first real commit set. (The history from filter-repo is already committed; later tasks add commits on top.)
+
+- [ ] **Step 5: Sanity-build the extracted SPA as-is (baseline)**
+
+```bash
+corepack enable
+pnpm install
+pnpm build
+```
+
+Expected: `pnpm build` succeeds and writes a `build/` directory containing `index.html` and the `report/` route. (It will warn about a missing `report.json` fetch at runtime — that is fixed in Task 4. The build itself must pass.)
+
+If `pnpm build` fails because the project assumed a workspace root, note the exact error and proceed to Task 2 (which makes it standalone); re-run this build at the end of Task 2.
+
+---
+
+### Task 2: Make `package.json` standalone
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Rewrite the package manifest**
+
+The extracted `package.json` is `@regis/dashboard`, `private: true`, version `0.0.1`, with no repo metadata. Replace its top-level metadata fields (keep `scripts`, `dependencies`, `devDependencies`, `browserslist`, `engines` exactly as they are) so the head of the file reads:
+
+```json
+{
+  "name": "regis-dashboard",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Standalone interactive viewer for regis container-security reports",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trivoallan/regis-dashboard.git"
+  },
+  "homepage": "https://trivoallan.github.io/regis-dashboard/",
+  "packageManager": "pnpm@9.0.0",
+```
+
+Notes: `private: false` (it will be a public, optionally-published package). `version: 0.0.0` — release-please owns the version from here (Task 7). Keep all `scripts`/deps unchanged.
+
+- [ ] **Step 2: Add a `.gitignore` if absent**
+
+Ensure `node_modules`, `build`, `.docusaurus`, and `static/report.json` patterns are ignored where appropriate. The demo report in Task 4 is committed deliberately, so do **not** ignore `static/report.json` — instead ignore only `node_modules/`, `build/`, `.docusaurus/`:
+
+```gitignore
+node_modules/
+build/
+.docusaurus/
+*.log
+```
+
+- [ ] **Step 3: Verify standalone install + build**
+
+```bash
+rm -rf node_modules build .docusaurus
+pnpm install
+pnpm build
+pnpm typecheck
+```
+
+Expected: install, build, and `tsc --noEmit` all succeed with no workspace-related errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json .gitignore
+git commit -m "chore: make package standalone (rename, repo metadata, version 0.0.0)"
+```
+
+---
+
+### Task 3: Configure Docusaurus for GitHub Pages
+
+**Files:**
+
+- Modify: `docusaurus.config.ts`
+
+`docusaurus.config.ts` derives `url`/`baseUrl` from env vars (`ARCHIVE_URL`/`REPORT_URL`, `ARCHIVE_BASE_URL`/`REPORT_BASE_URL`, defaulting to `https://example.com` and `/`). GitHub Pages also needs `organizationName`, `projectName`, and (for Pages) `trailingSlash`.
+
+- [ ] **Step 1: Add the Pages identity fields**
+
+In `docusaurus.config.ts`, immediately after the `baseUrl:` line (~line 25), add:
+
+```ts
+  organizationName: "trivoallan",
+  projectName: "regis-dashboard",
+  trailingSlash: false,
+```
+
+Do **not** hardcode `url`/`baseUrl` — the env-var derivation stays (the Pages workflow sets them at build time in Task 8).
+
+- [ ] **Step 2: Verify a Pages-style build**
+
+Simulate the Pages build (project site served under `/regis-dashboard/`):
+
+```bash
+REPORT_URL=https://trivoallan.github.io REPORT_BASE_URL=/regis-dashboard/ pnpm build
+```
+
+Expected: build succeeds; `build/index.html` references assets under `/regis-dashboard/` (verify: `grep -o "/regis-dashboard/[^\"']*" build/index.html | head` prints matches).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docusaurus.config.ts
+git commit -m "feat: configure Docusaurus for GitHub Pages (org/project/trailingSlash)"
+```
+
+---
+
+### Task 4: Bake in a demo `report.json` so Pages renders
+
+**Files:**
+
+- Create: `static/report.json`
+
+The SPA fetches `{baseUrl}report.json` at runtime (`src/components/ReportProvider.tsx`). Without it the deployed site shows an error state. Commit a demo report so the live Pages site renders real content. Use the core's contract fixture (it is realistic and schema-honest), which also pre-stages the 1c contract test.
+
+- [ ] **Step 1: Copy the core's contract fixture as the demo report**
+
+From a local checkout of the core repo (or via raw URL), copy `tests/fixtures/report.v1.json` to `static/report.json`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/trivoallan/regis/main/tests/fixtures/report.v1.json -o static/report.json
+```
+
+Expected: `static/report.json` exists and is valid JSON: `node -e "JSON.parse(require('fs').readFileSync('static/report.json','utf8')); console.log('valid JSON')"` prints `valid JSON`.
+
+- [ ] **Step 2: Verify the built site serves the report and the SPA loads it**
+
+```bash
+REPORT_BASE_URL=/ pnpm build
+test -f build/report.json && echo "OK: report.json copied to build root"
+pnpm serve --no-open &   # docusaurus serve on :3000
+sleep 4
+curl -fsSL http://localhost:3000/report.json | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const r=JSON.parse(d);console.log('schemaVersion', r.schemaVersion)})"
+kill %1
+```
+
+Expected: "OK: report.json copied to build root"; the curl prints `schemaVersion 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add static/report.json
+git commit -m "docs: add demo report.json (core report.v1 fixture) for Pages preview"
+```
+
+---
+
+### Task 5: Repo docs — README, CONTRIBUTING, LICENSE (no Memory Bank)
+
+**Files:**
+
+- Create: `README.md`, `CONTRIBUTING.md`, `LICENSE`
+
+Per the design: a single-responsibility front-end project gets a `README` + `CONTRIBUTING`, **not** a Memory Bank.
+
+- [ ] **Step 1: Write `README.md`** with this content:
+
+```markdown
+# regis-dashboard
+
+Standalone interactive viewer for [regis](https://github.com/trivoallan/regis)
+container-security reports.
+
+Live demo: https://trivoallan.github.io/regis-dashboard/
+
+## What it does
+
+Renders a regis `report.json` as an interactive Docusaurus + Tremor site:
+summary, rules, per-analyzer pages, and a multi-report archive browser.
+
+## Contract
+
+This viewer consumes the regis report envelope identified by an integer
+`schemaVersion`. The supported range is declared per release (see the runtime
+compatibility check — added in a later phase). The reference report shape lives
+at `trivoallan/regis:tests/fixtures/report.v1.json`.
+
+## Develop
+
+    corepack enable
+    pnpm install
+    pnpm start          # dev server with the demo report (static/report.json)
+    pnpm build          # static build into build/
+
+## Status
+
+Extracted from the regis monorepo (`apps/dashboard`). The CLI (`render` / `serve`
+/ `archive` / `bootstrap archive`) and the published Docker image are added in
+Phase 1b.
+```
+
+- [ ] **Step 2: Write `CONTRIBUTING.md`**
+
+```markdown
+# Contributing
+
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (Angular type list). Releases are cut by release-please from the commit log.
+- `pnpm install && pnpm build && pnpm typecheck` must pass before opening a PR.
+- Feature branches → PR → `main` (protected). Rebase on latest `main`; never
+  merge `main` back into a feature branch.
+```
+
+- [ ] **Step 3: Add `LICENSE`** — MIT, copyright holder `Tristan Rivoallan`, year 2026 (match the core repo's license; copy its `LICENSE` text verbatim, updating only the project reference if the core's contains one).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md LICENSE
+git commit -m "docs: add README, CONTRIBUTING, and LICENSE"
+```
+
+---
+
+### Task 6: Remove the dropped GitLab live-backend feature from the SPA
+
+**Files:**
+
+- Delete: `src/pages/gitlab.tsx`, `src/components/GitLabMRList.tsx`, `src/components/MRComparison.tsx`, `src/components/TriggerAnalysis.tsx`
+- Modify: any navbar/config reference to the `/gitlab` route in `docusaurus.config.ts`
+
+Decision recorded in the spec: standalone is **static-preview-only**; the GitLab proxy/webhook backend is dropped. The SPA's `gitlab.tsx` page calls that backend and would be dead in the standalone build. Remove it and the three components it exclusively owns.
+
+The exact deletion set was determined against the source: `gitlab.tsx` imports `GitLabMRList`, `TriggerAnalysis`, and `MRComparison`, and a reference scan confirms those three are imported by **nothing** other than `gitlab.tsx` (and they do not import each other). Everything else — `ArchiveView`, `ReportProvider`, `SummaryView`, `AnalyzerPage`, all `*Section` components, and the `components/Dashboard/` chart cards — is used by `index.tsx`/the docs pages and must stay.
+
+- [ ] **Step 1: Re-confirm the deletion set is still exclusive (guard against drift since this plan was written)**
+
+```bash
+for c in GitLabMRList MRComparison TriggerAnalysis; do
+  echo "$c referenced outside gitlab.tsx + its own file:"
+  grep -rl "\b$c\b" src docs | grep -vE "src/components/$c.tsx|src/pages/gitlab.tsx" || echo "  (none — safe to delete)"
+done
+```
+
+Expected: each prints "(none — safe to delete)". If any prints a file, that component is now shared — stop and report it before deleting.
+
+- [ ] **Step 2: Delete the page and its three exclusive components**
+
+```bash
+git rm src/pages/gitlab.tsx \
+       src/components/GitLabMRList.tsx \
+       src/components/MRComparison.tsx \
+       src/components/TriggerAnalysis.tsx
+```
+
+- [ ] **Step 3: Remove the navbar/config link to `/gitlab`** in `docusaurus.config.ts` (delete the navbar item whose `to`/`href` is `/gitlab`, if present — `grep -n "gitlab" docusaurus.config.ts` locates it).
+
+- [ ] **Step 4: Verify the build is clean with no dangling references**
+
+```bash
+pnpm typecheck
+pnpm build
+grep -rn "gitlab" src/ docusaurus.config.ts || echo "OK: no gitlab references remain"
+```
+
+Expected: `typecheck` and `build` pass; "OK: no gitlab references remain" (or only incidental, non-code matches).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: drop GitLab live-backend page (static-preview-only)"
+```
+
+> **Out of scope (do not action here):** `src/components/PlaybookView.tsx` is referenced by nothing (not even `gitlab.tsx`) — it is **pre-existing dead code**, unrelated to the GitLab feature. Leave it; removing it is a separate cleanup, not part of this extraction.
+
+---
+
+### Task 7: release-please + Conventional Commits
+
+**Files:**
+
+- Create: `release-please-config.json`, `.release-please-manifest.json`
+
+- [ ] **Step 1: Create `release-please-config.json`**
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "bump-minor-pre-major": true,
+  "packages": {
+    ".": {
+      "package-name": "regis-dashboard"
+    }
+  }
+}
+```
+
+`bump-minor-pre-major: true` mirrors the core: pre-1.0 breaking changes bump minor, not major.
+
+- [ ] **Step 2: Create `.release-please-manifest.json`**
+
+```json
+{
+  ".": "0.0.0"
+}
+```
+
+- [ ] **Step 3: Verify config is valid JSON**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('release-please-config.json','utf8'));JSON.parse(require('fs').readFileSync('.release-please-manifest.json','utf8'));console.log('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add release-please-config.json .release-please-manifest.json
+git commit -m "ci: add release-please config (node, bump-minor-pre-major)"
+```
+
+---
+
+### Task 8: GitHub Pages deploy workflow
+
+**Files:**
+
+- Create: `.github/workflows/cd-pages.yml`
+
+- [ ] **Step 1: Write the Pages workflow**
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+        env:
+          REPORT_URL: https://trivoallan.github.io
+          REPORT_BASE_URL: /regis-dashboard/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+- [ ] **Step 2: Enable Pages (source = GitHub Actions)**
+
+```bash
+gh api -X POST repos/trivoallan/regis-dashboard/pages -f build_type=workflow 2>/dev/null || \
+  echo "Enable Pages → Settings → Pages → Source: GitHub Actions (if the API call 409s, it is already enabled)"
+```
+
+- [ ] **Step 3: Commit (do not push yet — Task 10 pushes everything)**
+
+```bash
+git add .github/workflows/cd-pages.yml
+git commit -m "ci: add GitHub Pages deploy workflow"
+```
+
+---
+
+### Task 9: PR-check + release-please workflows
+
+**Files:**
+
+- Create: `.github/workflows/ci.yml`, `.github/workflows/release-please.yml`
+
+- [ ] **Step 1: Write `ci.yml` (build + typecheck on PRs)**
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm build
+```
+
+- [ ] **Step 2: Write `release-please.yml`**
+
+```yaml
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/release-please.yml
+git commit -m "ci: add PR build check and release-please workflows"
+```
+
+---
+
+### Task 10: Push, verify Pages deploy, protect main
+
+**Files:** none (infra)
+
+- [ ] **Step 1: Push the prepared history**
+
+```bash
+git push -u origin main
+```
+
+Expected: push succeeds (the repo was empty on the remote; the filter-repo history + Tasks 2–9 commits land).
+
+- [ ] **Step 2: Verify the Pages deploy ran and the live site renders**
+
+```bash
+gh run watch --exit-status   # waits for the cd-pages run to finish green
+```
+
+Then load `https://trivoallan.github.io/regis-dashboard/` and confirm:
+
+- the summary page renders (not the "No report loaded" error state),
+- `https://trivoallan.github.io/regis-dashboard/report.json` returns the demo report with `schemaVersion: 1`.
+
+```bash
+curl -fsSL https://trivoallan.github.io/regis-dashboard/report.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log('live schemaVersion', JSON.parse(d).schemaVersion))"
+```
+
+Expected: `live schemaVersion 1`.
+
+- [ ] **Step 3: Protect `main`**
+
+```bash
+gh api -X PUT repos/trivoallan/regis-dashboard/branches/main/protection \
+  -F "required_status_checks[strict]=true" \
+  -F "required_status_checks[contexts][]=build" \
+  -F "enforce_admins=false" \
+  -F "required_pull_request_reviews[required_approving_review_count]=0" \
+  -F "restrictions=" 2>&1 | tail -3 || \
+  echo "If the API shape errors, set branch protection via Settings → Branches: require the CI 'build' check."
+```
+
+- [ ] **Step 4: Final verification checklist**
+
+- [ ] `pnpm install && pnpm build && pnpm typecheck` pass locally on a fresh clone.
+- [ ] No `gitlab`/backend references remain (`grep -rn gitlab src/`).
+- [ ] Pages site is live and serves the demo `report.json`.
+- [ ] `git log` in the new repo shows preserved `apps/dashboard` history plus the Task 2–9 commits.
+- [ ] release-please opened (or is ready to open) a release PR on the next push.
+
+---
+
+## Self-review notes (reconciled against the spec & decisions)
+
+- **Spec Phase-1 "git filter-repo of apps/dashboard, history preserved"** → Task 1.
+- **Spec Phase-1 "new-repo CI: pnpm build → dedicated GitHub Pages"** → Tasks 3, 4, 8, 10.
+- **Spec Phase-1 "release-please + Conventional Commits"** → Tasks 7, 9.
+- **Spec Phase-1 "Settings App / GitHub config (same pattern as core)"** → Task 1 Step 4 + Task 10 Step 3 (repo creation + branch protection via `gh`; a Settings-App `.github/settings.yml` can be added in 1b alongside the rest of CI — noted, not blocking 1a).
+- **Spec "No Memory Bank — README + CONTRIBUTING suffice"** → Task 5 (explicitly no memory-bank).
+- **Decision: static-preview-only (GitLab backend dropped)** → Task 6 removes `gitlab.tsx` and its exclusive components.
+- **Deferred to 1b/1c (correctly NOT here):** the `render`/`serve`/`archive`/`bootstrap` CLI, the Docker image, and the runtime `schemaVersion` compatibility gate. 1a ships a deployable site that renders a baked-in demo report; the CLI that feeds _arbitrary_ reports is 1b.
+
+## Risks / watch-points
+
+- **`pnpm-lock.yaml`**: `filter-repo` re-roots only `apps/dashboard/`, which historically had **no** lockfile (the lockfile lived at the monorepo root and is excluded). Task 2's `pnpm install` generates a fresh `regis-dashboard` lockfile — commit it (add to the Task 2 commit if `pnpm install` created it). CI uses `--frozen-lockfile`, so the lockfile **must** be committed or CI fails.
+- **`tsconfig.json` extends `@docusaurus/tsconfig`**: that dep is already in `devDependencies`, so standalone typecheck works. If `tsconfig.json` references a monorepo-root path, fix it in Task 2.
+- **Demo report drift**: Task 4 pins the demo to the core's `report.v1.json` at _fetch time_. Phase 1c formalizes this as a CI-fetched contract test; until then the demo is a static snapshot — acceptable.
+- **`gitlab.tsx` shared components**: Task 6 must not delete components also used by `index.tsx`/docs pages. The Step-1 inventory + the `grep -rl "<Component"` guard prevents over-deletion.

--- a/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1b-cli.md
+++ b/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1b-cli.md
@@ -1,0 +1,1349 @@
+# Phase 1b — regis-dashboard CLI & Docker Image — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a TypeScript CLI (`regis-dashboard`) to the standalone repo with `render`, `serve`, `archive add`, `archive configure`, and `bootstrap archive` commands, plus a published Docker image — porting the behavior currently in the Python core's `regis/report/docusaurus.py`, `regis/commands/archive.py`, `regis/commands/dashboard.py` (export), `regis/archive/store.py`, and the `archive` cookiecutter.
+
+**Architecture:** A `commander`-based CLI compiled with `tsc` to `dist/`. Pure data logic (archive summary, archive store, archives.json config) lives in `src/cli/lib/` as side-effect-free functions, unit-tested with `vitest` against the core's `report.v1.json` fixture. The `render`/`serve` commands are thin wrappers that stage `report.json` into `static/`, set `REPORT_BASE_URL`, and shell out to the project's own `docusaurus build`/`serve`. The Docker image bundles the dashboard source + `node_modules` + the compiled CLI so `docker run regis-dashboard render /data/report.json` works offline.
+
+**Tech Stack:** TypeScript, commander, vitest, Docusaurus 3.10 (the repo's own build), pnpm, Node ≥18, Docker (node:20-alpine), GitHub Actions, GHCR.
+
+---
+
+## Prerequisites & scope
+
+**Depends on:** Phase 1a complete (the standalone `regis-dashboard` repo exists, builds, and deploys). This plan runs **in that repo**, not in a core worktree.
+
+**This is Phase 1b of three** (see `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`). 1a = extraction; **1b (this) = CLI + Docker**; 1c = runtime `schemaVersion` compat + cross-repo contract test. 1b introduces `vitest`, which 1c reuses.
+
+**Ported behavior — source of truth in the core repo** (read these for exact semantics; do not import them — reimplement in TS):
+
+- `regis/archive/store.py` → `add_to_archive`, `_make_summary`, `_calculate_status`, `_safe_segment`, `_load_json_array`.
+- `regis/commands/archive.py` → `archive add` / `archive configure` CLI behavior + `_load_archives_config` / `_write_archives_config`.
+- `regis/report/docusaurus.py` → `_build_from_source` (the `render` flow: stage report.json into `static/`, set `REPORT_BASE_URL`, run the build, ensure `report.json` lands at output root).
+- `regis/commands/dashboard.py` → `export` (`-a Name:path` → `archives.json`) and the dropped `serve` (we keep only static preview).
+- `regis/cookiecutters/archive/` → the 5 files `bootstrap archive` emits.
+
+**Out of scope (1c):** the runtime `schemaVersion` gate in `ReportProvider`, the cross-repo contract test. **Dropped (decision):** the GitLab proxy / webhook backend — `serve` is static-preview-only.
+
+## File structure (new files in the repo)
+
+```text
+regis-dashboard/
+  src/cli/
+    index.ts                  # commander entry; registers all commands; bin target
+    lib/
+      summary.ts              # makeSummary() + calculateStatus()  (port of _make_summary/_calculate_status)
+      archiveStore.ts         # addToArchive()                     (port of add_to_archive)
+      archivesConfig.ts       # load/add/remove/list/write archives.json (port of archive.py)
+      paths.ts                # safeSegment(), tsSafe()            (port of _safe_segment + timestamp normalisation)
+    commands/
+      render.ts               # render <report> -o -A --base-url
+      serve.ts                # serve <report> -p
+      archiveAdd.ts           # archive add <report> -A --print-path
+      archiveConfigure.ts     # archive configure -o --add --remove --list
+      bootstrapArchive.ts     # bootstrap archive --platform
+    templates/archive/        # the 5 cookiecutter files, de-jinja'd (raw GH expressions kept verbatim)
+      .github/workflows/analyze.yml
+      .github/workflows/preview.yml
+      .github/workflows/.nojekyll
+      gitlab-ci.yml           # written out as .gitlab-ci.yml
+      regis-post-install.md   # written out as .regis-post-install.md
+  src/cli/__tests__/
+    summary.test.ts
+    archiveStore.test.ts
+    archivesConfig.test.ts
+    bootstrapArchive.test.ts
+  tsconfig.cli.json           # CLI build config (CommonJS/Node, outDir dist)
+  vitest.config.ts
+  Dockerfile
+  .dockerignore
+  .github/workflows/cd-docker.yml
+```
+
+`package.json` gains: `"bin": { "regis-dashboard": "dist/cli/index.js" }`, scripts `build:cli`, `test`, and devDeps `commander`, `vitest`, `@types/node`.
+
+---
+
+### Task 1: CLI scaffolding — commander entry, build, test runner
+
+**Files:**
+
+- Modify: `package.json`
+- Create: `tsconfig.cli.json`, `vitest.config.ts`, `src/cli/index.ts`
+
+- [ ] **Step 1: Add deps and scripts**
+
+```bash
+pnpm add commander
+pnpm add -D vitest @types/node
+```
+
+In `package.json`, add to `scripts`:
+
+```json
+    "build:cli": "tsc -p tsconfig.cli.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+```
+
+and add at top level:
+
+```json
+  "bin": { "regis-dashboard": "dist/cli/index.js" },
+```
+
+- [ ] **Step 2: Create `tsconfig.cli.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": ["src/cli/**/*.ts"],
+  "exclude": ["src/cli/__tests__/**", "node_modules"]
+}
+```
+
+- [ ] **Step 3: Create `vitest.config.ts`**
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/cli/__tests__/**/*.test.ts"],
+    environment: "node",
+  },
+});
+```
+
+- [ ] **Step 4: Create `src/cli/index.ts` (commander root)**
+
+```ts
+#!/usr/bin/env node
+import { Command } from "commander";
+import { registerRender } from "./commands/render";
+import { registerServe } from "./commands/serve";
+import { registerArchiveAdd } from "./commands/archiveAdd";
+import { registerArchiveConfigure } from "./commands/archiveConfigure";
+import { registerBootstrapArchive } from "./commands/bootstrapArchive";
+
+const program = new Command();
+program
+  .name("regis-dashboard")
+  .description("Render and serve regis container-security reports")
+  .version("0.0.0");
+
+registerRender(program);
+registerServe(program);
+registerArchiveAdd(program);
+registerArchiveConfigure(program);
+registerBootstrapArchive(program);
+
+program.parseAsync(process.argv);
+```
+
+- [ ] **Step 5: Create command stubs so the build compiles**
+
+For each of the five command modules, create a minimal stub now (they are filled in by later tasks). Example `src/cli/commands/render.ts`:
+
+```ts
+import { Command } from "commander";
+export function registerRender(program: Command): void {
+  program
+    .command("render")
+    .description("(implemented in Task 6)")
+    .action(() => {
+      throw new Error("not implemented");
+    });
+}
+```
+
+Create the analogous `registerServe`, `registerArchiveAdd`, `registerArchiveConfigure`, `registerBootstrapArchive` stubs.
+
+- [ ] **Step 6: Verify it builds and runs**
+
+```bash
+pnpm build:cli
+node dist/cli/index.js --help
+```
+
+Expected: help text lists `render`, `serve`, `archive add`/`configure` (added in Task 5), `bootstrap`. (Sub-grouped commands appear once their parent is registered.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml tsconfig.cli.json vitest.config.ts src/cli
+git commit -m "feat(cli): scaffold regis-dashboard CLI (commander + vitest)"
+```
+
+---
+
+### Task 2: Port the archive summary logic (TDD)
+
+**Files:**
+
+- Create: `src/cli/lib/paths.ts`, `src/cli/lib/summary.ts`
+- Test: `src/cli/__tests__/summary.test.ts`
+
+Port of `_make_summary` + `_calculate_status` + the timestamp/segment helpers from `regis/archive/store.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/cli/__tests__/summary.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { makeSummary, calculateStatus } from "../lib/summary";
+
+const baseReport = {
+  request: {
+    registry: "registry-1.docker.io",
+    repository: "library/nginx",
+    tag: "1.27",
+    digest: "sha256:abc",
+    timestamp: "2026-05-31T12:00:00+00:00",
+  },
+  rules_summary: { score: 100, passed: ["a"], total: ["a"] },
+  results: {
+    cve: { critical_count: 0, high_count: 1, medium_count: 4, low_count: 12 },
+  },
+  rules: [{ slug: "a", passed: true, level: "Gold" }],
+};
+
+describe("makeSummary", () => {
+  it("flattens a report into the manifest summary row", () => {
+    const s = makeSummary(
+      baseReport,
+      "registry-1.docker.io/library/nginx/1.27/x/report.json",
+    );
+    expect(s.id).toBe(
+      "registry-1.docker.io/library/nginx/1.27/2026-05-31T12-00-00",
+    );
+    expect(s.registry).toBe("registry-1.docker.io");
+    expect(s.repository).toBe("library/nginx");
+    expect(s.tag).toBe("1.27");
+    expect(s.score).toBe(100);
+    expect(s.rules_passed).toBe(1);
+    expect(s.rules_total).toBe(1);
+    expect(s.cve_critical).toBe(0);
+    expect(s.cve_high).toBe(1);
+    expect(s.path).toBe(
+      "registry-1.docker.io/library/nginx/1.27/x/report.json",
+    );
+    expect(s.status).toBe("pass");
+  });
+
+  it("derives status from the highest-severity failing rule", () => {
+    expect(
+      calculateStatus({ rules: [{ passed: false, level: "warning" }] }),
+    ).toBe("warning");
+    expect(
+      calculateStatus({
+        rules: [
+          { passed: false, level: "critical" },
+          { passed: false, level: "info" },
+        ],
+      }),
+    ).toBe("critical");
+    expect(
+      calculateStatus({ rules: [{ passed: true, level: "critical" }] }),
+    ).toBe("pass");
+    expect(calculateStatus({})).toBe("pass");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- summary`
+Expected: FAIL — module `../lib/summary` not found.
+
+- [ ] **Step 3: Implement `src/cli/lib/paths.ts`**
+
+```ts
+/** Replace characters unsafe for directory names (port of _safe_segment). */
+export function safeSegment(value: string): string {
+  return value.replace(/\//g, "_").replace(/\\/g, "_").replace(/:/g, "_");
+}
+
+/** Normalise an ISO timestamp to a filesystem-safe id fragment.
+ *  "2026-05-31T12:00:00+00:00" -> "2026-05-31T12-00-00"  (no suffix)
+ *  Pass suffix "Z" to mirror the archive directory naming. */
+export function tsSafe(timestamp: string, suffix = ""): string {
+  const noFrac = timestamp.split(".")[0];
+  return noFrac.replace(/:/g, "-").replace(/\+/g, "") + suffix;
+}
+```
+
+- [ ] **Step 4: Implement `src/cli/lib/summary.ts`**
+
+```ts
+import { tsSafe } from "./paths";
+
+type Report = Record<string, any>;
+
+const LEVEL_RANK: Record<string, number> = { critical: 1, warning: 2, info: 3 };
+const RANK_LEVEL: Record<number, string> = {
+  1: "critical",
+  2: "warning",
+  3: "info",
+};
+
+/** Port of _calculate_status: highest-severity failing rule level, else "pass". */
+export function calculateStatus(report: Report): string {
+  const rules: Report[] = report.rules ?? [];
+  if (rules.length === 0 && !report.rules_summary) return "pass";
+  let maxRank = 99;
+  for (const r of rules) {
+    if (!r.passed) {
+      const lvl = String(r.level ?? "info").toLowerCase();
+      const rank = LEVEL_RANK[lvl] ?? 3;
+      if (rank < maxRank) maxRank = rank;
+    }
+  }
+  return RANK_LEVEL[maxRank] ?? "pass";
+}
+
+/** Port of _make_summary: flat manifest row from a full report. */
+export function makeSummary(report: Report, path: string): Report {
+  const req: Report = report.request ?? {};
+  const registry = req.registry ?? "unknown";
+  const repository = req.repository ?? "unknown";
+  const tag = req.tag ?? "unknown";
+  const timestamp = req.timestamp ?? new Date().toISOString();
+  const id = `${registry}/${repository}/${tag}/${tsSafe(timestamp)}`;
+
+  const rs: Report = report.rules_summary ?? {};
+  const passedRaw = rs.passed ?? 0;
+  const totalRaw = rs.total ?? 0;
+  const rulesPassed = Array.isArray(passedRaw)
+    ? passedRaw.length
+    : Number(passedRaw || 0);
+  const rulesTotal = Array.isArray(totalRaw)
+    ? totalRaw.length
+    : Number(totalRaw || 0);
+  const score = Number(rs.score ?? 0) | 0;
+
+  const pb = report.playbook ?? (report.playbooks ?? [{}])[0];
+  const tier =
+    report.tier ?? (pb && typeof pb === "object" ? pb.tier : null) ?? null;
+
+  const results: Report = report.results ?? {};
+  const cve: Report = results.cve ?? {};
+  const freshness: Report = results.freshness ?? {};
+  const sbom: Report = results.sbom ?? {};
+  const scorecard: Report = results.scorecarddev ?? {};
+
+  return {
+    id,
+    timestamp,
+    registry,
+    repository,
+    tag,
+    digest: req.digest ?? null,
+    score,
+    tier,
+    rules_passed: rulesPassed,
+    rules_total: rulesTotal,
+    cve_critical: cve.critical_count ?? null,
+    cve_high: cve.high_count ?? null,
+    cve_medium: cve.medium_count ?? null,
+    cve_low: cve.low_count ?? null,
+    age_days: freshness.age_days ?? null,
+    sbom_component_count: sbom.component_count ?? null,
+    scorecard_score: scorecard.score ?? null,
+    status: calculateStatus(report),
+    path,
+  };
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm test -- summary`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/lib/paths.ts src/cli/lib/summary.ts src/cli/__tests__/summary.test.ts
+git commit -m "feat(cli): port archive summary + status logic"
+```
+
+---
+
+### Task 3: Port the archive store (TDD)
+
+**Files:**
+
+- Create: `src/cli/lib/archiveStore.ts`
+- Test: `src/cli/__tests__/archiveStore.test.ts`
+
+Port of `add_to_archive` + `_load_json_array` from `regis/archive/store.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/cli/__tests__/archiveStore.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addToArchive } from "../lib/archiveStore";
+
+function report(tag: string, ts: string) {
+  return {
+    request: {
+      registry: "r",
+      repository: "repo",
+      tag,
+      digest: "sha256:x",
+      timestamp: ts,
+    },
+    rules_summary: { score: 90, passed: [], total: [] },
+    rules: [],
+  };
+}
+
+describe("addToArchive", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "arch-"));
+  });
+
+  it("writes report.json under registry/repo/tag/timestampZ and a manifest", () => {
+    const p = addToArchive(report("1.0", "2026-05-31T10:00:00+00:00"), dir);
+    expect(p).toContain(join("r", "repo", "1.0"));
+    expect(p.endsWith("report.json")).toBe(true);
+    expect(existsSync(p)).toBe(true);
+
+    const manifest = JSON.parse(
+      readFileSync(join(dir, "manifest.json"), "utf8"),
+    );
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].tag).toBe("1.0");
+    expect(manifest[0].path).toMatch(/^r\/repo\/1\.0\/.*\/report\.json$/);
+
+    // data.json mirrors manifest.json
+    const data = JSON.parse(readFileSync(join(dir, "data.json"), "utf8"));
+    expect(data).toEqual(manifest);
+  });
+
+  it("replaces an entry with the same id and sorts by timestamp desc", () => {
+    addToArchive(report("1.0", "2026-05-30T10:00:00+00:00"), dir);
+    addToArchive(report("2.0", "2026-05-31T10:00:00+00:00"), dir);
+    // re-add 1.0 with same timestamp → same id → replaced, not duplicated
+    addToArchive(report("1.0", "2026-05-30T10:00:00+00:00"), dir);
+
+    const manifest = JSON.parse(
+      readFileSync(join(dir, "manifest.json"), "utf8"),
+    );
+    expect(manifest).toHaveLength(2);
+    expect(manifest[0].tag).toBe("2.0"); // newest first
+    expect(manifest[1].tag).toBe("1.0");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- archiveStore`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/cli/lib/archiveStore.ts`**
+
+```ts
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join, relative, sep, posix } from "node:path";
+import { makeSummary } from "./summary";
+import { safeSegment, tsSafe } from "./paths";
+
+type Report = Record<string, any>;
+
+function loadJsonArray(path: string): Report[] {
+  if (!existsSync(path)) return [];
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8"));
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Port of add_to_archive. Returns the absolute path to the written report.json. */
+export function addToArchive(
+  report: Report,
+  archiveDir: string,
+  pretty = true,
+): string {
+  mkdirSync(archiveDir, { recursive: true });
+  const req: Report = report.request ?? {};
+  const registry = safeSegment(req.registry ?? "unknown");
+  const repository = safeSegment(req.repository ?? "unknown");
+  const tag = safeSegment(req.tag ?? "unknown");
+  const timestamp = req.timestamp ?? new Date().toISOString();
+  const tsDir = tsSafe(timestamp, "Z");
+
+  const reportDir = join(archiveDir, registry, repository, tag, tsDir);
+  mkdirSync(reportDir, { recursive: true });
+  const reportPath = join(reportDir, "report.json");
+
+  const indent = pretty ? 2 : undefined;
+  writeFileSync(reportPath, JSON.stringify(report, null, indent), "utf8");
+
+  // relative posix path for the manifest
+  const relativePath = relative(archiveDir, reportPath)
+    .split(sep)
+    .join(posix.sep);
+  const summary = makeSummary(report, relativePath);
+
+  const manifestPath = join(archiveDir, "manifest.json");
+  let manifest = loadJsonArray(manifestPath).filter((e) => e.id !== summary.id);
+  manifest.push(summary);
+  manifest.sort((a, b) =>
+    String(b.timestamp ?? "").localeCompare(String(a.timestamp ?? "")),
+  );
+
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, indent), "utf8");
+  writeFileSync(
+    join(archiveDir, "data.json"),
+    JSON.stringify(manifest, null, indent),
+    "utf8",
+  );
+
+  return reportPath;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test -- archiveStore`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/lib/archiveStore.ts src/cli/__tests__/archiveStore.test.ts
+git commit -m "feat(cli): port archive store (addToArchive + manifest)"
+```
+
+---
+
+### Task 4: `archive add` command
+
+**Files:**
+
+- Modify: `src/cli/commands/archiveAdd.ts`
+
+Port of `regis archive add` (`regis/commands/archive.py`).
+
+- [ ] **Step 1: Implement the command**
+
+```ts
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { addToArchive } from "../lib/archiveStore";
+
+export function registerArchiveAdd(program: Command): void {
+  const archive =
+    program.commands.find((c) => c.name() === "archive") ??
+    program.command("archive").description("Manage the report archive");
+
+  archive
+    .command("add <report_file>")
+    .requiredOption(
+      "-A, --archive-dir <dir>",
+      "Archive directory to add the report to",
+    )
+    .option(
+      "--print-path",
+      "Print only the archived report path (machine-readable)",
+      false,
+    )
+    .action(
+      (
+        reportFile: string,
+        opts: { archiveDir: string; printPath: boolean },
+      ) => {
+        let report: unknown;
+        try {
+          report = JSON.parse(readFileSync(resolve(reportFile), "utf8"));
+        } catch (e) {
+          throw new Error(
+            `Could not read ${reportFile}: ${(e as Error).message}`,
+          );
+        }
+        const dest = addToArchive(
+          report as Record<string, any>,
+          resolve(opts.archiveDir),
+        );
+        if (opts.printPath) {
+          process.stdout.write(dest + "\n");
+        } else {
+          process.stderr.write(`Archived to ${dest}\n`);
+        }
+      },
+    );
+}
+```
+
+Note: the `archive` parent command is shared between `archive add` (Task 4) and `archive configure` (Task 5). The `find(...) ?? program.command(...)` idiom registers the parent once. Whichever of Tasks 4/5 runs first creates it; the other reuses it.
+
+- [ ] **Step 2: Smoke test**
+
+```bash
+pnpm build:cli
+echo '{"schemaVersion":1,"version":"0.33.0","request":{"url":"r/repo:1","registry":"r","repository":"repo","tag":"1","analyzers":[],"timestamp":"2026-05-31T10:00:00+00:00"},"results":{}}' > /tmp/r.json
+node dist/cli/index.js archive add /tmp/r.json -A /tmp/arch --print-path
+test -f /tmp/arch/manifest.json && echo "OK manifest written"
+```
+
+Expected: prints the archived report path; "OK manifest written".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/commands/archiveAdd.ts
+git commit -m "feat(cli): add 'archive add' command"
+```
+
+---
+
+### Task 5: `archive configure` + archives.json config (TDD)
+
+**Files:**
+
+- Create: `src/cli/lib/archivesConfig.ts`
+- Test: `src/cli/__tests__/archivesConfig.test.ts`
+- Modify: `src/cli/commands/archiveConfigure.ts`
+
+Port of `_load_archives_config` / `_write_archives_config` and the `archive configure` flags (`--add`/`--remove`/`--list`) from `regis/commands/archive.py`. The archives.json shape is `{ "archives": [{ "name", "path" }] }` (from `regis/schemas/archives.schema.json`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/cli/__tests__/archivesConfig.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadArchives,
+  addArchive,
+  removeArchive,
+  writeArchives,
+} from "../lib/archivesConfig";
+
+describe("archivesConfig", () => {
+  let file: string;
+  beforeEach(() => {
+    file = join(mkdtempSync(join(tmpdir(), "cfg-")), "archives.json");
+  });
+
+  it("adds an entry and round-trips the {archives:[...]} shape", () => {
+    const next = addArchive(
+      loadArchives(file),
+      "Prod",
+      "https://x/manifest.json",
+    );
+    writeArchives(file, next);
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    expect(parsed).toEqual({
+      archives: [{ name: "Prod", path: "https://x/manifest.json" }],
+    });
+  });
+
+  it("rejects a duplicate name", () => {
+    const one = addArchive([], "Prod", "a");
+    expect(() => addArchive(one, "Prod", "b")).toThrow(/already exists/);
+  });
+
+  it("removes by name and errors when absent", () => {
+    const one = addArchive([], "Prod", "a");
+    expect(removeArchive(one, "Prod")).toEqual([]);
+    expect(() => removeArchive([], "Nope")).toThrow(/not found/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test -- archivesConfig`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/cli/lib/archivesConfig.ts`**
+
+```ts
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface ArchiveEntry {
+  name: string;
+  path: string;
+}
+
+export function loadArchives(file: string): ArchiveEntry[] {
+  if (!existsSync(file)) return [];
+  try {
+    const data = JSON.parse(readFileSync(file, "utf8"));
+    return Array.isArray(data?.archives) ? data.archives : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addArchive(
+  archives: ArchiveEntry[],
+  name: string,
+  path: string,
+): ArchiveEntry[] {
+  if (!name.trim() || !path.trim())
+    throw new Error("Name and path must not be empty.");
+  if (archives.some((a) => a.name === name)) {
+    throw new Error(
+      `Archive '${name}' already exists. Remove it first with --remove.`,
+    );
+  }
+  return [...archives, { name, path }];
+}
+
+export function removeArchive(
+  archives: ArchiveEntry[],
+  name: string,
+): ArchiveEntry[] {
+  const next = archives.filter((a) => a.name !== name);
+  if (next.length === archives.length)
+    throw new Error(`Archive '${name}' not found.`);
+  return next;
+}
+
+export function writeArchives(file: string, archives: ArchiveEntry[]): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify({ archives }, null, 2) + "\n", "utf8");
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test -- archivesConfig`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Implement the `archive configure` command** in `src/cli/commands/archiveConfigure.ts`
+
+```ts
+import { Command } from "commander";
+import { resolve } from "node:path";
+import {
+  loadArchives,
+  addArchive,
+  removeArchive,
+  writeArchives,
+} from "../lib/archivesConfig";
+
+export function registerArchiveConfigure(program: Command): void {
+  const archive =
+    program.commands.find((c) => c.name() === "archive") ??
+    program.command("archive").description("Manage the report archive");
+
+  archive
+    .command("configure")
+    .option("-o, --output <file>", "Path to archives.json", "archives.json")
+    .option("--add <entry>", 'Add an archive: "Name:path-or-url"')
+    .option("--remove <name>", "Remove an archive by name")
+    .option("--list", "List configured archives and exit", false)
+    .action(
+      (opts: {
+        output: string;
+        add?: string;
+        remove?: string;
+        list: boolean;
+      }) => {
+        const file = resolve(opts.output);
+        let archives = loadArchives(file);
+
+        if (opts.list) {
+          if (archives.length === 0)
+            process.stderr.write("No archives configured.\n");
+          else
+            archives.forEach((a) =>
+              process.stdout.write(`  ${a.name}: ${a.path}\n`),
+            );
+          return;
+        }
+        if (opts.remove) {
+          archives = removeArchive(archives, opts.remove);
+          writeArchives(file, archives);
+          process.stderr.write(
+            `Removed '${opts.remove}'. ${archives.length} remaining.\n`,
+          );
+          return;
+        }
+        if (opts.add) {
+          const idx = opts.add.indexOf(":");
+          if (idx < 0)
+            throw new Error(
+              `Invalid format: ${opts.add}. Expected "Name:path-or-url".`,
+            );
+          const name = opts.add.slice(0, idx);
+          const path = opts.add.slice(idx + 1);
+          archives = addArchive(archives, name, path);
+          writeArchives(file, archives);
+          process.stderr.write(`Added '${name}' -> ${path}\n`);
+          return;
+        }
+        process.stderr.write(
+          'Nothing to do. Use --add "Name:path", --remove NAME, or --list.\n',
+        );
+      },
+    );
+}
+```
+
+(The Python interactive prompt mode is intentionally dropped — non-interactive flags only, which is what CI uses.)
+
+- [ ] **Step 6: Verify build + smoke**
+
+```bash
+pnpm build:cli
+node dist/cli/index.js archive configure -o /tmp/archives.json --add "Prod:https://x/manifest.json"
+node dist/cli/index.js archive configure -o /tmp/archives.json --list
+```
+
+Expected: writes `/tmp/archives.json`; `--list` prints `Prod: https://x/manifest.json`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/lib/archivesConfig.ts src/cli/__tests__/archivesConfig.test.ts src/cli/commands/archiveConfigure.ts
+git commit -m "feat(cli): add 'archive configure' command + archives.json config"
+```
+
+---
+
+### Task 6: `render` command
+
+**Files:**
+
+- Modify: `src/cli/commands/render.ts`
+
+Port of `_build_from_source` (`regis/report/docusaurus.py`) + the `-a` archives option from `dashboard export`. In the standalone repo the CLI lives **inside** the Docusaurus project, so `render` stages files into the project's own `static/` and runs its own build.
+
+- [ ] **Step 1: Implement the command**
+
+```ts
+import { Command } from "commander";
+import { execFileSync } from "node:child_process";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  cpSync,
+  existsSync,
+  copyFileSync,
+} from "node:fs";
+import { resolve, join, dirname } from "node:path";
+
+// Repo root = two levels up from dist/cli/ (or src/cli/ in ts-node). Resolved at runtime.
+function repoRoot(): string {
+  // dist/cli/index.js -> dist/cli -> dist -> repo root
+  return resolve(__dirname, "..", "..");
+}
+
+function parseArchives(entries: string[]): { name: string; path: string }[] {
+  return entries.map((e) => {
+    const idx = e.indexOf(":");
+    if (idx < 0)
+      throw new Error(`Invalid archive ${e}. Expected "Name:path-or-url".`);
+    return { name: e.slice(0, idx), path: e.slice(idx + 1) };
+  });
+}
+
+export function registerRender(program: Command): void {
+  program
+    .command("render <report>")
+    .description("Build a static report site from a report.json")
+    .requiredOption(
+      "-o, --output <dir>",
+      "Directory to write the static site into",
+    )
+    .option("--base-url <url>", "Base URL for the site (e.g. /reports/)", "/")
+    .option(
+      "-a, --archive <entry...>",
+      'Named archive "Name:path-or-url" (repeatable)',
+    )
+    .action(
+      (
+        report: string,
+        opts: { output: string; baseUrl: string; archive?: string[] },
+      ) => {
+        const root = repoRoot();
+        const staticDir = join(root, "static");
+        mkdirSync(staticDir, { recursive: true });
+
+        // 1. stage report.json
+        const reportData = readFileSync(resolve(report), "utf8");
+        writeFileSync(join(staticDir, "report.json"), reportData, "utf8");
+
+        // 2. stage archives.json if provided
+        if (opts.archive?.length) {
+          const archives = parseArchives(opts.archive);
+          writeFileSync(
+            join(staticDir, "archives.json"),
+            JSON.stringify({ archives }, null, 2),
+            "utf8",
+          );
+        }
+
+        // 3. run the project's own docusaurus build with REPORT_BASE_URL set
+        const baseUrl = opts.baseUrl.endsWith("/")
+          ? opts.baseUrl
+          : opts.baseUrl + "/";
+        execFileSync("pnpm", ["run", "build"], {
+          cwd: root,
+          env: {
+            ...process.env,
+            REPORT_BASE_URL: baseUrl,
+            NODE_ENV: "production",
+          },
+          stdio: "inherit",
+        });
+
+        // 4. copy build/ to the output dir, ensuring report.json at the root
+        const outDir = resolve(opts.output);
+        mkdirSync(outDir, { recursive: true });
+        cpSync(join(root, "build"), outDir, { recursive: true });
+        const outReport = join(outDir, "report.json");
+        if (!existsSync(outReport)) {
+          mkdirSync(dirname(outReport), { recursive: true });
+          copyFileSync(join(staticDir, "report.json"), outReport);
+        }
+        process.stderr.write(`Report site written to ${outDir}\n`);
+      },
+    );
+}
+```
+
+- [ ] **Step 2: Smoke test (uses the demo report from Phase 1a)**
+
+```bash
+pnpm build:cli
+node dist/cli/index.js render static/report.json -o /tmp/site --base-url /
+test -f /tmp/site/index.html && test -f /tmp/site/report.json && echo "OK render produced a site with report.json"
+```
+
+Expected: the build runs and "OK render produced a site with report.json" prints.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/commands/render.ts
+git commit -m "feat(cli): add 'render' command (static report site build)"
+```
+
+---
+
+### Task 7: `serve` command
+
+**Files:**
+
+- Modify: `src/cli/commands/serve.ts`
+
+Static preview only (GitLab/webhook backend dropped). Stage the report, then run the project's own `docusaurus serve` after a build, or `docusaurus start` for live reload.
+
+- [ ] **Step 1: Implement the command**
+
+```ts
+import { Command } from "commander";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+function repoRoot(): string {
+  return resolve(__dirname, "..", "..");
+}
+
+export function registerServe(program: Command): void {
+  program
+    .command("serve <report>")
+    .description("Build and serve a report locally (static preview)")
+    .option("-p, --port <port>", "Port to listen on", "8000")
+    .action((report: string, opts: { port: string }) => {
+      const root = repoRoot();
+      const staticDir = join(root, "static");
+      mkdirSync(staticDir, { recursive: true });
+      writeFileSync(
+        join(staticDir, "report.json"),
+        readFileSync(resolve(report), "utf8"),
+        "utf8",
+      );
+
+      // Build once, then serve the static output (matches the dropped FastAPI preview's behavior).
+      execFileSync("pnpm", ["run", "build"], {
+        cwd: root,
+        env: { ...process.env, REPORT_BASE_URL: "/", NODE_ENV: "production" },
+        stdio: "inherit",
+      });
+      execFileSync("pnpm", ["run", "serve", "--", "--port", opts.port], {
+        cwd: root,
+        stdio: "inherit",
+      });
+    });
+}
+```
+
+- [ ] **Step 2: Manual verification (documented, not automated — serve is long-running)**
+
+```bash
+pnpm build:cli
+node dist/cli/index.js serve static/report.json -p 8123 &
+sleep 8
+curl -fsSL http://localhost:8123/report.json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log('schemaVersion',JSON.parse(d).schemaVersion))"
+kill %1
+```
+
+Expected: prints `schemaVersion 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/commands/serve.ts
+git commit -m "feat(cli): add 'serve' command (static preview)"
+```
+
+---
+
+### Task 8: `bootstrap archive` command + templates (TDD)
+
+**Files:**
+
+- Create: `src/cli/templates/archive/**` (the 5 files, copied verbatim from the core cookiecutter output)
+- Modify: `src/cli/commands/bootstrapArchive.ts`
+- Test: `src/cli/__tests__/bootstrapArchive.test.ts`
+
+The core cookiecutter does **no** real variable substitution (all GitHub `${{ }}` expressions are raw-wrapped, the image is hardcoded to `:main`). So `bootstrap archive` is a fixed file-copy with a platform-conditional deletion: `github` keeps `.github/`, drops `.gitlab-ci.yml`; `gitlab` keeps `.gitlab-ci.yml`, drops `.github/`.
+
+- [ ] **Step 1: Copy the template files from the core**
+
+From a core checkout, copy the **rendered** template tree (after cookiecutter strips `{% raw %}`/`{% endraw %}` — i.e. copy the literal file bodies the core ships, removing only the Jinja raw markers) into `src/cli/templates/archive/`:
+
+- `.github/workflows/analyze.yml`
+- `.github/workflows/preview.yml`
+- `.github/workflows/.nojekyll`
+- `gitlab-ci.yml` (will be written out as `.gitlab-ci.yml`)
+- `regis-post-install.md` (written out as `.regis-post-install.md`)
+
+When copying, replace any `{% raw %}` / `{% endraw %}` markers with nothing (the GitHub `${{ ... }}` expressions stay verbatim).
+
+- [ ] **Step 2: Write the failing test**
+
+`src/cli/__tests__/bootstrapArchive.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scaffoldArchive } from "../commands/bootstrapArchive";
+
+describe("scaffoldArchive", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "boot-"));
+  });
+
+  it("github platform keeps .github and drops .gitlab-ci.yml", () => {
+    scaffoldArchive(dir, "github");
+    expect(existsSync(join(dir, ".github/workflows/analyze.yml"))).toBe(true);
+    expect(existsSync(join(dir, ".github/workflows/preview.yml"))).toBe(true);
+    expect(existsSync(join(dir, ".gitlab-ci.yml"))).toBe(false);
+    expect(existsSync(join(dir, ".regis-post-install.md"))).toBe(true);
+  });
+
+  it("gitlab platform keeps .gitlab-ci.yml and drops .github", () => {
+    scaffoldArchive(dir, "gitlab");
+    expect(existsSync(join(dir, ".gitlab-ci.yml"))).toBe(true);
+    expect(existsSync(join(dir, ".github"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pnpm test -- bootstrapArchive`
+Expected: FAIL — `scaffoldArchive` not exported.
+
+- [ ] **Step 4: Implement `src/cli/commands/bootstrapArchive.ts`**
+
+```ts
+import { Command } from "commander";
+import { cpSync, mkdirSync, copyFileSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+function templatesDir(): string {
+  return resolve(__dirname, "..", "templates", "archive");
+}
+
+/** Scaffold an archive project into outDir for the given platform. Pure-ish (filesystem only). */
+export function scaffoldArchive(
+  outDir: string,
+  platform: "github" | "gitlab",
+): void {
+  const tpl = templatesDir();
+  mkdirSync(outDir, { recursive: true });
+
+  // always: the post-install note
+  copyFileSync(
+    join(tpl, "regis-post-install.md"),
+    join(outDir, ".regis-post-install.md"),
+  );
+
+  if (platform === "github") {
+    cpSync(join(tpl, ".github"), join(outDir, ".github"), { recursive: true });
+  } else {
+    copyFileSync(join(tpl, "gitlab-ci.yml"), join(outDir, ".gitlab-ci.yml"));
+  }
+}
+
+export function registerBootstrapArchive(program: Command): void {
+  const bootstrap =
+    program.commands.find((c) => c.name() === "bootstrap") ??
+    program.command("bootstrap").description("Scaffold archive/CI projects");
+
+  bootstrap
+    .command("archive")
+    .description(
+      "Scaffold a report-archive project with CI for GitHub or GitLab Pages",
+    )
+    .requiredOption("-o, --output <dir>", "Directory to scaffold into")
+    .option("--platform <platform>", "github | gitlab", "github")
+    .action((opts: { output: string; platform: "github" | "gitlab" }) => {
+      if (opts.platform !== "github" && opts.platform !== "gitlab") {
+        throw new Error(
+          `--platform must be 'github' or 'gitlab', got '${opts.platform}'`,
+        );
+      }
+      const out = resolve(opts.output);
+      if (
+        existsSync(join(out, ".github")) ||
+        existsSync(join(out, ".gitlab-ci.yml"))
+      ) {
+        throw new Error(`${out} already contains an archive scaffold.`);
+      }
+      scaffoldArchive(out, opts.platform);
+      process.stderr.write(
+        `Scaffolded ${opts.platform} archive project in ${out}\n`,
+      );
+    });
+}
+```
+
+- [ ] **Step 5: Run to verify pass + ensure templates ship in the build**
+
+The templates are non-`.ts` assets; `tsc` does not copy them. Add a copy step to `build:cli` so `dist/cli/templates/` exists:
+
+```json
+    "build:cli": "tsc -p tsconfig.cli.json && cp -r src/cli/templates dist/cli/templates",
+```
+
+Then:
+
+```bash
+pnpm test -- bootstrapArchive
+pnpm build:cli
+node dist/cli/index.js bootstrap archive -o /tmp/boot --platform gitlab && test -f /tmp/boot/.gitlab-ci.yml && echo OK
+```
+
+Expected: tests PASS; "OK".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/templates src/cli/commands/bootstrapArchive.ts src/cli/__tests__/bootstrapArchive.test.ts package.json
+git commit -m "feat(cli): add 'bootstrap archive' command + templates"
+```
+
+---
+
+### Task 9: Dockerfile + image publish workflow
+
+**Files:**
+
+- Create: `Dockerfile`, `.dockerignore`, `.github/workflows/cd-docker.yml`
+
+- [ ] **Step 1: Write the `Dockerfile`**
+
+The image must contain the dashboard source + `node_modules` + the compiled CLI so `render`/`serve` can run `docusaurus build` offline.
+
+```dockerfile
+FROM node:20-alpine AS build
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build:cli
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+RUN corepack enable
+ENV NODE_ENV=production
+COPY --from=build /app /app
+# the CLI is the entrypoint; default workdir for user data is /data
+WORKDIR /data
+ENTRYPOINT ["node", "/app/dist/cli/index.js"]
+CMD ["--help"]
+```
+
+- [ ] **Step 2: Write `.dockerignore`**
+
+```dockerignore
+node_modules
+build
+.docusaurus
+.git
+*.log
+```
+
+(Do not ignore `pnpm-lock.yaml` — it is needed for `--frozen-lockfile`.)
+
+- [ ] **Step 3: Local build + run smoke test**
+
+```bash
+docker build -t regis-dashboard:dev .
+docker run --rm -v "$PWD/static:/data" regis-dashboard:dev render /data/report.json -o /data/out
+test -f static/out/index.html && echo "OK docker render"
+```
+
+Expected: image builds; "OK docker render".
+
+- [ ] **Step 4: Write `.github/workflows/cd-docker.yml`**
+
+```yaml
+name: Publish Docker image
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/trivoallan/regis-dashboard
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+(release-please tags `v*` on release → this publishes `ghcr.io/trivoallan/regis-dashboard:<version>` and `:latest`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile .dockerignore .github/workflows/cd-docker.yml
+git commit -m "ci: add Dockerfile and GHCR publish workflow"
+```
+
+---
+
+### Task 10: Wire CLI checks into CI + update README
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml` (from 1a), `README.md`
+
+- [ ] **Step 1: Add test + CLI build to the PR CI**
+
+In `.github/workflows/ci.yml`, after the existing `pnpm build` step, add:
+
+```yaml
+- run: pnpm test
+- run: pnpm build:cli
+```
+
+- [ ] **Step 2: Update the README "Status"/usage section** to document the CLI:
+
+```markdown
+## Use the CLI
+
+    # render a static site from a report
+    docker run --rm -v "$PWD:/data" ghcr.io/trivoallan/regis-dashboard render /data/report.json -o /data/site
+
+    # live preview
+    docker run --rm -p 8000:8000 -v "$PWD:/data" ghcr.io/trivoallan/regis-dashboard serve /data/report.json
+
+    # manage a multi-report archive
+    regis-dashboard archive add report.json -A ./archive
+    regis-dashboard archive configure --add "Prod:https://example.com/manifest.json"
+    regis-dashboard bootstrap archive -o ./my-archive --platform github
+```
+
+- [ ] **Step 3: Verify the full check suite locally**
+
+```bash
+pnpm install
+pnpm typecheck
+pnpm test
+pnpm build:cli
+pnpm build
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml README.md
+git commit -m "ci: run CLI tests + build in PR checks; document CLI in README"
+```
+
+---
+
+## Self-review notes (reconciled against the spec & ports)
+
+- **Spec Phase-1 "rewrite render/serve/bootstrap archive/archive add|configure JS-first"** → Tasks 6, 7, 8, 4, 5.
+- **Ported logic fidelity:** `summary.ts`/`archiveStore.ts` mirror `_make_summary`/`_calculate_status`/`add_to_archive` (same `_SUMMARY_KEYS`, same id format `{registry}/{repo}/{tag}/{ts-safe}`, same `Z`-suffixed dir, same manifest replace-by-id + timestamp-desc sort, same `data.json == manifest.json`). `archivesConfig.ts` mirrors the `{archives:[{name,path}]}` schema and the add/remove/list flags.
+- **`render` fidelity:** stages `report.json` into `static/`, sets `REPORT_BASE_URL`, runs the project build, copies `build/`→output, ensures `report.json` at output root — same four steps as `_build_from_source`.
+- **Dropped behavior (intentional):** the Python `archive configure` interactive prompt (CI uses flags); the `dashboard serve` GitLab/webhook backend (static-preview-only decision).
+- **Deferred to 1c (correctly NOT here):** the runtime `schemaVersion` compatibility gate and the cross-repo contract test. `vitest` is introduced here and reused there.
+
+## Risks / watch-points
+
+- **`repoRoot()` resolution:** `render`/`serve` assume the compiled CLI sits at `dist/cli/index.js` two levels under the repo root, and that the Docusaurus project (with `node_modules`) is at that root. This holds in the Docker image (Task 9) and in a local `pnpm build:cli` checkout. If the CLI is ever published to npm standalone (without the Docusaurus project), `render`/`serve` would need the project path injected — note for a future task, not needed for the Docker-primary distribution.
+- **Templates in the build output:** `tsc` ignores non-TS files, so Task 8 Step 5 adds an explicit `cp` of `src/cli/templates` → `dist/cli/templates`. Without it, `bootstrap archive` fails at runtime. The test runs against `src/` paths, so it passes even if the copy is forgotten — the Step-5 smoke run against `dist/` is what catches a missing copy.
+- **`pnpm` availability inside `render`/`serve`:** both shell out to `pnpm run build`. The Docker image enables corepack; a bare npm-only environment would fail. Documented as Docker-primary.
+- **Timestamp helper divergence:** `tsSafe` must match the Python `.replace(":", "-").replace("+", "").split(".")[0]` exactly (the `id` is the manifest dedup key). The `summary.test.ts` `id` assertion guards this.

--- a/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1c-compat-contract.md
+++ b/docs/superpowers/plans/2026-05-31-dashboard-decouple-phase1c-compat-contract.md
@@ -1,0 +1,484 @@
+# Phase 1c — Runtime schemaVersion Compatibility + Cross-Repo Contract Test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `regis-dashboard` gate rendering on the report's integer `schemaVersion` at runtime, and add a cross-repo contract test so the dashboard's CI fails loudly if the core's report contract drifts beyond what this dashboard supports.
+
+**Architecture:** A pure `checkSchemaCompat(schemaVersion)` function declares the dashboard's supported range and returns one of `ok` / `best-effort` / `unsupported`. `ReportProvider` calls it right after parsing `report.json`: `unsupported` routes to the existing error UI (no broken render); `best-effort` (missing `schemaVersion`, treated as 0) renders with a non-blocking banner; `ok` renders normally. Two layers of contract testing: an **offline** vitest test asserts the committed demo report (the core's `report.v1.json`) is `ok`, and a **live** scheduled CI job fetches the core's fixture from GitHub and re-asserts, catching drift between the two repos.
+
+**Tech Stack:** TypeScript, React 19, vitest (introduced in 1b), GitHub Actions.
+
+---
+
+## Prerequisites & scope
+
+**Depends on:** Phase 1a (standalone repo) **and** Phase 1b (vitest + the CLI). This plan runs **in the `regis-dashboard` repo**.
+
+**This is Phase 1c of three** (see `docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`). It implements the spec's runtime-only compatibility model: _"Enforcement is 100% runtime, dashboard-side… The dashboard declares the schemaVersion range each release can render."_ and the cross-repo contract test: _"regis-dashboard CI fetches these fixtures (raw GitHub URL pinned to a tag) and asserts the render works."_
+
+**Spec rules implemented here:**
+
+- `schemaVersion` out of range → explicit message, never a silently broken render.
+- `schemaVersion` absent → treat as `0`, show "predates schema versioning, best-effort" rather than crash.
+- The dashboard owns all compatibility logic; the core emits and never gates.
+
+## File structure (new/changed files)
+
+```text
+regis-dashboard/
+  src/lib/
+    schemaCompat.ts                 # SUPPORTED_SCHEMA_VERSION + checkSchemaCompat()  (NEW)
+    __tests__/
+      schemaCompat.test.ts          # unit tests for the pure function           (NEW)
+      contract.test.ts              # offline: demo report (static/report.json) is ok (NEW)
+  src/components/ReportProvider.tsx  # wire the check + warning state            (MODIFIED)
+  vitest.config.ts                   # broaden include to src/**                  (MODIFIED)
+  .github/workflows/contract.yml     # live cross-repo drift check                (NEW)
+```
+
+---
+
+### Task 1: The `checkSchemaCompat` pure function (TDD)
+
+**Files:**
+
+- Create: `src/lib/schemaCompat.ts`
+- Test: `src/lib/__tests__/schemaCompat.test.ts`
+- Modify: `vitest.config.ts` (broaden test include beyond `src/cli/`)
+
+- [ ] **Step 1: Broaden the vitest include**
+
+In `vitest.config.ts` (created in 1b, currently `include: ["src/cli/__tests__/**/*.test.ts"]`), change `include` to:
+
+```ts
+    include: ["src/**/__tests__/**/*.test.ts"],
+```
+
+This keeps the CLI tests and also picks up `src/lib/__tests__/`.
+
+- [ ] **Step 2: Write the failing tests**
+
+`src/lib/__tests__/schemaCompat.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { checkSchemaCompat, SUPPORTED_SCHEMA_VERSION } from "../schemaCompat";
+
+describe("checkSchemaCompat", () => {
+  it("accepts a version inside the supported range", () => {
+    const r = checkSchemaCompat(SUPPORTED_SCHEMA_VERSION.min);
+    expect(r.mode).toBe("ok");
+    expect(r.message).toBeNull();
+  });
+
+  it("treats a missing version as best-effort (predates versioning)", () => {
+    const r = checkSchemaCompat(undefined);
+    expect(r.mode).toBe("best-effort");
+    expect(r.message).toMatch(/predates schema versioning/i);
+  });
+
+  it("treats schemaVersion 0 as best-effort", () => {
+    expect(checkSchemaCompat(0).mode).toBe("best-effort");
+  });
+
+  it("rejects a version above the supported range with an explicit message", () => {
+    const tooNew = SUPPORTED_SCHEMA_VERSION.max + 1;
+    const r = checkSchemaCompat(tooNew);
+    expect(r.mode).toBe("unsupported");
+    expect(r.message).toContain(String(tooNew));
+    expect(r.message).toContain(String(SUPPORTED_SCHEMA_VERSION.max));
+  });
+
+  it("uses an injectable range for testing future windows", () => {
+    expect(checkSchemaCompat(2, { min: 1, max: 3 }).mode).toBe("ok");
+    expect(checkSchemaCompat(4, { min: 1, max: 3 }).mode).toBe("unsupported");
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pnpm test -- schemaCompat`
+Expected: FAIL — module `../schemaCompat` not found.
+
+- [ ] **Step 4: Implement `src/lib/schemaCompat.ts`**
+
+```ts
+/** The schemaVersion range this dashboard release can render.
+ *  Bump `max` when the dashboard adds support for a new report schemaVersion. */
+export const SUPPORTED_SCHEMA_VERSION = { min: 1, max: 1 } as const;
+
+export interface SchemaRange {
+  min: number;
+  max: number;
+}
+
+export interface CompatResult {
+  mode: "ok" | "best-effort" | "unsupported";
+  /** Non-null for best-effort (warning) and unsupported (error); null for ok. */
+  message: string | null;
+}
+
+/** Decide whether this dashboard can render a report of the given schemaVersion.
+ *  - undefined / 0  → best-effort (report predates schema versioning)
+ *  - within [min,max] → ok
+ *  - otherwise      → unsupported (explicit, actionable message) */
+export function checkSchemaCompat(
+  schemaVersion: number | undefined,
+  range: SchemaRange = SUPPORTED_SCHEMA_VERSION,
+): CompatResult {
+  const v = schemaVersion ?? 0;
+  if (v === 0) {
+    return {
+      mode: "best-effort",
+      message:
+        "This report predates schema versioning (no schemaVersion field); rendering is best-effort.",
+    };
+  }
+  if (v < range.min || v > range.max) {
+    return {
+      mode: "unsupported",
+      message:
+        `This report uses schemaVersion ${v}; this dashboard supports ${range.min}–${range.max}. ` +
+        `Use a newer regis-dashboard image, or regenerate the report with a compatible regis version.`,
+    };
+  }
+  return { mode: "ok", message: null };
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm test -- schemaCompat`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/schemaCompat.ts src/lib/__tests__/schemaCompat.test.ts vitest.config.ts
+git commit -m "feat(compat): add checkSchemaCompat with declared supported range"
+```
+
+---
+
+### Task 2: Wire the compat check into `ReportProvider`
+
+**Files:**
+
+- Modify: `src/components/ReportProvider.tsx`
+
+The current provider (recon'd) has:
+
+- a `ReportData` interface (with `version?: string`, no `schemaVersion`),
+- a context `{ report, loading, error, reportUrl }`,
+- a fetch `.then((data) => { if (Array.isArray(data)) {…return;} setReport(data); setError(null); setLoading(false); })`.
+
+We add a `schemaVersion` field, a `warning` channel, and call `checkSchemaCompat` between the array guard and `setReport`.
+
+- [ ] **Step 1: Add `schemaVersion` to `ReportData`**
+
+In the `ReportData` interface, add (next to `version?: string;`):
+
+```ts
+  schemaVersion?: number;
+```
+
+- [ ] **Step 2: Add `warning` to the context type, default, and `useReport`**
+
+Change the `ReportContextValue` interface (currently `{ report, loading, error, reportUrl }`) to add:
+
+```ts
+warning: string | null;
+```
+
+Update the `createContext<ReportContextValue>({ … })` default to include `warning: null,`.
+
+- [ ] **Step 3: Add warning state and import the checker**
+
+At the top of `ReportProvider.tsx`, add the import:
+
+```ts
+import { checkSchemaCompat } from "../lib/schemaCompat";
+```
+
+Inside `ReportProvider`, alongside the existing `useState` calls, add:
+
+```ts
+const [warning, setWarning] = useState<string | null>(null);
+```
+
+- [ ] **Step 4: Insert the compat check and route the three outcomes**
+
+Replace the post-array-guard block (currently the three lines `setReport(data); setError(null); setLoading(false);` immediately after the `if (Array.isArray(data)) { … return; }`) with:
+
+```ts
+const compat = checkSchemaCompat(data.schemaVersion);
+if (compat.mode === "unsupported") {
+  setError(compat.message);
+  setReport(null);
+  setLoading(false);
+  return;
+}
+setWarning(compat.mode === "best-effort" ? compat.message : null);
+setReport(data);
+setError(null);
+setLoading(false);
+```
+
+- [ ] **Step 5: Surface `warning` in the provider output (non-blocking banner)**
+
+Change the provider return so the warning renders above children and `warning` is exposed in context:
+
+```tsx
+return (
+  <ReportContext.Provider
+    value={{ report, loading, error, warning, reportUrl }}
+  >
+    {warning && (
+      <div
+        role="status"
+        style={{
+          background: "#fef3c7",
+          color: "#92400e",
+          padding: "0.5rem 1rem",
+          fontSize: "0.875rem",
+          borderBottom: "1px solid #f59e0b",
+        }}
+      >
+        {warning}
+      </div>
+    )}
+    {children}
+  </ReportContext.Provider>
+);
+```
+
+- [ ] **Step 6: Verify typecheck + build**
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass. (No new unit test here — the logic under test is `checkSchemaCompat`, covered in Task 1; this task is the wiring, validated by typecheck/build and the contract test in Task 3.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/ReportProvider.tsx
+git commit -m "feat(compat): gate rendering on report schemaVersion in ReportProvider"
+```
+
+---
+
+### Task 3: Offline contract test against the committed demo report
+
+**Files:**
+
+- Create: `src/lib/__tests__/contract.test.ts`
+
+The demo `static/report.json` committed in Phase 1a **is** the core's `report.v1.json`. Asserting it is `ok` guarantees the dashboard's `SUPPORTED_SCHEMA_VERSION` includes the core's current contract — deterministically, offline, on every test run.
+
+- [ ] **Step 1: Write the test**
+
+`src/lib/__tests__/contract.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { checkSchemaCompat } from "../schemaCompat";
+
+describe("contract: committed demo report", () => {
+  it("static/report.json is renderable by this dashboard (mode 'ok')", () => {
+    const report = JSON.parse(
+      readFileSync(resolve(__dirname, "../../../static/report.json"), "utf8"),
+    );
+    expect(typeof report.schemaVersion).toBe("number");
+    const compat = checkSchemaCompat(report.schemaVersion);
+    expect(compat.mode).toBe("ok");
+  });
+});
+```
+
+(Adjust the relative path if `src/lib/__tests__/` is not three levels under the repo root — `resolve(__dirname, ...)` should point at `<repo>/static/report.json`.)
+
+- [ ] **Step 2: Run to verify pass**
+
+Run: `pnpm test -- contract`
+Expected: PASS — the demo report's `schemaVersion` (1) is within `SUPPORTED_SCHEMA_VERSION`.
+
+If it FAILS because `static/report.json` is missing, Phase 1a Task 4 was not completed — stop and report (this plan depends on it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/__tests__/contract.test.ts
+git commit -m "test(compat): offline contract test against committed demo report"
+```
+
+---
+
+### Task 4: Live cross-repo drift check (CI)
+
+**Files:**
+
+- Create: `.github/workflows/contract.yml`
+
+The offline test (Task 3) only guards the _committed snapshot_. This workflow fetches the **live** core fixture from GitHub and re-asserts compat, so if the core bumps `schemaVersion` beyond this dashboard's range, the dashboard repo gets a failing signal (scheduled + on every push).
+
+- [ ] **Step 1: Add a tiny assertion script** — `scripts/check-contract.mjs`:
+
+```js
+// Fetches the core's report.v1 fixture and asserts this dashboard supports its schemaVersion.
+import { readFileSync } from "node:fs";
+
+const fixtureUrl =
+  process.env.CORE_FIXTURE_URL ??
+  "https://raw.githubusercontent.com/trivoallan/regis/main/tests/fixtures/report.v1.json";
+
+// Read the dashboard's supported range straight from source (single source of truth).
+// (Do not shadow the global URL constructor — it is needed for the import.meta.url resolve.)
+const srcPath = new URL("../src/lib/schemaCompat.ts", import.meta.url);
+const src = readFileSync(srcPath, "utf8");
+const min = Number(/min:\s*(\d+)/.exec(src)?.[1]);
+const max = Number(/max:\s*(\d+)/.exec(src)?.[1]);
+
+const res = await fetch(fixtureUrl);
+if (!res.ok) {
+  console.error(
+    `Failed to fetch core fixture: ${res.status} ${res.statusText}`,
+  );
+  process.exit(2);
+}
+const report = await res.json();
+const v = report.schemaVersion ?? 0;
+
+if (v < min || v > max) {
+  console.error(
+    `DRIFT: core report.v1 schemaVersion=${v} is outside this dashboard's supported range ${min}-${max}. ` +
+      `Bump SUPPORTED_SCHEMA_VERSION.max in src/lib/schemaCompat.ts and add render support.`,
+  );
+  process.exit(1);
+}
+console.log(
+  `OK: core schemaVersion ${v} is within supported range ${min}-${max}.`,
+);
+```
+
+- [ ] **Step 2: Add the workflow** — `.github/workflows/contract.yml`:
+
+```yaml
+name: Cross-repo contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # weekly Monday 06:00 UTC — catches core drift between PRs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/check-contract.mjs
+```
+
+- [ ] **Step 3: Local dry-run**
+
+```bash
+node scripts/check-contract.mjs
+```
+
+Expected: prints `OK: core schemaVersion 1 is within supported range 1-1.` (requires network and that the core `main` has `tests/fixtures/report.v1.json` — i.e. PR #630 is merged. If the fixture 404s, this exits 2 — see watch-points.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check-contract.mjs .github/workflows/contract.yml
+git commit -m "ci: add live cross-repo schemaVersion drift check"
+```
+
+---
+
+### Task 5: Wire the contract test into PR CI + document the bump procedure
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`, `README.md`
+
+- [ ] **Step 1: Ensure `pnpm test` (now including schemaCompat + contract) runs in PR CI**
+
+`pnpm test` already runs in `ci.yml` (added in Phase 1b Task 10). Confirm the contract + compat tests are picked up by the broadened vitest `include`:
+
+```bash
+pnpm test 2>&1 | grep -E "schemaCompat|contract"
+```
+
+Expected: both test files appear and pass. No CI change needed if 1b already added `pnpm test`; if not, add it.
+
+- [ ] **Step 2: Document the compatibility contract in the README**
+
+Replace the README "Contract" section (from Phase 1a) with the concrete mechanism:
+
+```markdown
+## Report compatibility
+
+This dashboard renders regis reports identified by an integer `schemaVersion`.
+The supported range is declared in `src/lib/schemaCompat.ts`
+(`SUPPORTED_SCHEMA_VERSION`). At runtime:
+
+- in range → renders normally;
+- no `schemaVersion` (legacy report) → renders best-effort with a banner;
+- out of range → shows an explicit upgrade message instead of a broken view.
+
+When the core ships a new report `schemaVersion`, bump
+`SUPPORTED_SCHEMA_VERSION.max` and add any needed render handling. The
+`Cross-repo contract` workflow fails if the core drifts past the supported range.
+```
+
+- [ ] **Step 3: Verify the whole suite**
+
+```bash
+pnpm install
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml README.md
+git commit -m "docs(compat): document schemaVersion contract and bump procedure"
+```
+
+---
+
+## Self-review notes (reconciled against the spec)
+
+- **Spec "enforcement 100% runtime, dashboard-side"** → Task 2 (`ReportProvider` calls `checkSchemaCompat` at fetch time; no build-time gate, no core involvement).
+- **Spec "dashboard declares the supported range per release"** → `SUPPORTED_SCHEMA_VERSION` in `schemaCompat.ts` (Task 1), surfaced in the README bump procedure (Task 5).
+- **Spec "out of range → explicit message, never silently broken"** → Task 1 `unsupported` message + Task 2 routing to the existing error UI (report stays null).
+- **Spec "absent → treat as 0, best-effort"** → Task 1 `best-effort` branch + Task 2 non-blocking banner.
+- **Spec "cross-repo contract test: CI fetches the fixture and asserts"** → Task 4 live drift workflow; Task 3 adds an offline deterministic guard against the committed snapshot.
+- **Spec "core has zero compat logic"** → respected: nothing in this plan touches the core; all logic is dashboard-side.
+
+## Risks / watch-points
+
+- **Contract workflow gated on PR #630:** `scripts/check-contract.mjs` fetches `…/regis/main/tests/fixtures/report.v1.json`, which only exists once Phase 0 (PR #630) is merged to the core's `main`. Until then the live check exits 2 (fetch failure). The **offline** test (Task 3) does not depend on the core and passes immediately. Consider pinning the fetch URL to a tag once the core cuts the release that includes the fixture.
+- **Range parsed by regex in the drift script:** `check-contract.mjs` greps `min:`/`max:` out of `schemaCompat.ts` to avoid a TS build step in CI. If that literal's formatting changes, the regex must still match — the `as const` object keeps `min: 1, max: 1` on one logical line; keep it greppable, or replace the script with a compiled import if it becomes fragile.
+- **Warning banner styling:** Task 2 uses inline styles to avoid coupling to Tailwind/Tremor theme internals during extraction. A follow-up can restyle it with the design system; functionally it satisfies the spec's "show a message rather than crash."
+- **`schemaVersion` typing:** the core emits an integer; `checkSchemaCompat` coerces `undefined`→0 but does not guard against non-numeric junk (e.g. a string). The core schema enforces integer, so a malformed value would already fail upstream; `ReportProvider`'s existing JSON-parse/`content-type` guards cover gross corruption.


### PR DESCRIPTION
## Summary

Adds the three **Phase 1** implementation plans for extracting the dashboard into a standalone `regis-dashboard` repo, under `docs/superpowers/plans/`. **Documentation only** — no code or CI changes.

These follow the approved design (`docs/superpowers/specs/2026-05-31-dashboard-full-decouple-design.md`, landing via #630) and the shipped **Phase 0** (`schemaVersion` contract, also #630).

### Plans

- **1a — extraction + standalone bootstrap** (`…-phase1a-extraction.md`): `git filter-repo` of `apps/dashboard` into a new repo with history, standalone build, GitHub Pages deploy, release-please. Drops the GitLab live-backend page (static-preview-only decision).
- **1b — CLI + Docker** (`…-phase1b-cli.md`): a TypeScript `commander` CLI (`render` / `serve` / `archive add|configure` / `bootstrap archive`) porting `docusaurus.py`, `archive.py`, and `store.py`, with vitest TDD and a GHCR image.
- **1c — runtime compat + contract** (`…-phase1c-compat-contract.md`): a pure `checkSchemaCompat()` gating `ReportProvider` at runtime (out-of-range → explicit error; missing → best-effort banner), plus offline + live cross-repo contract tests against the core's `report.v1.json`.

### Scope decisions captured

- **Static-preview-only**: the `regis dashboard serve` GitLab MR proxy + webhook/SSE backend is dropped, not reimplemented; `gitlab.tsx` and its 3 exclusive components are removed in 1a.
- Phase 1 is decomposed into 1a/1b/1c so each produces working, testable software on its own.

### Dependency note

1a Task 4 and 1c's live contract check fetch `report.v1.json` from the core's `main` — that file lands when **#630** merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)