### PR TITLE
feat(playbook)!: rename API group to regis.io

### DIFF
--- a/docs/website/docs/concepts/playbooks.md
+++ b/docs/website/docs/concepts/playbooks.md
@@ -23,7 +23,7 @@ Playbooks use a Kubernetes-style resource envelope. Every `playbook.yaml` must d
 
 | Field        | Required | Description                                                |
 | ------------ | -------- | ---------------------------------------------------------- |
-| `apiVersion` | yes      | Must be `regis.trivoallan.dev/v1alpha1`.                   |
+| `apiVersion` | yes      | Must be `regis.io/v1alpha1`.                               |
 | `kind`       | yes      | Must be `Playbook`.                                        |
 | `metadata`   | yes      | Identity and version of this playbook (see below).         |
 | `spec`       | yes      | Rules, tiers, badges, integrations, and links (see below). |
@@ -439,7 +439,7 @@ The following example shows a minimal valid playbook definition:
 
 ```yaml
 # yaml-language-server: $schema=https://trivoallan.github.io/regis/schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: minimal

--- a/docs/website/docs/reference/playbook-versioning.md
+++ b/docs/website/docs/reference/playbook-versioning.md
@@ -6,15 +6,15 @@ sidebar_position: 4
 
 Every Regis playbook uses a Kubernetes-style resource envelope. Two fields carry version information:
 
-| Field                                          | Required | Purpose                                                                     |
-| ---------------------------------------------- | -------- | --------------------------------------------------------------------------- |
-| `apiVersion`                                   | yes      | Identifies the playbook format. Must equal `regis.trivoallan.dev/v1alpha1`. |
-| `metadata.labels["app.kubernetes.io/version"]` | yes      | SemVer of your playbook bundle (`MAJOR.MINOR.PATCH`).                       |
+| Field                                          | Required | Purpose                                                         |
+| ---------------------------------------------- | -------- | --------------------------------------------------------------- |
+| `apiVersion`                                   | yes      | Identifies the playbook format. Must equal `regis.io/v1alpha1`. |
+| `metadata.labels["app.kubernetes.io/version"]` | yes      | SemVer of your playbook bundle (`MAJOR.MINOR.PATCH`).           |
 
 ## Example
 
 ```yaml
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: my-playbook
@@ -28,7 +28,7 @@ spec:
 ## `apiVersion`
 
 The `apiVersion` field encodes the API group and version of the playbook format.
-The only supported value is `regis.trivoallan.dev/v1alpha1`.
+The only supported value is `regis.io/v1alpha1`.
 
 Future breaking changes to the schema will introduce a new `apiVersion` (e.g.
 `v1beta1`, `v1`). Regis will reject playbooks declaring an unsupported
@@ -61,7 +61,7 @@ regis playbook validate path/to/playbook.yaml
 A successful run prints:
 
 ```text
-  ✓ path/to/playbook.yaml is valid (apiVersion=regis.trivoallan.dev/v1alpha1, kind=Playbook, version=1.0.0).
+  ✓ path/to/playbook.yaml is valid (apiVersion=regis.io/v1alpha1, kind=Playbook, version=1.0.0).
 ```
 
 If validation fails, the error message names the offending field and suggests the fix.
@@ -75,7 +75,7 @@ traceability:
 {
   "playbook_name": "My Playbook",
   "playbook_version": "1.2.3",
-  "api_version": "regis.trivoallan.dev/v1alpha1",
+  "api_version": "regis.io/v1alpha1",
   "version": "0.33.0"
 }
 ```

--- a/docs/website/docs/reference/schemas/playbook/playbook.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/playbook.schema.md
@@ -11,7 +11,7 @@
 
 | Property                     | Pattern | Type   | Deprecated | Definition | Title/Description                                                  |
 | ---------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------------------------------ |
-| + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'. |
+| + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.io/v1alpha1'. |
 | + [kind](#kind )             | No      | const  | No         | -          | Resource kind. Must equal 'Playbook'.                              |
 | + [metadata](#metadata )     | No      | object | No         | -          | -                                                                  |
 | + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, integrations, links.          |
@@ -22,9 +22,9 @@
 | -------- | ------- |
 | **Type** | `const` |
 
-**Description:** API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'.
+**Description:** API group and version. Must equal 'regis.io/v1alpha1'.
 
-Specific value: `"regis.trivoallan.dev/v1alpha1"`
+Specific value: `"regis.io/v1alpha1"`
 
 ## <a name="kind"></a>2. ![Required](https://img.shields.io/badge/Required-blue) Property `kind`
 

--- a/docs/website/docs/reference/schemas/playbook/result.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/result.schema.md
@@ -13,7 +13,7 @@
 | ------------------------------------------ | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------- |
 | + [playbook_name](#playbook_name )         | No      | string          | No         | -          | Identifier of the playbook that was executed.                                                |
 | - [playbook_version](#playbook_version )   | No      | string or null  | No         | -          | SemVer of the playbook that produced this report.                                            |
-| - [api_version](#api_version )             | No      | string or null  | No         | -          | apiVersion of the playbook that produced this result (e.g. "regis.trivoallan.dev/v1alpha1"). |
+| - [api_version](#api_version )             | No      | string or null  | No         | -          | apiVersion of the playbook that produced this result (e.g. "regis.io/v1alpha1"). |
 | - [sidebar](#sidebar )                     | No      | object          | No         | -          | Sidebar navigation metadata for the report UI.                                               |
 | - [version](#version )                     | No      | string or null  | No         | -          | Version of regis that generated this report.                                                 |
 | - [tier](#tier )                           | No      | string or null  | No         | -          | The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions.                    |
@@ -49,7 +49,7 @@
 | -------- | ---------------- |
 | **Type** | `string or null` |
 
-**Description:** apiVersion of the playbook that produced this result (e.g. "regis.trivoallan.dev/v1alpha1").
+**Description:** apiVersion of the playbook that produced this result (e.g. "regis.io/v1alpha1").
 
 ## <a name="sidebar"></a>4. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `sidebar`
 

--- a/docs/website/docs/reference/schemas/playbook/v1alpha1/playbook.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/v1alpha1/playbook.schema.md
@@ -11,7 +11,7 @@
 
 | Property                     | Pattern | Type   | Deprecated | Definition | Title/Description                                                  |
 | ---------------------------- | ------- | ------ | ---------- | ---------- | ------------------------------------------------------------------ |
-| + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'. |
+| + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.io/v1alpha1'. |
 | + [kind](#kind )             | No      | const  | No         | -          | Resource kind. Must equal 'Playbook'.                              |
 | + [metadata](#metadata )     | No      | object | No         | -          | -                                                                  |
 | + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, integrations, links.          |
@@ -22,9 +22,9 @@
 | -------- | ------- |
 | **Type** | `const` |
 
-**Description:** API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'.
+**Description:** API group and version. Must equal 'regis.io/v1alpha1'.
 
-Specific value: `"regis.trivoallan.dev/v1alpha1"`
+Specific value: `"regis.io/v1alpha1"`
 
 ## <a name="kind"></a>2. ![Required](https://img.shields.io/badge/Required-blue) Property `kind`
 

--- a/docs/website/docs/reference/schemas/report/report.schema.md
+++ b/docs/website/docs/reference/schemas/report/report.schema.md
@@ -365,7 +365,7 @@ Must be one of:
 | ---------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------------------------------------------------------------------- |
 | + [playbook_name](#playbooks_items_playbook_name )         | No      | string          | No         | -          | Identifier of the playbook that was executed.                                                |
 | - [playbook_version](#playbooks_items_playbook_version )   | No      | string or null  | No         | -          | SemVer of the playbook that produced this report.                                            |
-| - [api_version](#playbooks_items_api_version )             | No      | string or null  | No         | -          | apiVersion of the playbook that produced this result (e.g. "regis.trivoallan.dev/v1alpha1"). |
+| - [api_version](#playbooks_items_api_version )             | No      | string or null  | No         | -          | apiVersion of the playbook that produced this result (e.g. "regis.io/v1alpha1"). |
 | - [sidebar](#playbooks_items_sidebar )                     | No      | object          | No         | -          | Sidebar navigation metadata for the report UI.                                               |
 | - [version](#playbooks_items_version )                     | No      | string or null  | No         | -          | Version of regis that generated this report.                                                 |
 | - [tier](#playbooks_items_tier )                           | No      | string or null  | No         | -          | The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions.                    |
@@ -401,7 +401,7 @@ Must be one of:
 | -------- | ---------------- |
 | **Type** | `string or null` |
 
-**Description:** apiVersion of the playbook that produced this result (e.g. "regis.trivoallan.dev/v1alpha1").
+**Description:** apiVersion of the playbook that produced this result (e.g. "regis.io/v1alpha1").
 
 #### <a name="playbooks_items_sidebar"></a>10.1.4. Property `sidebar`
 

--- a/docs/website/docs/upgrade/playbook-schema-v1.md
+++ b/docs/website/docs/upgrade/playbook-schema-v1.md
@@ -8,7 +8,7 @@ Starting with Regis v0.34, every playbook **must** use the Kubernetes-style
 resource envelope:
 
 ```yaml
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: <id>
@@ -26,19 +26,19 @@ back to disk. Run the migration command to make the change permanent.
 
 ## Field mapping
 
-| Old field                    | New location                                   | Notes                                       |
-| ---------------------------- | ---------------------------------------------- | ------------------------------------------- |
-| `schemaVersion`              | replaced by `apiVersion`                       | `apiVersion: regis.trivoallan.dev/v1alpha1` |
-| `name`                       | `metadata.title`                               | human-readable display name                 |
-| `slug`                       | `metadata.name`                                | machine id — RFC 1123 DNS label             |
-| `description`                | `metadata.description`                         | optional                                    |
-| `version`                    | `metadata.labels["app.kubernetes.io/version"]` | SemVer string                               |
-| `tiers`                      | `spec.tiers`                                   |                                             |
-| `rules`                      | `spec.rules`                                   |                                             |
-| `badges`                     | `spec.badges`                                  |                                             |
-| `integrations`               | `spec.integrations`                            |                                             |
-| `links`                      | `spec.links`                                   |                                             |
-| `pages`/`sections`/`sidebar` | removed                                        | not used by the report viewer               |
+| Old field                    | New location                                   | Notes                           |
+| ---------------------------- | ---------------------------------------------- | ------------------------------- |
+| `schemaVersion`              | replaced by `apiVersion`                       | `apiVersion: regis.io/v1alpha1` |
+| `name`                       | `metadata.title`                               | human-readable display name     |
+| `slug`                       | `metadata.name`                                | machine id — RFC 1123 DNS label |
+| `description`                | `metadata.description`                         | optional                        |
+| `version`                    | `metadata.labels["app.kubernetes.io/version"]` | SemVer string                   |
+| `tiers`                      | `spec.tiers`                                   |                                 |
+| `rules`                      | `spec.rules`                                   |                                 |
+| `badges`                     | `spec.badges`                                  |                                 |
+| `integrations`               | `spec.integrations`                            |                                 |
+| `links`                      | `spec.links`                                   |                                 |
+| `pages`/`sections`/`sidebar` | removed                                        | not used by the report viewer   |
 
 ## Automated migration
 
@@ -81,7 +81,7 @@ description: "Optional description."
 
 ```yaml
 # yaml-language-server: $schema=https://trivoallan.github.io/regis/schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: your-playbook # was: slug
@@ -108,7 +108,7 @@ regis playbook validate path/to/playbook.yaml
 A successful run prints:
 
 ```text
-  ✓ path/to/playbook.yaml is valid (apiVersion=regis.trivoallan.dev/v1alpha1, kind=Playbook, version=1.0.0).
+  ✓ path/to/playbook.yaml is valid (apiVersion=regis.io/v1alpha1, kind=Playbook, version=1.0.0).
 ```
 
 If validation fails, the error message names the offending field and suggests

--- a/docs/website/docs/usage/custom-playbook.md
+++ b/docs/website/docs/usage/custom-playbook.md
@@ -34,7 +34,7 @@ A minimal playbook uses the Kubernetes-style envelope (`apiVersion`/`kind`/`meta
 
 ```yaml
 # yaml-language-server: $schema=https://trivoallan.github.io/regis/schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: my-security-policy # machine id — RFC 1123 DNS label

--- a/docs/website/static/schemas/playbook/result.schema.json
+++ b/docs/website/static/schemas/playbook/result.schema.json
@@ -23,7 +23,7 @@
     },
     "api_version": {
       "type": ["string", "null"],
-      "description": "apiVersion of the playbook that produced this result (e.g. \"regis.trivoallan.dev/v1alpha1\")."
+      "description": "apiVersion of the playbook that produced this result (e.g. \"regis.io/v1alpha1\")."
     },
     "sidebar": {
       "type": "object",

--- a/docs/website/static/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/docs/website/static/schemas/playbook/v1alpha1/playbook.schema.json
@@ -8,8 +8,8 @@
   "additionalProperties": false,
   "properties": {
     "apiVersion": {
-      "const": "regis.trivoallan.dev/v1alpha1",
-      "description": "API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'."
+      "const": "regis.io/v1alpha1",
+      "description": "API group and version. Must equal 'regis.io/v1alpha1'."
     },
     "kind": {
       "const": "Playbook",

--- a/regis/commands/playbook.py
+++ b/regis/commands/playbook.py
@@ -255,7 +255,7 @@ def upgrade_playbook(path: Path) -> None:
     dropped = [k for k in ("pages", "sections", "sidebar") if k in data]
 
     new_doc = CommentedMap()
-    new_doc["apiVersion"] = "regis.trivoallan.dev/v1alpha1"
+    new_doc["apiVersion"] = "regis.io/v1alpha1"
     new_doc["kind"] = "Playbook"
     new_doc["metadata"] = metadata
     new_doc["spec"] = spec

--- a/regis/cookiecutters/playbook/{{cookiecutter.project_slug}}/playbook.yaml
+++ b/regis/cookiecutters/playbook/{{cookiecutter.project_slug}}/playbook.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/trivoallan/regis/main/regis/schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: "{{ cookiecutter.project_slug }}"

--- a/regis/playbook/loader.py
+++ b/regis/playbook/loader.py
@@ -91,7 +91,7 @@ def _extract_api_version(raw: dict[str, Any], path: str | Path) -> str:
     if "apiVersion" not in raw:
         raise PlaybookVersionError(
             f"playbook '{path}' is missing required field 'apiVersion'.\n"
-            f"Add `apiVersion: regis.trivoallan.dev/v1alpha1` and `kind: Playbook` "
+            f"Add `apiVersion: regis.io/v1alpha1` and `kind: Playbook` "
             f"at the top of the file (run `regis playbook upgrade` to migrate a "
             f"legacy playbook).\n"
             f"Supported: {schema_registry.supported_versions()}."

--- a/regis/playbook/schema_registry.py
+++ b/regis/playbook/schema_registry.py
@@ -17,7 +17,7 @@ def _load_schema_v1alpha1() -> dict[str, Any]:
 
 
 _SCHEMAS: dict[str, Callable[[], dict[str, Any]]] = {
-    "regis.trivoallan.dev/v1alpha1": _load_schema_v1alpha1,
+    "regis.io/v1alpha1": _load_schema_v1alpha1,
 }
 
 

--- a/regis/playbooks/default/playbook.yaml
+++ b/regis/playbooks/default/playbook.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: default

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -23,7 +23,7 @@
     },
     "api_version": {
       "type": ["string", "null"],
-      "description": "apiVersion of the playbook that produced this result (e.g. \"regis.trivoallan.dev/v1alpha1\")."
+      "description": "apiVersion of the playbook that produced this result (e.g. \"regis.io/v1alpha1\")."
     },
     "sidebar": {
       "type": "object",

--- a/regis/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/regis/schemas/playbook/v1alpha1/playbook.schema.json
@@ -8,8 +8,8 @@
   "additionalProperties": false,
   "properties": {
     "apiVersion": {
-      "const": "regis.trivoallan.dev/v1alpha1",
-      "description": "API group and version. Must equal 'regis.trivoallan.dev/v1alpha1'."
+      "const": "regis.io/v1alpha1",
+      "description": "API group and version. Must equal 'regis.io/v1alpha1'."
     },
     "kind": {
       "const": "Playbook",

--- a/tests/commands/test_playbook_migrate.py
+++ b/tests/commands/test_playbook_migrate.py
@@ -39,7 +39,7 @@ from regis.rules.evaluator import evaluate_rules
 #     interpolation `${results.cve.${rule.params.level}_count}`.
 _LEGACY_PLAYBOOK = """\
 # yaml-language-server: $schema=../../schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: legacy
@@ -326,7 +326,7 @@ def test_migrate_already_migrated_is_noop(tmp_path: Path) -> None:
 # byte-for-byte.
 _CRITERION_NATIVE_PLAYBOOK = """\
 # yaml-language-server: $schema=../../schemas/playbook/v1alpha1/playbook.schema.json
-apiVersion: regis.trivoallan.dev/v1alpha1
+apiVersion: regis.io/v1alpha1
 kind: Playbook
 metadata:
   name: native

--- a/tests/commands/test_playbook_upgrade.py
+++ b/tests/commands/test_playbook_upgrade.py
@@ -31,7 +31,7 @@ def test_upgrade_flat_to_envelope(tmp_path) -> None:
     )
     _run(pb)
     data = yaml.safe_load(pb.read_text(encoding="utf-8"))
-    assert data["apiVersion"] == "regis.trivoallan.dev/v1alpha1"
+    assert data["apiVersion"] == "regis.io/v1alpha1"
     assert data["kind"] == "Playbook"
     assert data["metadata"]["name"] == "my-pb"
     assert data["metadata"]["title"] == "My Playbook"

--- a/tests/commands/test_playbook_validate.py
+++ b/tests/commands/test_playbook_validate.py
@@ -11,7 +11,7 @@ from regis.cli import main
 
 # Minimal valid envelope fixture (reused across tests).
 _VALID_ENVELOPE = (
-    "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+    "apiVersion: regis.io/v1alpha1\n"
     "kind: Playbook\n"
     "metadata:\n"
     "  name: minimal\n"
@@ -34,7 +34,7 @@ class TestPlaybookValidate:
         bad = tmp_path / "bad.yaml"
         # Envelope without metadata.name — schema requires it.
         bad.write_text(
-            "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+            "apiVersion: regis.io/v1alpha1\n"
             "kind: Playbook\n"
             "metadata:\n"
             "  labels:\n"
@@ -52,7 +52,7 @@ class TestPlaybookValidate:
         # Extra property at the envelope root — additionalProperties: false.
         bad.write_text(
             textwrap.dedent("""
-                apiVersion: regis.trivoallan.dev/v1alpha1
+                apiVersion: regis.io/v1alpha1
                 kind: Playbook
                 metadata:
                   name: with-extras
@@ -95,7 +95,7 @@ class TestPlaybookValidate:
     def test_validate_reports_api_version_and_version(self, tmp_path: Path):
         playbook = tmp_path / "playbook.yaml"
         playbook.write_text(
-            "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+            "apiVersion: regis.io/v1alpha1\n"
             "kind: Playbook\n"
             "metadata:\n"
             "  name: apiversiontest\n"
@@ -107,7 +107,7 @@ class TestPlaybookValidate:
         runner = CliRunner()
         result = runner.invoke(main, ["playbook", "validate", str(playbook)])
         assert result.exit_code == 0, result.output
-        assert "apiVersion=regis.trivoallan.dev/v1alpha1" in result.output
+        assert "apiVersion=regis.io/v1alpha1" in result.output
         assert "kind=Playbook" in result.output
         assert "version=1.2.3" in result.output
 
@@ -135,7 +135,7 @@ def test_validate_prints_api_version(tmp_path) -> None:
 
     pb = tmp_path / "playbook.yaml"
     pb.write_text(
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: Playbook\n"
         "metadata:\n  name: x\n  labels:\n"
         '    app.kubernetes.io/version: "1.0.0"\n'
@@ -144,5 +144,5 @@ def test_validate_prints_api_version(tmp_path) -> None:
     )
     result = CliRunner().invoke(playbook_group, ["validate", str(pb)])
     assert result.exit_code == 0
-    assert "regis.trivoallan.dev/v1alpha1" in result.output
+    assert "regis.io/v1alpha1" in result.output
     assert "Playbook" in result.output

--- a/tests/test_default_playbook_envelope.py
+++ b/tests/test_default_playbook_envelope.py
@@ -13,7 +13,7 @@ def test_default_playbook_loads_as_envelope() -> None:
     )
     with importlib.resources.as_file(path) as p:
         pb = load_playbook(p)
-    assert pb["apiVersion"] == "regis.trivoallan.dev/v1alpha1"
+    assert pb["apiVersion"] == "regis.io/v1alpha1"
     assert pb["kind"] == "Playbook"
     assert pb["slug"] == "default"
     assert pb["version"] == "1.0.0"

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -26,7 +26,7 @@ class TestLoadPlaybook:
 
     def test_load_from_file(self, tmp_path):
         custom = {
-            "apiVersion": "regis.trivoallan.dev/v1alpha1",
+            "apiVersion": "regis.io/v1alpha1",
             "kind": "Playbook",
             "metadata": {
                 "name": "custom",
@@ -54,7 +54,7 @@ class TestLoadPlaybook:
         import json
 
         custom = {
-            "apiVersion": "regis.trivoallan.dev/v1alpha1",
+            "apiVersion": "regis.io/v1alpha1",
             "kind": "Playbook",
             "metadata": {
                 "name": "json-card",
@@ -618,7 +618,7 @@ def test_evaluate_propagates_playbook_metadata() -> None:
     from regis.playbook.evaluator import evaluate
 
     playbook = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "version": "2.3.4",
         "name": "MetadataPlaybook",
@@ -628,7 +628,7 @@ def test_evaluate_propagates_playbook_metadata() -> None:
 
     assert result["playbook_name"] == "MetadataPlaybook"
     assert result["playbook_version"] == "2.3.4"
-    assert result["api_version"] == "regis.trivoallan.dev/v1alpha1"
+    assert result["api_version"] == "regis.io/v1alpha1"
     assert "schema_version" not in result
 
 
@@ -636,13 +636,13 @@ def test_evaluate_propagates_api_version() -> None:
     from regis.playbook.evaluator import evaluate
 
     playbook = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "name": "X",
         "version": "1.0.0",
         "rules": [],
     }
     result = evaluate(playbook, {"analyzers": {}})
-    assert result["api_version"] == "regis.trivoallan.dev/v1alpha1"
+    assert result["api_version"] == "regis.io/v1alpha1"
     assert result["playbook_version"] == "1.0.0"
     assert "schema_version" not in result

--- a/tests/test_playbook_loader.py
+++ b/tests/test_playbook_loader.py
@@ -12,7 +12,7 @@ from regis.playbook.engine import bundle_meta_schema_path, is_bundle, load_playb
 from regis.playbook.loader import PlaybookVersionError
 
 MINIMAL_PLAYBOOK = {
-    "apiVersion": "regis.trivoallan.dev/v1alpha1",
+    "apiVersion": "regis.io/v1alpha1",
     "kind": "Playbook",
     "metadata": {
         "name": "bundle-playbook",
@@ -141,7 +141,7 @@ def _write(tmp_path, content: str) -> str:
 
 def test_loads_valid_envelope(tmp_path) -> None:
     content = (
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: Playbook\n"
         "metadata:\n"
         "  name: valid\n"
@@ -151,7 +151,7 @@ def test_loads_valid_envelope(tmp_path) -> None:
         "spec: {}\n"
     )
     pb = load_playbook(_write(tmp_path, content))
-    assert pb["apiVersion"] == "regis.trivoallan.dev/v1alpha1"
+    assert pb["apiVersion"] == "regis.io/v1alpha1"
     assert pb["kind"] == "Playbook"
     assert pb["name"] == "Valid Playbook"  # metadata.title
     assert pb["slug"] == "valid"  # metadata.name
@@ -160,7 +160,7 @@ def test_loads_valid_envelope(tmp_path) -> None:
 
 def test_name_falls_back_to_metadata_name_when_no_title(tmp_path) -> None:
     content = (
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: Playbook\n"
         "metadata:\n"
         "  name: no-title\n"
@@ -178,12 +178,12 @@ def test_missing_api_version_raises(tmp_path) -> None:
         load_playbook(_write(tmp_path, content))
     msg = str(exc.value)
     assert "apiVersion" in msg
-    assert "Add `apiVersion: regis.trivoallan.dev/v1alpha1`" in msg
+    assert "Add `apiVersion: regis.io/v1alpha1`" in msg
 
 
 def test_wrong_kind_raises(tmp_path) -> None:
     content = (
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: RuleSet\n"
         "metadata:\n  name: x\nspec: {}\n"
     )
@@ -194,7 +194,7 @@ def test_wrong_kind_raises(tmp_path) -> None:
 
 def test_unknown_api_version_raises(tmp_path) -> None:
     content = (
-        "apiVersion: regis.trivoallan.dev/v9\n"
+        "apiVersion: regis.io/v9\n"
         "kind: Playbook\n"
         "metadata:\n  name: x\nspec: {}\n"
     )
@@ -216,7 +216,7 @@ def test_missing_version_label_fails_schema_validation(tmp_path) -> None:
     import jsonschema
 
     content = (
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: Playbook\n"
         "metadata:\n  name: x\n  labels: {}\n"
         "spec: {}\n"
@@ -229,7 +229,7 @@ def test_invalid_semver_label_fails_schema_validation(tmp_path) -> None:
     import jsonschema
 
     content = (
-        "apiVersion: regis.trivoallan.dev/v1alpha1\n"
+        "apiVersion: regis.io/v1alpha1\n"
         "kind: Playbook\n"
         "metadata:\n  name: x\n  labels:\n"
         '    app.kubernetes.io/version: "1.2"\n'

--- a/tests/test_playbook_schema_v1alpha1.py
+++ b/tests/test_playbook_schema_v1alpha1.py
@@ -31,7 +31,7 @@ def _validator() -> jsonschema.Draft202012Validator:
 
 
 VALID = {
-    "apiVersion": "regis.trivoallan.dev/v1alpha1",
+    "apiVersion": "regis.io/v1alpha1",
     "kind": "Playbook",
     "metadata": {
         "name": "default",

--- a/tests/test_remote_playbook.py
+++ b/tests/test_remote_playbook.py
@@ -13,7 +13,7 @@ from regis.playbook.engine import load_playbook
 def test_load_playbook_remote_yaml():
     url = "https://example.com/playbook.yaml"
     content = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {
             "name": "remote-playbook",
@@ -50,7 +50,7 @@ def test_load_playbook_remote_json():
 
     url = "https://example.com/playbook.json"
     content = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {
             "name": "remote-json",

--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -8,14 +8,14 @@ from regis.playbook import schema_registry
 
 
 def test_supported_versions_lists_v1alpha1() -> None:
-    assert "regis.trivoallan.dev/v1alpha1" in schema_registry.supported_versions()
+    assert "regis.io/v1alpha1" in schema_registry.supported_versions()
 
 
 def test_get_schema_returns_playbook_kind() -> None:
-    schema = schema_registry.get_schema("regis.trivoallan.dev/v1alpha1")
+    schema = schema_registry.get_schema("regis.io/v1alpha1")
     assert schema["properties"]["kind"]["const"] == "Playbook"
 
 
 def test_get_schema_unknown_raises_keyerror() -> None:
     with pytest.raises(KeyError):
-        schema_registry.get_schema("regis.trivoallan.dev/v9")
+        schema_registry.get_schema("regis.io/v9")

--- a/tests/test_utils_report.py
+++ b/tests/test_utils_report.py
@@ -197,7 +197,7 @@ def test_result_schema_accepts_playbook_metadata() -> None:
     report = {
         "playbook_name": "Test",
         "playbook_version": "1.2.3",
-        "api_version": "regis.trivoallan.dev/v1alpha1",
+        "api_version": "regis.io/v1alpha1",
         "score": 100,
         "total_scorecards": 1,
         "passed_scorecards": 1,


### PR DESCRIPTION
## Summary

Renames the playbook API group from `regis.trivoallan.dev` to `regis.io`. Playbook envelopes now use `apiVersion: regis.io/v1alpha1`.

The rename covers source code (loader, schema registry, `playbook` command), JSON Schemas (core + published mirrors under `docs/website/static`), the default playbook, the cookiecutter template, current docs, and tests — 66 occurrences across 27 files.

Frozen historical snapshots are intentionally left untouched: versioned docs (`version-v0.34.0`), the memory-bank logs (`decisionLog`, `progress`, `plans`, the dated `activeContext` entry), and the dated design spec — they document the state of an already-released version.

## Breaking change

Playbooks declaring `apiVersion: regis.trivoallan.dev/v1alpha1` are now rejected by the loader. Update the `apiVersion` to `regis.io/v1alpha1`.

## Test plan

- [x] Playbook suite (loader, schema registry, v1alpha1 schema, migrate/upgrade/validate, remote, engine, report) — 122 passed
- [x] `trunk check` clean on the 27 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)