### PR TITLE
build!: drop dashboard frontend-builder stage from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,7 @@
 ARG VARIANT=slim
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 1: frontend-builder — builds the Docusaurus dashboard
-# ──────────────────────────────────────────────────────────────────────────────
-FROM node:25-alpine AS frontend-builder
-RUN npm install -g pnpm@10.10.0
-WORKDIR /app
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml* ./
-COPY apps/ apps/
-RUN pnpm install --frozen-lockfile
-WORKDIR /app/apps/dashboard
-RUN pnpm run build
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: python-builder — compiles Python deps into a venv
+# Stage 1: python-builder — compiles Python deps into a venv
 # ──────────────────────────────────────────────────────────────────────────────
 # Alpine 3.11 builder paired with Alpine 3.11 runtime — matching musl libc and
 # CPython ABIs so the venv's symlinked interpreter resolves cleanly at runtime.
@@ -37,11 +25,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /src
 COPY pyproject.toml Pipfile Pipfile.lock ./
 COPY regis/ regis/
-COPY --from=frontend-builder /app/apps/dashboard/build regis/dashboard_assets
 
-# Core install only — the optional [server] extra (FastAPI/Uvicorn) is
-# intentionally excluded to keep the runtime image small. Use a host with
-# `pip install 'regis[server]'` for `regis dashboard serve`.
+# Core install only. The interactive dashboard + its FastAPI server moved to
+# the standalone regis-dashboard repo, so there is no Node build stage and no
+# dashboard_assets baked into the image.
 # --no-compile skips .pyc generation (PYTHONDONTWRITEBYTECODE keeps runtime
 # from regenerating them); prune any residual bytecode caches afterwards.
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

Follow-up to #634 (Phase 2 core removal). That PR deleted `apps/dashboard`, but the Dockerfile still built it — a `node:25-alpine` `frontend-builder` stage running `COPY apps/ apps/` + `pnpm run build`, then copied the result into `regis/dashboard_assets`. With `apps/dashboard` gone the image build fails at `COPY apps/` (the `ci-image-size` check is non-blocking, so #634 auto-merged before this surfaced).

Drops the frontend-builder stage and the `dashboard_assets` copy; the runtime image is now Node-free. Verified locally: `docker build --build-arg VARIANT=slim` succeeds, image is **151 MB** (under the 200 MB slim ceiling) and `regis --help` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)