### PR TITLE
feat(playbook)!: generalize integrations.gitlab into spec.presentation

### DIFF
--- a/docs/superpowers/plans/2026-06-06-playbook-presentation-generalization-plan.md
+++ b/docs/superpowers/plans/2026-06-06-playbook-presentation-generalization-plan.md
@@ -1,0 +1,657 @@
+# Playbook Presentation Generalization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize the playbook's GitLab-specific `spec.integrations.gitlab` into a platform-neutral `spec.presentation` section, rename the GitLab-flavoured `report.json` output fields (`mr_*`) to neutral names, and bump `REPORT_SCHEMA_VERSION` — so the core no longer knows any platform.
+
+**Architecture:** The resolution logic is already generic; this is mostly a rename + relocation. The playbook schema gains `spec.presentation` (badges/checklists/templates) and loses `spec.integrations`. `playbook/integrations/gitlab.py` becomes `playbook/presentation.py` (`resolve_presentation`, reading the normalized flat `playbook["presentation"]`). Report fields `mr_description_checklists`/`mr_templates` become `checklists`/`templates`. `REPORT_SCHEMA_VERSION` goes 1 → 2 (hard-cut; downstream repos migrate in follow-up cycles). A `regis playbook migrate` codemod step moves `integrations.gitlab` → `presentation`.
+
+**Tech Stack:** Python 3.10+, Click, JSON Schema, ruamel.yaml, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md`.
+
+**Branch:** fresh branch off the latest `main` **after PR #652 (GitLab extraction) is merged** — this plan renames `regis/playbook/integrations/gitlab.py`, which #652 keeps; branching before #652 merges risks a rename conflict.
+
+**Breaking:** `feat(playbook)!` — playbook schema + report contract + `REPORT_SCHEMA_VERSION` bump.
+
+---
+
+## Task 1: Playbook schema — replace `spec.integrations` with `spec.presentation`
+
+**Files:**
+
+- Modify: `regis/schemas/playbook/v1alpha1/playbook.schema.json`
+- Test: `tests/test_playbook_schema.py` (or wherever playbook-schema validation is tested — search with `grep -rln "playbook.schema" tests/`; if no dedicated file, add `tests/test_presentation_schema.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_presentation_schema.py`:
+
+```python
+"""Schema validation for the spec.presentation section."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA = json.loads(
+    Path("regis/schemas/playbook/v1alpha1/playbook.schema.json").read_text()
+)
+
+
+def _doc(spec_extra: dict) -> dict:
+    return {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p", "labels": {"app.kubernetes.io/version": "1.0.0"}},
+        "spec": {"rules": [], **spec_extra},
+    }
+
+
+def test_presentation_section_validates():
+    doc = _doc(
+        {
+            "presentation": {
+                "badges": ["score"],
+                "checklists": [{"title": "T", "items": [{"label": "do X"}]}],
+                "templates": [{"url": "gh:org/tmpl"}],
+            }
+        }
+    )
+    jsonschema.Draft202012Validator(SCHEMA).validate(doc)
+
+
+def test_integrations_section_is_rejected():
+    doc = _doc({"integrations": {"gitlab": {"badges": ["score"]}}})
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(SCHEMA).validate(doc)
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pipenv run pytest tests/test_presentation_schema.py -q`
+Expected: FAIL (`presentation` not yet allowed; `integrations` still allowed so the second test fails).
+
+- [ ] **Step 3: Edit the schema**
+
+In `regis/schemas/playbook/v1alpha1/playbook.schema.json`, under `properties.spec.properties`, **remove** the `integrations` property entirely and **add** `presentation`:
+
+```json
+"presentation": {
+  "type": "object",
+  "description": "Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).",
+  "additionalProperties": false,
+  "properties": {
+    "badges": {
+      "type": "array",
+      "description": "Badge slugs to surface as labels for consuming integrations.",
+      "items": { "type": "string" }
+    },
+    "checklists": {
+      "type": "array",
+      "description": "Conditional checklists surfaced by integrations (e.g. in an MR/PR description).",
+      "items": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "title": { "type": "string", "description": "Display title for the checklist." },
+          "items": {
+            "type": "array",
+            "description": "Items in this checklist.",
+            "items": { "$ref": "#/$defs/checklist_item" }
+          }
+        }
+      }
+    },
+    "templates": {
+      "type": "array",
+      "description": "Conditional Cookiecutter templates surfaced to integrations.",
+      "items": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": { "type": "string", "description": "Cookiecutter template URL or path." },
+          "directory": { "type": "string", "description": "Optional subdirectory containing the template." },
+          "condition": {
+            "description": "JSON Logic expression to conditionally surface the template.",
+            "$ref": "../jsonlogic.schema.json"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Note: the deprecated singular `checklist` is intentionally NOT carried over (the migration folds it into `checklists`). Keep the existing `$defs/checklist_item` definition (still referenced).
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `pipenv run pytest tests/test_presentation_schema.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regis/schemas/playbook/v1alpha1/playbook.schema.json tests/test_presentation_schema.py
+git commit -m "$(cat <<'EOF'
+feat(playbook)!: add spec.presentation, remove spec.integrations
+
+BREAKING CHANGE: the playbook `spec.integrations.gitlab` section is
+replaced by the platform-neutral `spec.presentation` (badges, checklists,
+templates). Run `regis playbook migrate` to update playbooks.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Rename the resolver to `presentation.py` and read `presentation`
+
+**Files:**
+
+- Rename: `regis/playbook/integrations/gitlab.py` → `regis/playbook/presentation.py`
+- Delete: `regis/playbook/integrations/__init__.py` (and the now-empty `integrations/` dir)
+- Modify: `regis/playbook/evaluator.py` (import + call + docstring)
+
+- [ ] **Step 1: Move the module**
+
+```bash
+git mv regis/playbook/integrations/gitlab.py regis/playbook/presentation.py
+git rm regis/playbook/integrations/__init__.py
+```
+
+(`integrations/` is now empty; `git rm` of its `__init__.py` removes the package.)
+
+- [ ] **Step 2: Edit `regis/playbook/presentation.py`**
+
+Update the module docstring + the public function. Change the docstring (lines 1-5) to:
+
+```python
+"""Presentation resolvers for the playbook engine.
+
+Evaluates platform-neutral presentation directives (labels from badges,
+checklists, templates) against the full evaluation context. Consumed by
+downstream integrations (GitLab MR, GitHub PR, Backstage, …).
+"""
+```
+
+Rename the public function and change the section it reads — replace:
+
+```python
+def resolve_gitlab_integration(
+    playbook: dict[str, Any],
+    full_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve all GitLab integration directives (badges, checklists, templates).
+
+    Returns a dict merged into the evaluation result by the orchestrator.
+    """
+    integration = playbook.get("integrations", {}).get("gitlab", {})
+    result: dict[str, Any] = {}
+    result.update(_resolve_badge_labels(integration, full_context))
+    result.update(_resolve_checklists(integration, full_context))
+    result.update(_resolve_templates(integration, full_context))
+
+    return result
+```
+
+with:
+
+```python
+def resolve_presentation(
+    playbook: dict[str, Any],
+    full_context: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve all presentation directives (badges, checklists, templates).
+
+    Reads the normalized flat ``playbook["presentation"]`` (the loader projects
+    ``spec.presentation`` onto the top level). Returns a dict merged into the
+    evaluation result by the orchestrator.
+    """
+    presentation = playbook.get("presentation", {})
+    result: dict[str, Any] = {}
+    result.update(_resolve_badge_labels(presentation, full_context))
+    result.update(_resolve_checklists(presentation, full_context))
+    result.update(_resolve_templates(presentation, full_context))
+
+    return result
+```
+
+Leave `_resolve_badge_labels`, `_resolve_checklists`, `_resolve_templates` bodies as-is for now (their output keys are renamed in Task 3). The parameter name `integration` inside those helpers can stay or be renamed to `directives` — cosmetic, optional.
+
+- [ ] **Step 3: Edit `regis/playbook/evaluator.py`**
+
+Replace the import (currently line 17):
+
+```python
+from regis.playbook.integrations.gitlab import resolve_gitlab_integration
+```
+
+with:
+
+```python
+from regis.playbook.presentation import resolve_presentation
+```
+
+Replace the call (currently line 296):
+
+```python
+    result.update(resolve_gitlab_integration(playbook, full_context))
+```
+
+with:
+
+```python
+    result.update(resolve_presentation(playbook, full_context))
+```
+
+Update the comment on the line above (currently `# Resolve sidebar, links, and GitLab integration`) to `# Resolve sidebar, links, and presentation directives`, and the module docstring line 8 (`Resolves playbook-level links and GitLab integration directives.`) to `Resolves playbook-level links and presentation directives.`.
+
+- [ ] **Step 4: Verify imports resolve and nothing else references the old path**
+
+Run: `grep -rn "resolve_gitlab_integration\|playbook.integrations\|integrations.gitlab" regis/`
+Expected: no matches.
+
+Run: `pipenv run python -c "from regis.playbook.presentation import resolve_presentation; print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+refactor(playbook): rename gitlab resolver to generic presentation
+
+`playbook/integrations/gitlab.py` -> `playbook/presentation.py`;
+`resolve_gitlab_integration` -> `resolve_presentation`, reading
+`playbook["presentation"]`. Drops the hardcoded GitLab coupling from the
+evaluator.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Rename report output fields `mr_*` → neutral
+
+**Files:**
+
+- Modify: `regis/playbook/presentation.py` (output keys)
+- Modify: `regis/schemas/playbook/result.schema.json`
+- Test: `tests/test_playbook_engine.py` (the presentation tests — see Task 6 for renaming the classes; here, update expected keys)
+
+- [ ] **Step 1: Update the output keys in `presentation.py`**
+
+In `_resolve_checklists`, change the returned key (currently `return {"mr_description_checklists": resolved_checklists}`):
+
+```python
+    if resolved_checklists:
+        return {"checklists": resolved_checklists}
+    return {}
+```
+
+In `_resolve_templates`, change the returned key (currently `return {"mr_templates": resolved_templates}`):
+
+```python
+    if resolved_templates:
+        return {"templates": resolved_templates}
+    return {}
+```
+
+`_resolve_badge_labels` keeps `{"badge_labels": ...}` (already neutral).
+
+- [ ] **Step 2: Update `regis/schemas/playbook/result.schema.json`**
+
+Rename the `mr_templates` property to `templates` (same shape) and, if present, `mr_description_checklists` to `checklists`. Run `grep -n "mr_templates\|mr_description_checklists\|badge_labels\|checklists\|templates" regis/schemas/playbook/result.schema.json` first to locate them; rename the `mr_`-prefixed keys, keep `badge_labels`. If `mr_description_checklists` is not explicitly in the schema (the result schema allows extra props), add a `checklists` property mirroring the old shape (array of `{title, items:[{label, checked}]}`).
+
+- [ ] **Step 3: Update the engine tests' expected keys**
+
+In `tests/test_playbook_engine.py`, update every assertion that reads `result["mr_description_checklists"]` → `result["checklists"]` and `result["mr_templates"]` → `result["templates"]`. (Use `grep -n "mr_description_checklists\|mr_templates" tests/test_playbook_engine.py` to find them.)
+
+- [ ] **Step 4: Run the engine tests**
+
+Run: `pipenv run pytest tests/test_playbook_engine.py -q`
+Expected: PASS (after the key renames).
+
+- [ ] **Step 5: Confirm no `mr_`-prefixed presentation keys remain**
+
+Run: `grep -rn "mr_description_checklists\|mr_templates" regis/ tests/`
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add regis/playbook/presentation.py regis/schemas/playbook/result.schema.json tests/test_playbook_engine.py
+git commit -m "$(cat <<'EOF'
+feat(playbook)!: neutralize report presentation field names
+
+BREAKING CHANGE: report fields `mr_description_checklists` -> `checklists`
+and `mr_templates` -> `templates` (`badge_labels` unchanged). Downstream
+consumers must read the new field names.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Bump `REPORT_SCHEMA_VERSION` 1 → 2
+
+**Files:**
+
+- Modify: `regis/utils/report.py` (line 17)
+- Modify: contract fixture(s) — find with `grep -rln "schemaVersion" tests/fixtures/`
+
+- [ ] **Step 1: Bump the constant**
+
+In `regis/utils/report.py`, change:
+
+```python
+REPORT_SCHEMA_VERSION = 1
+```
+
+to:
+
+```python
+REPORT_SCHEMA_VERSION = 2
+```
+
+- [ ] **Step 2: Update the contract fixture**
+
+Run: `grep -rln "schemaVersion" tests/fixtures/`. For each report fixture (e.g. `tests/fixtures/report.v1.json`), update its `schemaVersion` to `2` (and rename the file to `report.v2.json` if the test references the version in the filename; update the referencing test accordingly). If a test asserts the exact integer, update it to `2`.
+
+- [ ] **Step 3: Run the report/schema tests**
+
+Run: `pipenv run pytest -q -k "schema_version or report_schema or ensure_schema"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add regis/utils/report.py tests/fixtures/
+git commit -m "$(cat <<'EOF'
+feat(schema)!: bump REPORT_SCHEMA_VERSION to 2
+
+BREAKING CHANGE: the report envelope advertises schemaVersion 2 (neutral
+presentation fields). Consumers gating on schemaVersion must widen their
+accepted range.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Migration codemod — `integrations.gitlab` → `presentation`
+
+**Files:**
+
+- Modify: `regis/commands/playbook.py` (`_migrate_playbook_data` + the `migrate` command docstring)
+- Test: `tests/commands/test_playbook_migrate.py` (or wherever migrate is tested — `grep -rln "playbook.*migrate\|_migrate_playbook_data" tests/`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the migrate test file:
+
+```python
+def test_migrate_integrations_gitlab_to_presentation():
+    from regis.commands.playbook import _migrate_playbook_data
+
+    data = {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p"},
+        "spec": {
+            "rules": [],
+            "integrations": {
+                "gitlab": {
+                    "badges": ["score"],
+                    "checklist": [{"label": "legacy item"}],
+                    "templates": [{"url": "gh:org/t"}],
+                }
+            },
+        },
+    }
+    _migrate_playbook_data(data)
+
+    assert "integrations" not in data["spec"]
+    pres = data["spec"]["presentation"]
+    assert pres["badges"] == ["score"]
+    # the deprecated singular `checklist` is folded into `checklists`
+    assert pres["checklists"] == [{"items": [{"label": "legacy item"}]}]
+    assert pres["templates"] == [{"url": "gh:org/t"}]
+
+
+def test_migrate_presentation_is_idempotent():
+    from regis.commands.playbook import _migrate_playbook_data
+
+    data = {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p"},
+        "spec": {"rules": [], "presentation": {"badges": ["score"]}},
+    }
+    _migrate_playbook_data(data)
+    assert data["spec"]["presentation"] == {"badges": ["score"]}
+    assert "integrations" not in data["spec"]
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `pipenv run pytest tests/commands/test_playbook_migrate.py -q -k presentation`
+Expected: FAIL (`presentation` not produced; `integrations` still present).
+
+- [ ] **Step 3: Add the migration helper + wire it into `_migrate_playbook_data`**
+
+In `regis/commands/playbook.py`, add a helper above `_migrate_playbook_data`:
+
+```python
+def _migrate_integrations_to_presentation(container: Any) -> None:
+    """Move ``integrations.gitlab.{badges,checklist,checklists,templates}`` to a
+    platform-neutral ``presentation`` block on the same container. Idempotent.
+
+    Folds the deprecated singular ``checklist`` into ``checklists``.
+    """
+    if not isinstance(container, dict):
+        return
+    integrations = container.get("integrations")
+    if not isinstance(integrations, dict):
+        return
+    gitlab = integrations.get("gitlab")
+    if not isinstance(gitlab, dict):
+        return
+
+    presentation = container.get("presentation")
+    if not isinstance(presentation, dict):
+        presentation = {}
+
+    if "badges" in gitlab and "badges" not in presentation:
+        presentation["badges"] = gitlab["badges"]
+    if "templates" in gitlab and "templates" not in presentation:
+        presentation["templates"] = gitlab["templates"]
+
+    checklists = gitlab.get("checklists")
+    if not checklists and gitlab.get("checklist"):
+        # fold the deprecated singular `checklist` into the `checklists` shape
+        checklists = [{"items": gitlab["checklist"]}]
+    if checklists and "checklists" not in presentation:
+        presentation["checklists"] = checklists
+
+    if presentation:
+        container["presentation"] = presentation
+
+    # remove the now-migrated gitlab integration; drop `integrations` if empty
+    integrations.pop("gitlab", None)
+    if not integrations:
+        container.pop("integrations", None)
+```
+
+Then, inside `_migrate_playbook_data`, after the rule-migration loop, add the presentation migration for both the envelope and flat shapes:
+
+```python
+    # presentation migration (integrations.gitlab -> presentation)
+    if isinstance(spec, dict):
+        _migrate_integrations_to_presentation(spec)
+    else:
+        _migrate_integrations_to_presentation(data)
+```
+
+(Place this at the end of `_migrate_playbook_data`. `spec` is already computed earlier in that function; reuse it.)
+
+- [ ] **Step 4: Update the `migrate` command docstring**
+
+In `migrate_playbook`'s docstring, add a third bullet:
+
+```text
+    3. ``spec.integrations.gitlab`` → platform-neutral ``spec.presentation``
+       (folding the deprecated singular ``checklist`` into ``checklists``).
+```
+
+- [ ] **Step 5: Run the migration tests**
+
+Run: `pipenv run pytest tests/commands/test_playbook_migrate.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add regis/commands/playbook.py tests/commands/test_playbook_migrate.py
+git commit -m "$(cat <<'EOF'
+feat(playbook): migrate integrations.gitlab to presentation in codemod
+
+`regis playbook migrate` now moves spec.integrations.gitlab to the
+neutral spec.presentation (idempotent; folds singular checklist).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Dogfood — migrate the default playbook + cookiecutters + test class names
+
+**Files:**
+
+- Modify: `regis/playbooks/default/playbook.yaml` (lines ~153–end of integrations)
+- Modify: `regis/cookiecutters/playbook/` (any `integrations:` in the templated playbook)
+- Modify: `tests/test_playbook_engine.py` (rename `TestGitLabChecklist`/`TestGitLabTemplates` and their playbook fixtures)
+
+- [ ] **Step 1: Migrate the default playbook in place**
+
+Run: `pipenv run regis playbook migrate regis/playbooks/default/playbook.yaml --in-place`
+Then open `regis/playbooks/default/playbook.yaml` and confirm `spec.integrations` is gone and `spec.presentation` carries `badges`/`checklists`/`templates`. Validate:
+Run: `pipenv run regis playbook validate regis/playbooks/default/playbook.yaml`
+Expected: `✓ ... is valid`.
+
+- [ ] **Step 2: Migrate the cookiecutter playbook(s)**
+
+Run: `grep -rln "integrations:" regis/cookiecutters/playbook/`. For each hit, change `integrations:\n  gitlab:` to a `presentation:` block with the same `badges`/`checklists`/`templates` children (drop the `gitlab:` nesting). Keep any Jinja/cookiecutter placeholders intact.
+
+- [ ] **Step 3: Rename the engine test classes + their playbook fixtures**
+
+In `tests/test_playbook_engine.py`: rename `class TestGitLabChecklist` → `class TestPresentationChecklists` and `class TestGitLabTemplates` → `class TestPresentationTemplates`. In their inline playbook fixtures, change `integrations: {gitlab: {...}}` → `presentation: {...}` (drop the `gitlab` nesting). Expected result keys are already `checklists`/`templates` from Task 3.
+
+- [ ] **Step 4: Run the relevant tests**
+
+Run: `pipenv run pytest tests/test_playbook_engine.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm no `integrations.gitlab` remains in shipped playbooks/tests**
+
+Run: `grep -rn "integrations:" regis/playbooks regis/cookiecutters tests/ | grep -v versioned`
+Expected: no matches (or only unrelated uses).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add regis/playbooks regis/cookiecutters tests/test_playbook_engine.py
+git commit -m "$(cat <<'EOF'
+chore(playbook): migrate default playbook and cookiecutters to presentation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+
+- Modify: `docs/website/docs/concepts/playbooks.md`
+- Modify: `docs/website/docs/roadmap.md`
+- Regenerate: `docs/website/docs/reference/schemas/playbook/*.md` (if generated; else edit by hand)
+
+- [ ] **Step 1: Reframe `concepts/playbooks.md`**
+
+Find the GitLab-integration / MR-description-checklists section(s): `grep -n "integrations\|gitlab\|mr_description\|MR description\|Merge Request" docs/website/docs/concepts/playbooks.md`. Rewrite them around `spec.presentation` (badges → labels, checklists, templates) as platform-neutral directives that integrations (GitLab MR, GitHub PR, Backstage) render. Keep anchors used by other pages working (e.g. if `#mr-description-checklists` is linked elsewhere, add a redirecting note or update the linkers — check with `grep -rn "mr-description-checklists" docs/website/docs/ | grep -v versioned`).
+
+- [ ] **Step 2: Update `roadmap.md` "Stable API surface"**
+
+In `docs/website/docs/roadmap.md`, the stable-API bullet lists `mr_description_checklists`. Replace it with the neutral `presentation` / `checklists` naming, and note the `report.json` `schemaVersion` is now `2`.
+
+- [ ] **Step 3: Regenerate / fix the schema reference docs**
+
+If `docs/website/docs/reference/schemas/playbook/*.md` are generated from the JSON schemas, regenerate them (find the generator: `grep -rln "json-schema-for-humans\|schema.*\.md" scripts/ docs/`); else hand-edit the `playbook.schema.md` / `result.schema.md` to reflect `presentation` and the renamed result fields.
+
+- [ ] **Step 4: Verify docs build with no broken links**
+
+Run the Docusaurus build under `docs/website`. Confirm success and no broken-link errors. Run `grep -rn "integrations.gitlab\|mr_description_checklists\|mr_templates" docs/website/docs/ | grep -v versioned_docs` → expect no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/website/docs
+git commit -m "$(cat <<'EOF'
+docs(playbook): document spec.presentation and neutral report fields
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Final verification & PR
+
+- [ ] **Step 1: Full lint + suite with coverage**
+
+Run: `pipenv run ruff check . && pipenv run pytest`
+Expected: lint clean; suite PASS; coverage ≥ 90 %.
+
+- [ ] **Step 2: Confirm the platform coupling is gone**
+
+Run: `grep -rn "integrations.gitlab\|resolve_gitlab_integration\|mr_description_checklists\|mr_templates\|playbook.integrations" regis/ tests/`
+Expected: no matches.
+
+Run: `pipenv run regis analyze --help` (sanity — the CLI still loads).
+
+- [ ] **Step 3: Run trunk**
+
+Run: `trunk check`
+Expected: green (commit any auto-fixes).
+
+- [ ] **Step 4: Open the PR**
+
+Push the branch and open a PR titled `feat(playbook)!: generalize integrations.gitlab into spec.presentation`. In `## Summary`, document the breaking changes (playbook schema, report fields, `REPORT_SCHEMA_VERSION` 1→2) and that follow-up cycles update regis-gitlab (#2), regis-backstage (#3), and regis-action (#4) to the neutral contract. Confirm Release Please bumps the minor version (pre-v1, `bump-minor-pre-major`).
+
+---
+
+## Notes for the implementer
+
+- Branch off `main` **after PR #652 merges** (this renames `playbook/integrations/gitlab.py`, kept by #652).
+- This is breaking on three surfaces (playbook schema, report fields, schemaVersion) → one `feat(playbook)!` PR, pre-v1 minor bump.
+- Downstream repos are explicitly out of scope (follow-up sub-projects #2/#3/#4); they degrade gracefully until updated (backstage gates on schemaVersion; the regis-gitlab template uses `// []`).
+- `versioned_docs/**` are frozen — never edit them.

--- a/docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md
+++ b/docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md
@@ -1,0 +1,140 @@
+# Design — Généralisation de la couche « integrations » du playbook → `spec.presentation`
+
+- **Date** : 2026-06-06
+- **Statut** : validé (brainstorming)
+- **Sous-projet** : #1 (cœur) d'un effort multi-dépôts. Découple le moteur de playbook des
+  spécificités plateforme, le rend extensible, et déplace le *rendu* plateforme vers les dépôts
+  d'intégration.
+
+## 1. Contexte et cadrage
+
+Aujourd'hui le cœur connaît GitLab en dur :
+
+- **Schéma playbook** : `spec.integrations.gitlab.{badges, checklist, checklists, templates}`
+  (`regis/schemas/playbook/v1alpha1/playbook.schema.json`).
+- **Évaluateur** : `regis/playbook/evaluator.py` importe et appelle en dur
+  `resolve_gitlab_integration(...)` (`regis/playbook/integrations/gitlab.py`).
+- **Sortie `report.json`** : `badge_labels`, `mr_description_checklists`, `mr_templates` (le préfixe
+  `mr_` = Merge Request = GitLab).
+
+Or **la logique de résolution est déjà générique** (évaluer `show_if`/`check_if` contre le contexte,
+résoudre des badges en labels). Seuls le **nommage** (`integrations.gitlab`, `mr_*`) et l'**import en
+dur** sont spécifiques plateforme. La **résolution doit rester dans le cœur** (elle a besoin du moteur
+d'évaluation + du contexte d'analyse) ; le **rendu** plateforme (resolved data → labels MR/PR,
+annotations) appartient déjà aux intégrations externes (regis-gitlab template, regis-action,
+regis-backstage), qui sont **non-Python** et ne peuvent pas exécuter de résolveur du cœur.
+
+### Décisions (brainstorming)
+
+1. **Généraliser** (vs registry de plugins / hybride) : le cœur expose des directives playbook
+   **neutres**, résolues en champs `report.json` **neutres** ; chaque intégration lit ces champs et
+   rend à sa plateforme. Le cœur ne connaît plus aucune plateforme.
+2. **Nom de section : `spec.presentation`** (« comment les findings sont présentés aux
+   consommateurs » : labels, checklists, templates).
+3. **Transition : hard-cut coordonné** — le cœur **renomme** les champs (pas de dual-emit) et
+   **bumpe `REPORT_SCHEMA_VERSION` (1 → 2)**. Les consommateurs (#2/#3/#4) migrent en lockstep.
+   La dégradation downstream est **gracieuse** : regis-backstage gate sur `schemaVersion` (UI d'erreur
+   hors plage, pas de crash) et le template regis-gitlab utilise `// []` en jq (labels/checklists
+   vides plutôt que crash) tant qu'il n'est pas mis à jour.
+
+### Décomposition de l'effort (rappel)
+
+| # | Sous-projet | Statut |
+| --- | --- | --- |
+| **1** | **Cœur — généralisation** (ce spec) | en cours |
+| 2 | regis-gitlab (template lit les champs neutres) | cycle propre, après #1 |
+| 3 | regis-backstage (`regis-common` types/schema + rendu) | cycle propre, après #1 |
+| 4 | regis-action (consomme les champs neutres → parité PR GitHub) | cycle propre, après #1 |
+
+**Ce spec ne couvre que #1 (cœur).** Les #2/#3/#4 auront leur propre spec→plan.
+
+## 2. Changements — schéma playbook (entrée, cassant)
+
+Dans `regis/schemas/playbook/v1alpha1/playbook.schema.json` :
+
+- Remplacer `spec.integrations` par **`spec.presentation`** (object), portant les **mêmes 3
+  directives**, plateforme-neutres :
+  - `badges` : liste de slugs de badges à exposer comme labels (ex-`integrations.gitlab.badges`).
+  - `checklists` : checklists conditionnelles (ex-`integrations.gitlab.checklists`) ; items via le
+    `$def` `checklist_item` existant (`label`, `show_if`, `check_if`).
+  - `templates` : templates cookiecutter conditionnels (ex-`integrations.gitlab.templates`).
+- **Drop** le `checklist` singulier déprécié (la migration le replie dans `checklists`).
+- Mettre à jour la `description` de la section (retirer « GitLab/GitHub »).
+
+`apiVersion` reste `regis.trivoallan.dev/v1alpha1` (le schéma est explicitement pré-v1/évolutif).
+
+## 3. Changements — évaluateur + résolveur (cœur)
+
+- **Renommer** `regis/playbook/integrations/gitlab.py` → `regis/playbook/presentation.py` ; renommer
+  `resolve_gitlab_integration` → **`resolve_presentation`**. Les helpers (`_resolve_badge_labels`,
+  `_resolve_checklists`, `_resolve_templates`) sont déjà génériques. **Précision loader** : le loader
+  valide l'enveloppe k8s (section sous `spec.presentation` dans le schéma) puis **normalise vers un
+  dict aplati** (cf. décision 2026-06-01) ; le résolveur lit donc la forme **aplatie**
+  `playbook.get("presentation", {})` (comme l'actuel `playbook["integrations"]["gitlab"]` lit déjà
+  la forme aplatie, pas `spec.*`).
+- **Supprimer** le package `regis/playbook/integrations/` (vide après le renommage).
+- `regis/playbook/evaluator.py` : remplacer l'import + l'appel `resolve_gitlab_integration(...)`
+  (l. 17, 296) par `resolve_presentation(...)`. Mettre à jour le docstring (« GitLab integration
+  directives » → « presentation directives »).
+
+## 4. Changements — sortie `report.json` (contrat, cassant + bump version)
+
+- Renommer dans le résultat produit + `regis/schemas/playbook/result.schema.json` :
+  - `mr_description_checklists` → **`checklists`**
+  - `mr_templates` → **`templates`**
+  - `badge_labels` → **conservé** (déjà neutre).
+- `regis/utils/report.py` : **`REPORT_SCHEMA_VERSION` 1 → 2**.
+- Mettre à jour `regis/schemas/report/report.schema.json` / `result.schema.json` en conséquence (les
+  champs neutres + la version).
+
+## 5. Migration + dogfood
+
+- **`regis playbook upgrade`** : déplacer `spec.integrations.gitlab.{badges,checklist,checklists,templates}`
+  → `spec.presentation.{badges,checklists,templates}` (replier `checklist`→`checklists`), idempotent.
+  Drop `spec.integrations` une fois vide.
+- **Playbook par défaut** (`regis/playbooks/default/…`) migré (dogfood) → plus de section
+  `integrations`.
+- Cookiecutters playbook (`regis/cookiecutters/playbook/`) mis à jour vers `presentation`.
+
+## 6. Documentation cœur
+
+- `concepts/playbooks.md` (section MR-description-checklists / integrations) recadrée sur
+  `spec.presentation`, neutre, sans framing GitLab.
+- `reference/` schémas régénérés (`playbook.schema.md`, `result.schema.md`).
+- `roadmap.md` : ligne « Stable API surface » (l. 25) — retirer `mr_description_checklists`,
+  mentionner `presentation` / `checklists` ; noter le bump `schemaVersion`.
+- `versioned_docs/**` : intacts.
+
+## 7. Tests
+
+- Renommer/adapter `tests/test_playbook_engine.py` (`TestGitLabChecklist` / `TestGitLabTemplates`
+  → `TestPresentationChecklists` / `TestPresentationTemplates`) : testent le résolveur générique,
+  lisant `spec.presentation`, attendant `checklists`/`templates`/`badge_labels`.
+- Tests de `regis playbook upgrade` : `integrations.gitlab` → `presentation` (+ repli `checklist`).
+- Tests de l'évaluateur / loader inchangés sauf chemin de section.
+- `pipenv run pytest` vert, couverture **≥ 90 %**. `ruff` + `trunk` verts. Build doc sans lien cassé.
+
+## 8. Hors périmètre (sous-projets suivants)
+
+- **#2 regis-gitlab** : le template `regis-mr.yml` lit `.playbook.checklists` / `.playbook.templates`
+  (ex-`mr_description_checklists`/`mr_templates`) ; nouvelle release `v2` ; gate sur le nouveau
+  `schemaVersion`.
+- **#3 regis-backstage** : `regis-common` types + `report.schema.json` alignés ; rendu sur les champs
+  neutres ; élargir la plage `checkSchemaCompat` (`{min,max}`) pour accepter `schemaVersion: 2`.
+- **#4 regis-action** : consommer `.playbook.badge_labels` / `.playbook.checklists` → parité PR GitHub
+  (labels + checklist dans la description de PR).
+
+## 9. Séquencement & risques
+
+| Risque | Mitigation |
+| --- | --- |
+| Hard-cut casse les consommateurs avant #2/#3/#4 | Dégradation gracieuse (gate `schemaVersion` côté backstage, `// []` côté template) ; merger #1 puis enchaîner #2/#3/#4 rapidement |
+| Dépendance à `regis-gitlab.py` (renommé) vs PR #652 ouverte | Brancher l'implémentation sur `main` **après merge de #652** (qui conserve `gitlab.py`) ; sinon conflit de renommage |
+| Champ « stable » documenté (`mr_description_checklists`) | Le schéma playbook est `v1alpha1` (évolutif, pré-v1) ; migration fournie ; roadmap mise à jour |
+| Playbooks tiers utilisant `integrations.gitlab` | `regis playbook upgrade` les migre ; warning de dépréciation possible si on veut un dual-read transitoire (optionnel, non retenu — hard-cut) |
+
+## 10. Livrable
+
+- **1 PR cœur** (breaking : `feat(playbook)!` — schéma playbook + contrat report + bump
+  `REPORT_SCHEMA_VERSION`). Branchée sur `main` après #652.
+- Mise à jour Memory Bank (`activeContext.md` + `progress.md` + `decisionLog.md`) à la complétion.

--- a/docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md
+++ b/docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md
@@ -3,7 +3,7 @@
 - **Date** : 2026-06-06
 - **Statut** : validé (brainstorming)
 - **Sous-projet** : #1 (cœur) d'un effort multi-dépôts. Découple le moteur de playbook des
-  spécificités plateforme, le rend extensible, et déplace le *rendu* plateforme vers les dépôts
+  spécificités plateforme, le rend extensible, et déplace le _rendu_ plateforme vers les dépôts
   d'intégration.
 
 ## 1. Contexte et cadrage
@@ -39,12 +39,12 @@ regis-backstage), qui sont **non-Python** et ne peuvent pas exécuter de résolv
 
 ### Décomposition de l'effort (rappel)
 
-| # | Sous-projet | Statut |
-| --- | --- | --- |
-| **1** | **Cœur — généralisation** (ce spec) | en cours |
-| 2 | regis-gitlab (template lit les champs neutres) | cycle propre, après #1 |
-| 3 | regis-backstage (`regis-common` types/schema + rendu) | cycle propre, après #1 |
-| 4 | regis-action (consomme les champs neutres → parité PR GitHub) | cycle propre, après #1 |
+| #     | Sous-projet                                                   | Statut                 |
+| ----- | ------------------------------------------------------------- | ---------------------- |
+| **1** | **Cœur — généralisation** (ce spec)                           | en cours               |
+| 2     | regis-gitlab (template lit les champs neutres)                | cycle propre, après #1 |
+| 3     | regis-backstage (`regis-common` types/schema + rendu)         | cycle propre, après #1 |
+| 4     | regis-action (consomme les champs neutres → parité PR GitHub) | cycle propre, après #1 |
 
 **Ce spec ne couvre que #1 (cœur).** Les #2/#3/#4 auront leur propre spec→plan.
 
@@ -126,12 +126,12 @@ Dans `regis/schemas/playbook/v1alpha1/playbook.schema.json` :
 
 ## 9. Séquencement & risques
 
-| Risque | Mitigation |
-| --- | --- |
-| Hard-cut casse les consommateurs avant #2/#3/#4 | Dégradation gracieuse (gate `schemaVersion` côté backstage, `// []` côté template) ; merger #1 puis enchaîner #2/#3/#4 rapidement |
-| Dépendance à `regis-gitlab.py` (renommé) vs PR #652 ouverte | Brancher l'implémentation sur `main` **après merge de #652** (qui conserve `gitlab.py`) ; sinon conflit de renommage |
-| Champ « stable » documenté (`mr_description_checklists`) | Le schéma playbook est `v1alpha1` (évolutif, pré-v1) ; migration fournie ; roadmap mise à jour |
-| Playbooks tiers utilisant `integrations.gitlab` | `regis playbook upgrade` les migre ; warning de dépréciation possible si on veut un dual-read transitoire (optionnel, non retenu — hard-cut) |
+| Risque                                                      | Mitigation                                                                                                                                   |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hard-cut casse les consommateurs avant #2/#3/#4             | Dégradation gracieuse (gate `schemaVersion` côté backstage, `// []` côté template) ; merger #1 puis enchaîner #2/#3/#4 rapidement            |
+| Dépendance à `regis-gitlab.py` (renommé) vs PR #652 ouverte | Brancher l'implémentation sur `main` **après merge de #652** (qui conserve `gitlab.py`) ; sinon conflit de renommage                         |
+| Champ « stable » documenté (`mr_description_checklists`)    | Le schéma playbook est `v1alpha1` (évolutif, pré-v1) ; migration fournie ; roadmap mise à jour                                               |
+| Playbooks tiers utilisant `integrations.gitlab`             | `regis playbook upgrade` les migre ; warning de dépréciation possible si on veut un dual-read transitoire (optionnel, non retenu — hard-cut) |
 
 ## 10. Livrable
 

--- a/docs/website/docs/concepts/playbooks.md
+++ b/docs/website/docs/concepts/playbooks.md
@@ -21,12 +21,12 @@ By using playbooks, you can decouple the raw data extraction (performed by analy
 
 Playbooks use a Kubernetes-style resource envelope. Every `playbook.yaml` must declare these four top-level keys:
 
-| Field        | Required | Description                                                |
-| ------------ | -------- | ---------------------------------------------------------- |
-| `apiVersion` | yes      | Must be `regis.io/v1alpha1`.                               |
-| `kind`       | yes      | Must be `Playbook`.                                        |
-| `metadata`   | yes      | Identity and version of this playbook (see below).         |
-| `spec`       | yes      | Rules, tiers, badges, integrations, and links (see below). |
+| Field        | Required | Description                                                           |
+| ------------ | -------- | --------------------------------------------------------------------- |
+| `apiVersion` | yes      | Must be `regis.io/v1alpha1`.                                          |
+| `kind`       | yes      | Must be `Playbook`.                                                   |
+| `metadata`   | yes      | Identity and version of this playbook (see below).                    |
+| `spec`       | yes      | Rules, tiers, badges, presentation directives, and links (see below). |
 
 ### `metadata` fields
 
@@ -40,13 +40,13 @@ Playbooks use a Kubernetes-style resource envelope. Every `playbook.yaml` must d
 
 ### `spec` fields
 
-| Field               | Required | Description                                                           |
-| ------------------- | -------- | --------------------------------------------------------------------- |
-| `spec.tiers`        | no       | Compliance tier thresholds (Gold / Silver / Bronze).                  |
-| `spec.rules`        | no       | Rules: bindings of a criterion (provider + criterion slug + options). |
-| `spec.badges`       | no       | Dynamic status badges displayed in the report header.                 |
-| `spec.integrations` | no       | Third-party platform integrations (e.g. `integrations.gitlab`).       |
-| `spec.links`        | no       | Custom action links displayed in the report.                          |
+| Field               | Required | Description                                                                                                                                     |
+| ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec.tiers`        | no       | Compliance tier thresholds (Gold / Silver / Bronze).                                                                                            |
+| `spec.rules`        | no       | Rules: bindings of a criterion (provider + criterion slug + options).                                                                           |
+| `spec.badges`       | no       | Dynamic status badges displayed in the report header.                                                                                           |
+| `spec.presentation` | no       | Platform-neutral presentation directives (badge labels, checklists, templates) consumed by integrations (e.g. GitLab MR, GitHub PR, Backstage). |
+| `spec.links`        | no       | Custom action links displayed in the report.                                                                                                    |
 
 ### Field mapping from the legacy format
 
@@ -68,7 +68,7 @@ The mapping is:
 | `tiers`                      | `spec.tiers`                                   |
 | `rules`                      | `spec.rules`                                   |
 | `badges`                     | `spec.badges`                                  |
-| `integrations`               | `spec.integrations`                            |
+| `integrations`               | `spec.presentation`                            |
 | `links`                      | `spec.links`                                   |
 | `pages`/`sections`/`sidebar` | removed (not used by the report viewer)        |
 
@@ -161,29 +161,28 @@ For example, to display the overall compliance score in a widget, you might use:
   value: "{{ playbooks.0.score }}%"
 ```
 
-## GitLab Integration
+## Presentation Directives
 
-Playbooks can automate Merge Request (MR) management in GitLab through the `integrations.gitlab` key.
+`spec.presentation` defines platform-neutral directives that consuming integrations (GitLab MR, GitHub PR, Backstage, etc.) can render. The playbook engine evaluates these directives once and exposes the results in the report; each integration then decides how to surface them.
 
-### Badge Synchronization
+### Badge Labels
 
-The `badges` list automatically synchronizes authorized status badges as GitLab labels. Each badge in the list is identified by its **slug**.
+The `badge_labels` list specifies which badge slugs integrations should surface as status labels. Each slug must match a badge defined in `spec.badges`.
 
 ```yaml
 spec:
-  integrations:
-    gitlab:
-      badges:
-        - score
-        - freshness
-        - cve-critical
+  presentation:
+    badge_labels:
+      - score
+      - freshness
+      - cve-critical
 ```
 
-This ensures that the MR UI (labels) always reflects the visual status shown in the HTML report. Regular condition-based labels are deprecated in favor of this badge-driven approach.
+Integrations use this list to keep their label surface (e.g. GitLab MR labels, GitHub PR labels) in sync with the badge values shown in the HTML report.
 
-### MR Description Checklists
+### Checklists
 
-The `checklists` list adds configurable checklists to the body of the Merge Request description. This lets you define manual verification steps that reviewers must tick off before approving the MR.
+The `checklists` list adds configurable verification checklists to integration surfaces (e.g. the Merge Request or Pull Request description). Each checklist lets you define manual steps that reviewers must tick off before approving.
 
 Each checklist can have a `title` and a list of `items`. Each item has a mandatory `label` and two optional conditions:
 
@@ -194,28 +193,27 @@ Each checklist can have a `title` and a list of `items`. Each item has a mandato
 
 ```yaml
 spec:
-  integrations:
-    gitlab:
-      checklists:
-        - title: 📝 Security Review
-          items:
-            - label: Security review completed # <1>
-            - label: No critical vulnerabilities found
-              show_if: { "==": [{ var: results.cve.critical_count }, 0] } # <2>
-              check_if: { "==": [{ var: results.cve.critical_count }, 0] } # <3>
-        - title: 🚀 Compliance checks
-          items:
-            - label: Image from a trusted registry
-              show_if:
-                {
-                  "in":
-                    [{ var: request.registry }, [docker.io, quay.io, ghcr.io]],
-                }
-              check_if:
-                {
-                  "in":
-                    [{ var: request.registry }, [docker.io, quay.io, ghcr.io]],
-                }
+  presentation:
+    checklists:
+      - title: 📝 Security Review
+        items:
+          - label: Security review completed # <1>
+          - label: No critical vulnerabilities found
+            show_if: { "==": [{ var: results.cve.critical_count }, 0] } # <2>
+            check_if: { "==": [{ var: results.cve.critical_count }, 0] } # <3>
+      - title: 🚀 Compliance checks
+        items:
+          - label: Image from a trusted registry
+            show_if:
+              {
+                "in":
+                  [{ var: request.registry }, [docker.io, quay.io, ghcr.io]],
+              }
+            check_if:
+              {
+                "in":
+                  [{ var: request.registry }, [docker.io, quay.io, ghcr.io]],
+              }
 ```
 
 (1) Unconditional item — always included, always unchecked.
@@ -226,11 +224,11 @@ spec:
 You can use `show_if` and `check_if` independently. For example, an item may always be shown (`no show_if`) but pre-checked only when a condition passes.
 :::
 
-The engine exposes the resolved checklists as `mr_description_checklists` (a list of `{title, items: [{label, checked}]}` objects) in the playbook evaluation result. The CI layer converts this list to Markdown checklists with H2 titles and appends it to the MR description.
+The engine exposes the resolved checklists as `checklists` (a list of `{title, items: [{label, checked}]}` objects) in the playbook evaluation result. Each integration converts this list to its native format — for example, a GitLab CI job appends them as Markdown checklists to the MR description.
 
-### MR Templates
+### Templates
 
-The `templates` list lets you define Cookiecutter templates that will be rendered directly into the Merge Request branch by the pipeline. This is useful for automatically generating boilerplate code, security compliance files, or evidence reports based on the analysis results.
+The `templates` list lets you define Cookiecutter templates that integrations can render into their target branch or workspace. This is useful for automatically generating boilerplate code, security compliance files, or evidence reports based on the analysis results.
 
 Each item must have a `url` and an optional `condition`:
 
@@ -242,12 +240,11 @@ Each item must have a `url` and an optional `condition`:
 
 ```yaml
 spec:
-  integrations:
-    gitlab:
-      templates:
-        - url: "https://github.com/my-org/security-evidence-template"
-          directory: "templates/my-evidence" # optional
-          condition: { ">": [{ var: results.cve.critical_count }, 0] }
+  presentation:
+    templates:
+      - url: "https://github.com/my-org/security-evidence-template"
+        directory: "templates/my-evidence" # optional
+        condition: { ">": [{ var: results.cve.critical_count }, 0] }
 ```
 
 :::warning
@@ -261,7 +258,7 @@ Because Cookiecutter ignores extra context variables that aren't defined in the 
 
 :::
 
-During evaluation, templates whose condition passes are aggregated. The CLI then executes these templates with access to the full analysis context (e.g., `cookiecutter.regis.score`), and writes the generated files back to the current working directory so they can be committed to the MR branch.
+During evaluation, templates whose condition passes are aggregated and exposed as `templates` in the playbook result. Each integration then executes these templates with the full analysis context (e.g., `cookiecutter.regis.score`) and writes the generated files to the appropriate location.
 
 ## Bundle Structure
 
@@ -393,20 +390,19 @@ spec:
       class: information
 ```
 
-**MR checklist — link to the security document:**
+**Presentation checklist — link to the security document:**
 
 ```yaml
 spec:
-  integrations:
-    gitlab:
-      checklists:
-        - title: 📋 Security Evidence
-          items:
-            - label: Security validation document submitted
-              show_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
-              check_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
-            - label: "Review document: ${metadata.SEC_DOC_URL}"
-              show_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
+  presentation:
+    checklists:
+      - title: 📋 Security Evidence
+        items:
+          - label: Security validation document submitted
+            show_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
+            check_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
+          - label: "Review document: ${metadata.SEC_DOC_URL}"
+            show_if: { "!!": [{ var: "metadata.SEC_DOC_URL" }] }
 ```
 
 **Tier condition — gate Gold tier on CI platform:**

--- a/docs/website/docs/reference/schemas/analyzer/cve.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/cve.schema.md
@@ -249,4 +249,4 @@ Specific value: `"cve"`
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:16 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/dockle.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/dockle.schema.md
@@ -212,4 +212,4 @@ Must be one of:
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/endoflife.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/endoflife.schema.md
@@ -161,4 +161,4 @@ Specific value: `"endoflife"`
 | **Minimum**  | &ge; 0 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/freshness.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/freshness.schema.md
@@ -95,4 +95,4 @@ Specific value: `"freshness"`
 **Description:** True if the current tag points to the same digest as the 'latest' tag.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:16 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/hadolint.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/hadolint.schema.md
@@ -185,4 +185,4 @@ Must be one of:
 **Description:** Line number in the pseudo-Dockerfile.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/oci.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/oci.schema.md
@@ -252,4 +252,4 @@ Specific value: `"oci"`
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:16 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/popularity.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/popularity.schema.md
@@ -96,4 +96,4 @@ Specific value: `"popularity"`
 **Description:** True if this is an official Docker Hub repository.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/provenance.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/provenance.schema.md
@@ -140,4 +140,4 @@ Specific value: `"provenance"`
 **Description:** The value of the indicator.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/sbom.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/sbom.schema.md
@@ -276,4 +276,4 @@ Specific value: `"sbom"`
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/scorecarddev.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/scorecarddev.schema.md
@@ -118,4 +118,4 @@ Specific value: `"scorecarddev"`
 **Description:** Human-readable explanation of the score.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:30 +0200

--- a/docs/website/docs/reference/schemas/analyzer/secrets.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/secrets.schema.md
@@ -124,4 +124,4 @@ Specific value: `"secrets"`
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/size.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/size.schema.md
@@ -249,4 +249,4 @@ Specific value: `"size"`
 | **Minimum**  | &ge; 0 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/analyzer/versioning.schema.md
+++ b/docs/website/docs/reference/schemas/analyzer/versioning.schema.md
@@ -332,4 +332,4 @@ Must be one of:
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/meta/well-known.schema.md
+++ b/docs/website/docs/reference/schemas/meta/well-known.schema.md
@@ -46,4 +46,4 @@ Must be one of:
 **Description:** URL to the CI job run
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:17 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/playbook/jsonlogic.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/jsonlogic.schema.md
@@ -9,4 +9,4 @@
 **Description:** Simplified schema for JSON Logic expressions used in regis playbooks.
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:18 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/playbook/playbook.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/playbook.schema.md
@@ -14,7 +14,7 @@
 | + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.io/v1alpha1'. |
 | + [kind](#kind )             | No      | const  | No         | -          | Resource kind. Must equal 'Playbook'.                              |
 | + [metadata](#metadata )     | No      | object | No         | -          | -                                                                  |
-| + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, integrations, links.          |
+| + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, presentation, links.          |
 
 ## <a name="apiVersion"></a>1. ![Required](https://img.shields.io/badge/Required-blue) Property `apiVersion`
 
@@ -136,12 +136,12 @@ Specific value: `"Playbook"`
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-**Description:** Playbook body: rules, tiers, badges, integrations, links.
+**Description:** Playbook body: rules, tiers, badges, presentation, links.
 
 | Property                              | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                           |
 | ------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
 | - [links](#spec_links )               | No      | array of object | No         | -          | Optional custom links to display as actions for this playbook.                                                              |
-| - [integrations](#spec_integrations ) | No      | object          | No         | -          | Optional third-party platform integrations (e.g. GitLab, GitHub).                                                           |
+| - [presentation](#spec_presentation ) | No      | object          | No         | -          | Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).               |
 | - [rules](#spec_rules )               | No      | array of object | No         | -          | Custom rule overrides or template instantiations.                                                                           |
 | - [tiers](#spec_tiers )               | No      | array of object | No         | -          | Compliance tier thresholds. Each tier is awarded when its JsonLogic condition evaluates to true, evaluated in order.        |
 | - [badges](#spec_badges )             | No      | array of object | No         | -          | Dynamic status badges displayed in the report header. Each badge is conditionally rendered based on a JsonLogic expression. |
@@ -206,126 +206,28 @@ Specific value: `"Playbook"`
 
 **Description:** Optional JsonLogic expression to determine if the link should be displayed.
 
-### <a name="spec_integrations"></a>4.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `integrations`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional third-party platform integrations (e.g. GitLab, GitHub).
-
-| Property                               | Pattern | Type   | Deprecated | Definition | Title/Description |
-| -------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [gitlab](#spec_integrations_gitlab ) | No      | object | No         | -          | -                 |
-
-#### <a name="spec_integrations_gitlab"></a>4.2.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `gitlab`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-| Property                                              | Pattern | Type            | Deprecated | Definition | Title/Description                                                                           |
-| ----------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------- |
-| - [badges](#spec_integrations_gitlab_badges )         | No      | array of string | No         | -          | List of badge slugs to be imported as GitLab Merge Request labels.                          |
-| - [checklist](#spec_integrations_gitlab_checklist )   | No      | array           | No         | -          | (Deprecated) Single checklist items added as checkboxes to the Merge Request description.   |
-| - [checklists](#spec_integrations_gitlab_checklists ) | No      | array of object | No         | -          | Configurable checklists added as checkboxes to the Merge Request description.               |
-| - [templates](#spec_integrations_gitlab_templates )   | No      | array of object | No         | -          | URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch. |
-
-##### <a name="spec_integrations_gitlab_badges"></a>4.2.1.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `badges`
-
-|          |                   |
-| -------- | ----------------- |
-| **Type** | `array of string` |
-
-**Description:** List of badge slugs to be imported as GitLab Merge Request labels.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                        | Description |
-| ------------------------------------------------------ | ----------- |
-| [badges items](#spec_integrations_gitlab_badges_items) | -           |
-
-###### <a name="spec_integrations_gitlab_badges_items"></a>4.2.1.1.1. badges items
-
-|          |          |
-| -------- | -------- |
-| **Type** | `string` |
-
-##### <a name="spec_integrations_gitlab_checklist"></a>4.2.1.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklist`
-
-|          |         |
-| -------- | ------- |
-| **Type** | `array` |
-
-**Description:** (Deprecated) Single checklist items added as checkboxes to the Merge Request description.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                             | Description |
-| ----------------------------------------------------------- | ----------- |
-| [checklist_item](#spec_integrations_gitlab_checklist_items) | -           |
-
-###### <a name="spec_integrations_gitlab_checklist_items"></a>4.2.1.2.1. checklist_item
+### <a name="spec_presentation"></a>4.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `presentation`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
-| **Defined in**            | #/$defs/checklist_item                                         |
 
-| Property                                                          | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                                                     |
-| ----------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| + [label](#spec_integrations_gitlab_checklist_items_label )       | No      | string | No         | -          | Text of the checkbox item.                                                                                                                            |
-| - [show_if](#spec_integrations_gitlab_checklist_items_show_if )   | No      | object | No         | -          | Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.                                        |
-| - [check_if](#spec_integrations_gitlab_checklist_items_check_if ) | No      | object | No         | -          | Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]). |
+**Description:** Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).
 
-###### <a name="spec_integrations_gitlab_checklist_items_label"></a>4.2.1.2.1.1. Property `label`
+| Property                                       | Pattern | Type            | Deprecated | Definition | Title/Description                                                               |
+| ---------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------- |
+| - [badges](#spec_presentation_badges )         | No      | array of string | No         | -          | Badge slugs to surface as labels for consuming integrations.                    |
+| - [checklists](#spec_presentation_checklists ) | No      | array of object | No         | -          | Conditional checklists surfaced by integrations (e.g. in an MR/PR description). |
+| - [templates](#spec_presentation_templates )   | No      | array of object | No         | -          | Conditional Cookiecutter templates surfaced to integrations.                    |
 
-|          |          |
-| -------- | -------- |
-| **Type** | `string` |
-
-**Description:** Text of the checkbox item.
-
-###### <a name="spec_integrations_gitlab_checklist_items_show_if"></a>4.2.1.2.1.2. Property `show_if`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.
-
-###### <a name="spec_integrations_gitlab_checklist_items_check_if"></a>4.2.1.2.1.3. Property `check_if`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]).
-
-##### <a name="spec_integrations_gitlab_checklists"></a>4.2.1.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklists`
+#### <a name="spec_presentation_badges"></a>4.2.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `badges`
 
 |          |                   |
 | -------- | ----------------- |
-| **Type** | `array of object` |
+| **Type** | `array of string` |
 
-**Description:** Configurable checklists added as checkboxes to the Merge Request description.
+**Description:** Badge slugs to surface as labels for consuming integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -335,23 +237,49 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                | Description |
-| -------------------------------------------------------------- | ----------- |
-| [checklists items](#spec_integrations_gitlab_checklists_items) | -           |
+| Each item of this array must be                 | Description |
+| ----------------------------------------------- | ----------- |
+| [badges items](#spec_presentation_badges_items) | -           |
 
-###### <a name="spec_integrations_gitlab_checklists_items"></a>4.2.1.3.1. checklists items
+##### <a name="spec_presentation_badges_items"></a>4.2.1.1. badges items
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+#### <a name="spec_presentation_checklists"></a>4.2.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklists`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+**Description:** Conditional checklists surfaced by integrations (e.g. in an MR/PR description).
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                         | Description |
+| ------------------------------------------------------- | ----------- |
+| [checklists items](#spec_presentation_checklists_items) | -           |
+
+##### <a name="spec_presentation_checklists_items"></a>4.2.2.1. checklists items
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                                     | Pattern | Type   | Deprecated | Definition | Title/Description                |
-| ------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | -------------------------------- |
-| - [title](#spec_integrations_gitlab_checklists_items_title ) | No      | string | No         | -          | Display title for the checklist. |
-| + [items](#spec_integrations_gitlab_checklists_items_items ) | No      | array  | No         | -          | Items in this checklist.         |
+| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description                |
+| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------- |
+| - [title](#spec_presentation_checklists_items_title ) | No      | string | No         | -          | Display title for the checklist. |
+| + [items](#spec_presentation_checklists_items_items ) | No      | array  | No         | -          | Items in this checklist.         |
 
-###### <a name="spec_integrations_gitlab_checklists_items_title"></a>4.2.1.3.1.1. Property `title`
+###### <a name="spec_presentation_checklists_items_title"></a>4.2.2.1.1. Property `title`
 
 |          |          |
 | -------- | -------- |
@@ -359,7 +287,7 @@ Specific value: `"Playbook"`
 
 **Description:** Display title for the checklist.
 
-###### <a name="spec_integrations_gitlab_checklists_items_items"></a>4.2.1.3.1.2. Property `items`
+###### <a name="spec_presentation_checklists_items_items"></a>4.2.2.1.2. Property `items`
 
 |          |         |
 | -------- | ------- |
@@ -375,25 +303,57 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                          | Description |
-| ------------------------------------------------------------------------ | ----------- |
-| [checklist_item](#spec_integrations_gitlab_checklists_items_items_items) | -           |
+| Each item of this array must be                                   | Description |
+| ----------------------------------------------------------------- | ----------- |
+| [checklist_item](#spec_presentation_checklists_items_items_items) | -           |
 
-###### <a name="spec_integrations_gitlab_checklists_items_items_items"></a>4.2.1.3.1.2.1. checklist_item
+###### <a name="spec_presentation_checklists_items_items_items"></a>4.2.2.1.2.1. checklist_item
 
-|                           |                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                              |
-| **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red)                        |
-| **Same definition as**    | [spec_integrations_gitlab_checklist_items](#spec_integrations_gitlab_checklist_items) |
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Type**                  | `object`                                                       |
+| **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
+| **Defined in**            | #/$defs/checklist_item                                         |
 
-##### <a name="spec_integrations_gitlab_templates"></a>4.2.1.4. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `templates`
+| Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                                                     |
+| ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| + [label](#spec_presentation_checklists_items_items_items_label )       | No      | string | No         | -          | Text of the checkbox item.                                                                                                                            |
+| - [show_if](#spec_presentation_checklists_items_items_items_show_if )   | No      | object | No         | -          | Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.                                        |
+| - [check_if](#spec_presentation_checklists_items_items_items_check_if ) | No      | object | No         | -          | Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]). |
+
+###### <a name="spec_presentation_checklists_items_items_items_label"></a>4.2.2.1.2.1.1. Property `label`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+**Description:** Text of the checkbox item.
+
+###### <a name="spec_presentation_checklists_items_items_items_show_if"></a>4.2.2.1.2.1.2. Property `show_if`
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+**Description:** Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.
+
+###### <a name="spec_presentation_checklists_items_items_items_check_if"></a>4.2.2.1.2.1.3. Property `check_if`
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+**Description:** Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]).
+
+#### <a name="spec_presentation_templates"></a>4.2.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `templates`
 
 |          |                   |
 | -------- | ----------------- |
 | **Type** | `array of object` |
 
-**Description:** URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch.
+**Description:** Conditional Cookiecutter templates surfaced to integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -403,24 +363,24 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                              | Description |
-| ------------------------------------------------------------ | ----------- |
-| [templates items](#spec_integrations_gitlab_templates_items) | -           |
+| Each item of this array must be                       | Description |
+| ----------------------------------------------------- | ----------- |
+| [templates items](#spec_presentation_templates_items) | -           |
 
-###### <a name="spec_integrations_gitlab_templates_items"></a>4.2.1.4.1. templates items
+##### <a name="spec_presentation_templates_items"></a>4.2.3.1. templates items
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                            | Pattern | Type                                           | Deprecated | Definition                                        | Title/Description                                                    |
-| ------------------------------------------------------------------- | ------- | ---------------------------------------------- | ---------- | ------------------------------------------------- | -------------------------------------------------------------------- |
-| + [url](#spec_integrations_gitlab_templates_items_url )             | No      | string                                         | No         | -                                                 | Cookiecutter template URL or path.                                   |
-| - [directory](#spec_integrations_gitlab_templates_items_directory ) | No      | string                                         | No         | -                                                 | Optional subdirectory within the repository containing the template. |
-| - [condition](#spec_integrations_gitlab_templates_items_condition ) | No      | object, array, string, number, boolean or null | No         | Same as [condition](#spec_links_items_condition ) | jsonlogic                                                            |
+| Property                                                     | Pattern | Type                                           | Deprecated | Definition                                        | Title/Description                              |
+| ------------------------------------------------------------ | ------- | ---------------------------------------------- | ---------- | ------------------------------------------------- | ---------------------------------------------- |
+| + [url](#spec_presentation_templates_items_url )             | No      | string                                         | No         | -                                                 | Cookiecutter template URL or path.             |
+| - [directory](#spec_presentation_templates_items_directory ) | No      | string                                         | No         | -                                                 | Optional subdirectory containing the template. |
+| - [condition](#spec_presentation_templates_items_condition ) | No      | object, array, string, number, boolean or null | No         | Same as [condition](#spec_links_items_condition ) | jsonlogic                                      |
 
-###### <a name="spec_integrations_gitlab_templates_items_url"></a>4.2.1.4.1.1. Property `url`
+###### <a name="spec_presentation_templates_items_url"></a>4.2.3.1.1. Property `url`
 
 |          |          |
 | -------- | -------- |
@@ -428,15 +388,15 @@ Specific value: `"Playbook"`
 
 **Description:** Cookiecutter template URL or path.
 
-###### <a name="spec_integrations_gitlab_templates_items_directory"></a>4.2.1.4.1.2. Property `directory`
+###### <a name="spec_presentation_templates_items_directory"></a>4.2.3.1.2. Property `directory`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-**Description:** Optional subdirectory within the repository containing the template.
+**Description:** Optional subdirectory containing the template.
 
-###### <a name="spec_integrations_gitlab_templates_items_condition"></a>4.2.1.4.1.3. Property `condition`
+###### <a name="spec_presentation_templates_items_condition"></a>4.2.3.1.3. Property `condition`
 
 **Title:** jsonlogic
 
@@ -445,7 +405,7 @@ Specific value: `"Playbook"`
 | **Type**               | `object, array, string, number, boolean or null` |
 | **Same definition as** | [condition](#spec_links_items_condition)         |
 
-**Description:** JSON Logic expression to conditionally render the template.
+**Description:** JSON Logic expression to conditionally surface the template.
 
 ### <a name="spec_rules"></a>4.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `rules`
 
@@ -740,4 +700,4 @@ Must be one of:
 * "information"
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:18 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/playbook/result.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/result.schema.md
@@ -25,7 +25,8 @@
 | + [passed_scorecards](#passed_scorecards ) | No      | integer         | No         | -          | Number of scorecards that passed.                                                            |
 | - [links](#links )                         | No      | array of object | No         | -          | External links associated with this playbook result.                                         |
 | + [pages](#pages )                         | No      | array of object | No         | -          | -                                                                                            |
-| - [mr_templates](#mr_templates )           | No      | array of object | No         | -          | Cookiecutter templates to be run for MR descriptions.                                        |
+| - [checklists](#checklists )               | No      | array of object | No         | -          | Resolved checklists surfaced to downstream integrations.                                     |
+| - [templates](#templates )                 | No      | array of object | No         | -          | Cookiecutter templates surfaced to downstream integrations.                                  |
 
 ## <a name="playbook_name"></a>1. ![Required](https://img.shields.io/badge/Required-blue) Property `playbook_name`
 
@@ -1075,13 +1076,13 @@ Must be one of:
 
 **Description:** The actual value fetched after resolution.
 
-## <a name="mr_templates"></a>15. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `mr_templates`
+## <a name="checklists"></a>15. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklists`
 
 |          |                   |
 | -------- | ----------------- |
 | **Type** | `array of object` |
 
-**Description:** Cookiecutter templates to be run for MR descriptions.
+**Description:** Resolved checklists surfaced to downstream integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -1091,33 +1092,115 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be           | Description |
-| ----------------------------------------- | ----------- |
-| [mr_templates items](#mr_templates_items) | -           |
+| Each item of this array must be       | Description |
+| ------------------------------------- | ----------- |
+| [checklists items](#checklists_items) | -           |
 
-### <a name="mr_templates_items"></a>15.1. mr_templates items
+### <a name="checklists_items"></a>15.1. checklists items
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
-| --------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| + [url](#mr_templates_items_url )             | No      | string | No         | -          | -                 |
-| - [directory](#mr_templates_items_directory ) | No      | string | No         | -          | -                 |
+| Property                            | Pattern | Type            | Deprecated | Definition | Title/Description                |
+| ----------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------- |
+| + [title](#checklists_items_title ) | No      | string          | No         | -          | Display title for the checklist. |
+| + [items](#checklists_items_items ) | No      | array of object | No         | -          | -                                |
 
-#### <a name="mr_templates_items_url"></a>15.1.1. Property `url`
+#### <a name="checklists_items_title"></a>15.1.1. Property `title`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-#### <a name="mr_templates_items_directory"></a>15.1.2. Property `directory`
+**Description:** Display title for the checklist.
+
+#### <a name="checklists_items_items"></a>15.1.2. Property `items`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be              | Description |
+| -------------------------------------------- | ----------- |
+| [items items](#checklists_items_items_items) | -           |
+
+##### <a name="checklists_items_items_items"></a>15.1.2.1. items items
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+| Property                                            | Pattern | Type    | Deprecated | Definition | Title/Description |
+| --------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| + [label](#checklists_items_items_items_label )     | No      | string  | No         | -          | -                 |
+| + [checked](#checklists_items_items_items_checked ) | No      | boolean | No         | -          | -                 |
+
+###### <a name="checklists_items_items_items_label"></a>15.1.2.1.1. Property `label`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+###### <a name="checklists_items_items_items_checked"></a>15.1.2.1.2. Property `checked`
+
+|          |           |
+| -------- | --------- |
+| **Type** | `boolean` |
+
+## <a name="templates"></a>16. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `templates`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+**Description:** Cookiecutter templates surfaced to downstream integrations.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be     | Description |
+| ----------------------------------- | ----------- |
+| [templates items](#templates_items) | -           |
+
+### <a name="templates_items"></a>16.1. templates items
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+| Property                                   | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ------------------------------------------ | ------- | ------ | ---------- | ---------- | ----------------- |
+| + [url](#templates_items_url )             | No      | string | No         | -          | -                 |
+| - [directory](#templates_items_directory ) | No      | string | No         | -          | -                 |
+
+#### <a name="templates_items_url"></a>16.1.1. Property `url`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+#### <a name="templates_items_directory"></a>16.1.2. Property `directory`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:18 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:31 +0200

--- a/docs/website/docs/reference/schemas/playbook/v1alpha1/playbook.schema.md
+++ b/docs/website/docs/reference/schemas/playbook/v1alpha1/playbook.schema.md
@@ -14,7 +14,7 @@
 | + [apiVersion](#apiVersion ) | No      | const  | No         | -          | API group and version. Must equal 'regis.io/v1alpha1'. |
 | + [kind](#kind )             | No      | const  | No         | -          | Resource kind. Must equal 'Playbook'.                              |
 | + [metadata](#metadata )     | No      | object | No         | -          | -                                                                  |
-| + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, integrations, links.          |
+| + [spec](#spec )             | No      | object | No         | -          | Playbook body: rules, tiers, badges, presentation, links.          |
 
 ## <a name="apiVersion"></a>1. ![Required](https://img.shields.io/badge/Required-blue) Property `apiVersion`
 
@@ -136,12 +136,12 @@ Specific value: `"Playbook"`
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-**Description:** Playbook body: rules, tiers, badges, integrations, links.
+**Description:** Playbook body: rules, tiers, badges, presentation, links.
 
 | Property                              | Pattern | Type            | Deprecated | Definition | Title/Description                                                                                                           |
 | ------------------------------------- | ------- | --------------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
 | - [links](#spec_links )               | No      | array of object | No         | -          | Optional custom links to display as actions for this playbook.                                                              |
-| - [integrations](#spec_integrations ) | No      | object          | No         | -          | Optional third-party platform integrations (e.g. GitLab, GitHub).                                                           |
+| - [presentation](#spec_presentation ) | No      | object          | No         | -          | Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).               |
 | - [rules](#spec_rules )               | No      | array of object | No         | -          | Custom rule overrides or template instantiations.                                                                           |
 | - [tiers](#spec_tiers )               | No      | array of object | No         | -          | Compliance tier thresholds. Each tier is awarded when its JsonLogic condition evaluates to true, evaluated in order.        |
 | - [badges](#spec_badges )             | No      | array of object | No         | -          | Dynamic status badges displayed in the report header. Each badge is conditionally rendered based on a JsonLogic expression. |
@@ -206,126 +206,28 @@ Specific value: `"Playbook"`
 
 **Description:** Optional JsonLogic expression to determine if the link should be displayed.
 
-### <a name="spec_integrations"></a>4.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `integrations`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional third-party platform integrations (e.g. GitLab, GitHub).
-
-| Property                               | Pattern | Type   | Deprecated | Definition | Title/Description |
-| -------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| - [gitlab](#spec_integrations_gitlab ) | No      | object | No         | -          | -                 |
-
-#### <a name="spec_integrations_gitlab"></a>4.2.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `gitlab`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-| Property                                              | Pattern | Type            | Deprecated | Definition | Title/Description                                                                           |
-| ----------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------- |
-| - [badges](#spec_integrations_gitlab_badges )         | No      | array of string | No         | -          | List of badge slugs to be imported as GitLab Merge Request labels.                          |
-| - [checklist](#spec_integrations_gitlab_checklist )   | No      | array           | No         | -          | (Deprecated) Single checklist items added as checkboxes to the Merge Request description.   |
-| - [checklists](#spec_integrations_gitlab_checklists ) | No      | array of object | No         | -          | Configurable checklists added as checkboxes to the Merge Request description.               |
-| - [templates](#spec_integrations_gitlab_templates )   | No      | array of object | No         | -          | URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch. |
-
-##### <a name="spec_integrations_gitlab_badges"></a>4.2.1.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `badges`
-
-|          |                   |
-| -------- | ----------------- |
-| **Type** | `array of string` |
-
-**Description:** List of badge slugs to be imported as GitLab Merge Request labels.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                        | Description |
-| ------------------------------------------------------ | ----------- |
-| [badges items](#spec_integrations_gitlab_badges_items) | -           |
-
-###### <a name="spec_integrations_gitlab_badges_items"></a>4.2.1.1.1. badges items
-
-|          |          |
-| -------- | -------- |
-| **Type** | `string` |
-
-##### <a name="spec_integrations_gitlab_checklist"></a>4.2.1.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklist`
-
-|          |         |
-| -------- | ------- |
-| **Type** | `array` |
-
-**Description:** (Deprecated) Single checklist items added as checkboxes to the Merge Request description.
-
-|                      | Array restrictions |
-| -------------------- | ------------------ |
-| **Min items**        | N/A                |
-| **Max items**        | N/A                |
-| **Items unicity**    | False              |
-| **Additional items** | False              |
-| **Tuple validation** | See below          |
-
-| Each item of this array must be                             | Description |
-| ----------------------------------------------------------- | ----------- |
-| [checklist_item](#spec_integrations_gitlab_checklist_items) | -           |
-
-###### <a name="spec_integrations_gitlab_checklist_items"></a>4.2.1.2.1. checklist_item
+### <a name="spec_presentation"></a>4.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `presentation`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
-| **Defined in**            | #/$defs/checklist_item                                         |
 
-| Property                                                          | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                                                     |
-| ----------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| + [label](#spec_integrations_gitlab_checklist_items_label )       | No      | string | No         | -          | Text of the checkbox item.                                                                                                                            |
-| - [show_if](#spec_integrations_gitlab_checklist_items_show_if )   | No      | object | No         | -          | Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.                                        |
-| - [check_if](#spec_integrations_gitlab_checklist_items_check_if ) | No      | object | No         | -          | Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]). |
+**Description:** Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).
 
-###### <a name="spec_integrations_gitlab_checklist_items_label"></a>4.2.1.2.1.1. Property `label`
+| Property                                       | Pattern | Type            | Deprecated | Definition | Title/Description                                                               |
+| ---------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------------------------------------------------------------- |
+| - [badges](#spec_presentation_badges )         | No      | array of string | No         | -          | Badge slugs to surface as labels for consuming integrations.                    |
+| - [checklists](#spec_presentation_checklists ) | No      | array of object | No         | -          | Conditional checklists surfaced by integrations (e.g. in an MR/PR description). |
+| - [templates](#spec_presentation_templates )   | No      | array of object | No         | -          | Conditional Cookiecutter templates surfaced to integrations.                    |
 
-|          |          |
-| -------- | -------- |
-| **Type** | `string` |
-
-**Description:** Text of the checkbox item.
-
-###### <a name="spec_integrations_gitlab_checklist_items_show_if"></a>4.2.1.2.1.2. Property `show_if`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.
-
-###### <a name="spec_integrations_gitlab_checklist_items_check_if"></a>4.2.1.2.1.3. Property `check_if`
-
-|                           |                                                                             |
-| ------------------------- | --------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                    |
-| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
-
-**Description:** Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]).
-
-##### <a name="spec_integrations_gitlab_checklists"></a>4.2.1.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklists`
+#### <a name="spec_presentation_badges"></a>4.2.1. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `badges`
 
 |          |                   |
 | -------- | ----------------- |
-| **Type** | `array of object` |
+| **Type** | `array of string` |
 
-**Description:** Configurable checklists added as checkboxes to the Merge Request description.
+**Description:** Badge slugs to surface as labels for consuming integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -335,23 +237,49 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                | Description |
-| -------------------------------------------------------------- | ----------- |
-| [checklists items](#spec_integrations_gitlab_checklists_items) | -           |
+| Each item of this array must be                 | Description |
+| ----------------------------------------------- | ----------- |
+| [badges items](#spec_presentation_badges_items) | -           |
 
-###### <a name="spec_integrations_gitlab_checklists_items"></a>4.2.1.3.1. checklists items
+##### <a name="spec_presentation_badges_items"></a>4.2.1.1. badges items
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+#### <a name="spec_presentation_checklists"></a>4.2.2. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `checklists`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+**Description:** Conditional checklists surfaced by integrations (e.g. in an MR/PR description).
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                         | Description |
+| ------------------------------------------------------- | ----------- |
+| [checklists items](#spec_presentation_checklists_items) | -           |
+
+##### <a name="spec_presentation_checklists_items"></a>4.2.2.1. checklists items
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                                     | Pattern | Type   | Deprecated | Definition | Title/Description                |
-| ------------------------------------------------------------ | ------- | ------ | ---------- | ---------- | -------------------------------- |
-| - [title](#spec_integrations_gitlab_checklists_items_title ) | No      | string | No         | -          | Display title for the checklist. |
-| + [items](#spec_integrations_gitlab_checklists_items_items ) | No      | array  | No         | -          | Items in this checklist.         |
+| Property                                              | Pattern | Type   | Deprecated | Definition | Title/Description                |
+| ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | -------------------------------- |
+| - [title](#spec_presentation_checklists_items_title ) | No      | string | No         | -          | Display title for the checklist. |
+| + [items](#spec_presentation_checklists_items_items ) | No      | array  | No         | -          | Items in this checklist.         |
 
-###### <a name="spec_integrations_gitlab_checklists_items_title"></a>4.2.1.3.1.1. Property `title`
+###### <a name="spec_presentation_checklists_items_title"></a>4.2.2.1.1. Property `title`
 
 |          |          |
 | -------- | -------- |
@@ -359,7 +287,7 @@ Specific value: `"Playbook"`
 
 **Description:** Display title for the checklist.
 
-###### <a name="spec_integrations_gitlab_checklists_items_items"></a>4.2.1.3.1.2. Property `items`
+###### <a name="spec_presentation_checklists_items_items"></a>4.2.2.1.2. Property `items`
 
 |          |         |
 | -------- | ------- |
@@ -375,25 +303,57 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                                          | Description |
-| ------------------------------------------------------------------------ | ----------- |
-| [checklist_item](#spec_integrations_gitlab_checklists_items_items_items) | -           |
+| Each item of this array must be                                   | Description |
+| ----------------------------------------------------------------- | ----------- |
+| [checklist_item](#spec_presentation_checklists_items_items_items) | -           |
 
-###### <a name="spec_integrations_gitlab_checklists_items_items_items"></a>4.2.1.3.1.2.1. checklist_item
+###### <a name="spec_presentation_checklists_items_items_items"></a>4.2.2.1.2.1. checklist_item
 
-|                           |                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------- |
-| **Type**                  | `object`                                                                              |
-| **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red)                        |
-| **Same definition as**    | [spec_integrations_gitlab_checklist_items](#spec_integrations_gitlab_checklist_items) |
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Type**                  | `object`                                                       |
+| **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
+| **Defined in**            | #/$defs/checklist_item                                         |
 
-##### <a name="spec_integrations_gitlab_templates"></a>4.2.1.4. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `templates`
+| Property                                                                | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                                                                     |
+| ----------------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| + [label](#spec_presentation_checklists_items_items_items_label )       | No      | string | No         | -          | Text of the checkbox item.                                                                                                                            |
+| - [show_if](#spec_presentation_checklists_items_items_items_show_if )   | No      | object | No         | -          | Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.                                        |
+| - [check_if](#spec_presentation_checklists_items_items_items_check_if ) | No      | object | No         | -          | Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]). |
+
+###### <a name="spec_presentation_checklists_items_items_items_label"></a>4.2.2.1.2.1.1. Property `label`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+**Description:** Text of the checkbox item.
+
+###### <a name="spec_presentation_checklists_items_items_items_show_if"></a>4.2.2.1.2.1.2. Property `show_if`
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+**Description:** Optional JsonLogic expression. If provided, the item is only included when the expression evaluates to truthy.
+
+###### <a name="spec_presentation_checklists_items_items_items_check_if"></a>4.2.2.1.2.1.3. Property `check_if`
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+**Description:** Optional JsonLogic expression. If provided and evaluates to truthy, the checkbox renders pre-checked (- [x]). Otherwise it renders unchecked (- [ ]).
+
+#### <a name="spec_presentation_templates"></a>4.2.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `templates`
 
 |          |                   |
 | -------- | ----------------- |
 | **Type** | `array of object` |
 
-**Description:** URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch.
+**Description:** Conditional Cookiecutter templates surfaced to integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -403,24 +363,24 @@ Specific value: `"Playbook"`
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                              | Description |
-| ------------------------------------------------------------ | ----------- |
-| [templates items](#spec_integrations_gitlab_templates_items) | -           |
+| Each item of this array must be                       | Description |
+| ----------------------------------------------------- | ----------- |
+| [templates items](#spec_presentation_templates_items) | -           |
 
-###### <a name="spec_integrations_gitlab_templates_items"></a>4.2.1.4.1. templates items
+##### <a name="spec_presentation_templates_items"></a>4.2.3.1. templates items
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                                            | Pattern | Type                                           | Deprecated | Definition                                        | Title/Description                                                    |
-| ------------------------------------------------------------------- | ------- | ---------------------------------------------- | ---------- | ------------------------------------------------- | -------------------------------------------------------------------- |
-| + [url](#spec_integrations_gitlab_templates_items_url )             | No      | string                                         | No         | -                                                 | Cookiecutter template URL or path.                                   |
-| - [directory](#spec_integrations_gitlab_templates_items_directory ) | No      | string                                         | No         | -                                                 | Optional subdirectory within the repository containing the template. |
-| - [condition](#spec_integrations_gitlab_templates_items_condition ) | No      | object, array, string, number, boolean or null | No         | Same as [condition](#spec_links_items_condition ) | jsonlogic                                                            |
+| Property                                                     | Pattern | Type                                           | Deprecated | Definition                                        | Title/Description                              |
+| ------------------------------------------------------------ | ------- | ---------------------------------------------- | ---------- | ------------------------------------------------- | ---------------------------------------------- |
+| + [url](#spec_presentation_templates_items_url )             | No      | string                                         | No         | -                                                 | Cookiecutter template URL or path.             |
+| - [directory](#spec_presentation_templates_items_directory ) | No      | string                                         | No         | -                                                 | Optional subdirectory containing the template. |
+| - [condition](#spec_presentation_templates_items_condition ) | No      | object, array, string, number, boolean or null | No         | Same as [condition](#spec_links_items_condition ) | jsonlogic                                      |
 
-###### <a name="spec_integrations_gitlab_templates_items_url"></a>4.2.1.4.1.1. Property `url`
+###### <a name="spec_presentation_templates_items_url"></a>4.2.3.1.1. Property `url`
 
 |          |          |
 | -------- | -------- |
@@ -428,15 +388,15 @@ Specific value: `"Playbook"`
 
 **Description:** Cookiecutter template URL or path.
 
-###### <a name="spec_integrations_gitlab_templates_items_directory"></a>4.2.1.4.1.2. Property `directory`
+###### <a name="spec_presentation_templates_items_directory"></a>4.2.3.1.2. Property `directory`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-**Description:** Optional subdirectory within the repository containing the template.
+**Description:** Optional subdirectory containing the template.
 
-###### <a name="spec_integrations_gitlab_templates_items_condition"></a>4.2.1.4.1.3. Property `condition`
+###### <a name="spec_presentation_templates_items_condition"></a>4.2.3.1.3. Property `condition`
 
 **Title:** jsonlogic
 
@@ -445,7 +405,7 @@ Specific value: `"Playbook"`
 | **Type**               | `object, array, string, number, boolean or null` |
 | **Same definition as** | [condition](#spec_links_items_condition)         |
 
-**Description:** JSON Logic expression to conditionally render the template.
+**Description:** JSON Logic expression to conditionally surface the template.
 
 ### <a name="spec_rules"></a>4.3. ![Optional](https://img.shields.io/badge/Optional-yellow) Property `rules`
 
@@ -474,16 +434,17 @@ Specific value: `"Playbook"`
 | **Type**                  | `object`                                                       |
 | **Additional properties** | ![Not allowed](https://img.shields.io/badge/Not%20allowed-red) |
 
-| Property                                  | Pattern | Type             | Deprecated | Definition | Title/Description                                   |
-| ----------------------------------------- | ------- | ---------------- | ---------- | ---------- | --------------------------------------------------- |
-| - [slug](#spec_rules_items_slug )         | No      | string           | No         | -          | Unique identifier for the rule instance.            |
-| - [provider](#spec_rules_items_provider ) | No      | string           | No         | -          | Analyzer name (e.g. 'cve').                         |
-| - [rule](#spec_rules_items_rule )         | No      | string           | No         | -          | Template name within the provider (e.g. 'cve-max'). |
-| - [options](#spec_rules_items_options )   | No      | object           | No         | -          | Configuration parameters for the rule template.     |
-| - [enable](#spec_rules_items_enable )     | No      | boolean          | No         | -          | Whether to enable this rule.                        |
-| - [level](#spec_rules_items_level )       | No      | enum (of string) | No         | -          | Severity level of the rule.                         |
-| - [tags](#spec_rules_items_tags )         | No      | array of string  | No         | -          | Arbitrary tags.                                     |
-| - [messages](#spec_rules_items_messages ) | No      | object           | No         | -          | -                                                   |
+| Property                                    | Pattern | Type             | Deprecated | Definition | Title/Description                                                                      |
+| ------------------------------------------- | ------- | ---------------- | ---------- | ---------- | -------------------------------------------------------------------------------------- |
+| - [slug](#spec_rules_items_slug )           | No      | string           | No         | -          | Unique identifier for the rule instance.                                               |
+| - [provider](#spec_rules_items_provider )   | No      | string           | No         | -          | Analyzer name (e.g. 'cve').                                                            |
+| - [criterion](#spec_rules_items_criterion ) | No      | string           | No         | -          | Criterion template name within the provider (e.g. 'cve-max').                          |
+| - [rule](#spec_rules_items_rule )           | No      | string           | No         | -          | (Deprecated) Alias of 'criterion'. Template name within the provider (e.g. 'cve-max'). |
+| - [options](#spec_rules_items_options )     | No      | object           | No         | -          | Configuration parameters for the rule template.                                        |
+| - [enable](#spec_rules_items_enable )       | No      | boolean          | No         | -          | Whether to enable this rule.                                                           |
+| - [level](#spec_rules_items_level )         | No      | enum (of string) | No         | -          | Severity level of the rule.                                                            |
+| - [tags](#spec_rules_items_tags )           | No      | array of string  | No         | -          | Arbitrary tags.                                                                        |
+| - [messages](#spec_rules_items_messages )   | No      | object           | No         | -          | -                                                                                      |
 
 ##### <a name="spec_rules_items_slug"></a>4.3.1.1. Property `slug`
 
@@ -501,15 +462,23 @@ Specific value: `"Playbook"`
 
 **Description:** Analyzer name (e.g. 'cve').
 
-##### <a name="spec_rules_items_rule"></a>4.3.1.3. Property `rule`
+##### <a name="spec_rules_items_criterion"></a>4.3.1.3. Property `criterion`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-**Description:** Template name within the provider (e.g. 'cve-max').
+**Description:** Criterion template name within the provider (e.g. 'cve-max').
 
-##### <a name="spec_rules_items_options"></a>4.3.1.4. Property `options`
+##### <a name="spec_rules_items_rule"></a>4.3.1.4. Property `rule`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+**Description:** (Deprecated) Alias of 'criterion'. Template name within the provider (e.g. 'cve-max').
+
+##### <a name="spec_rules_items_options"></a>4.3.1.5. Property `options`
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
@@ -522,7 +491,7 @@ Specific value: `"Playbook"`
 | ----------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
 | - [](#spec_rules_items_options_additionalProperties ) | No      | object | No         | -          | -                 |
 
-##### <a name="spec_rules_items_enable"></a>4.3.1.5. Property `enable`
+##### <a name="spec_rules_items_enable"></a>4.3.1.6. Property `enable`
 
 |             |           |
 | ----------- | --------- |
@@ -531,7 +500,7 @@ Specific value: `"Playbook"`
 
 **Description:** Whether to enable this rule.
 
-##### <a name="spec_rules_items_level"></a>4.3.1.6. Property `level`
+##### <a name="spec_rules_items_level"></a>4.3.1.7. Property `level`
 
 |          |                    |
 | -------- | ------------------ |
@@ -545,7 +514,7 @@ Must be one of:
 * "critical"
 * "none"
 
-##### <a name="spec_rules_items_tags"></a>4.3.1.7. Property `tags`
+##### <a name="spec_rules_items_tags"></a>4.3.1.8. Property `tags`
 
 |          |                   |
 | -------- | ----------------- |
@@ -565,13 +534,13 @@ Must be one of:
 | ------------------------------------------ | ----------- |
 | [tags items](#spec_rules_items_tags_items) | -           |
 
-###### <a name="spec_rules_items_tags_items"></a>4.3.1.7.1. tags items
+###### <a name="spec_rules_items_tags_items"></a>4.3.1.8.1. tags items
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-##### <a name="spec_rules_items_messages"></a>4.3.1.8. Property `messages`
+##### <a name="spec_rules_items_messages"></a>4.3.1.9. Property `messages`
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
@@ -583,13 +552,13 @@ Must be one of:
 | - [pass](#spec_rules_items_messages_pass ) | No      | string | No         | -          | -                 |
 | - [fail](#spec_rules_items_messages_fail ) | No      | string | No         | -          | -                 |
 
-###### <a name="spec_rules_items_messages_pass"></a>4.3.1.8.1. Property `pass`
+###### <a name="spec_rules_items_messages_pass"></a>4.3.1.9.1. Property `pass`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-###### <a name="spec_rules_items_messages_fail"></a>4.3.1.8.2. Property `fail`
+###### <a name="spec_rules_items_messages_fail"></a>4.3.1.9.2. Property `fail`
 
 |          |          |
 | -------- | -------- |
@@ -731,4 +700,4 @@ Must be one of:
 * "information"
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-01 at 17:11:42 +0200
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:49 +0200

--- a/docs/website/docs/reference/schemas/report/definition.schema.md
+++ b/docs/website/docs/reference/schemas/report/definition.schema.md
@@ -619,4 +619,4 @@ Must be one of:
 | **Maximum**  | &le; 100 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:19 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:32 +0200

--- a/docs/website/docs/reference/schemas/report/report.schema.md
+++ b/docs/website/docs/reference/schemas/report/report.schema.md
@@ -9,21 +9,21 @@
 
 **Description:** Final report envelope produced by regis, containing request metadata and analyzer results.
 
-| Property                           | Pattern | Type            | Deprecated | Definition                                   | Title/Description                                                                                                                                  |
-| ---------------------------------- | ------- | --------------- | ---------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Property                           | Pattern | Type            | Deprecated | Definition                                   | Title/Description                                                                                                             |
+| ---------------------------------- | ------- | --------------- | ---------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | + [schemaVersion](#schemaVersion ) | No      | integer         | No         | -                                            | Report-structure contract version. Downstream consumers gate rendering on this. Distinct from \`version\` (package/snapshot). |
-| + [version](#version )             | No      | string or null  | No         | -                                            | Version of regis that generated this report.                                                                                                       |
-| - [snapshot_date](#snapshot_date ) | No      | string          | No         | -                                            | ISO 8601 date when this version was snapshotted in the doc site.                                                                                   |
-| - [tier](#tier )                   | No      | string or null  | No         | -                                            | The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions.                                                                          |
-| - [badges](#badges )               | No      | array of object | No         | -                                            | -                                                                                                                                                  |
-| - [metadata](#metadata )           | No      | object          | No         | -                                            | Arbitrary user-provided metadata.                                                                                                                  |
-| - [links](#links )                 | No      | array of object | No         | -                                            | Custom templated links.                                                                                                                            |
-| + [request](#request )             | No      | object          | No         | -                                            | Metadata describing the analysis request.                                                                                                          |
-| + [results](#results )             | No      | object          | No         | -                                            | Analyzer results keyed by analyzer name.                                                                                                           |
-| - [playbooks](#playbooks )         | No      | array           | No         | -                                            | List of evaluated playbook results.                                                                                                                |
-| - [playbook](#playbook )           | No      | object          | No         | Same as [playbook.result](#playbooks_items ) | playbook.result                                                                                                                                    |
-| - [rules](#rules )                 | No      | array of object | No         | -                                            | List of unified rule results (promoted from playbooks[0]).                                                                                         |
-| - [rules_summary](#rules_summary ) | No      | object          | No         | -                                            | Summary of rule evaluation results.                                                                                                                |
+| + [version](#version )             | No      | string or null  | No         | -                                            | Version of regis that generated this report.                                                                                  |
+| - [snapshot_date](#snapshot_date ) | No      | string          | No         | -                                            | ISO 8601 date when this version was snapshotted in the doc site.                                                              |
+| - [tier](#tier )                   | No      | string or null  | No         | -                                            | The earned tier (e.g. Gold, Silver, Bronze) based on playbook conditions.                                                     |
+| - [badges](#badges )               | No      | array of object | No         | -                                            | -                                                                                                                             |
+| - [metadata](#metadata )           | No      | object          | No         | -                                            | Arbitrary user-provided metadata.                                                                                             |
+| - [links](#links )                 | No      | array of object | No         | -                                            | Custom templated links.                                                                                                       |
+| + [request](#request )             | No      | object          | No         | -                                            | Metadata describing the analysis request.                                                                                     |
+| + [results](#results )             | No      | object          | No         | -                                            | Analyzer results keyed by analyzer name.                                                                                      |
+| - [playbooks](#playbooks )         | No      | array           | No         | -                                            | List of evaluated playbook results.                                                                                           |
+| - [playbook](#playbook )           | No      | object          | No         | Same as [playbook.result](#playbooks_items ) | playbook.result                                                                                                               |
+| - [rules](#rules )                 | No      | array of object | No         | -                                            | List of unified rule results (promoted from playbooks[0]).                                                                    |
+| - [rules_summary](#rules_summary ) | No      | object          | No         | -                                            | Summary of rule evaluation results.                                                                                           |
 
 ## <a name="schemaVersion"></a>1. ![Required](https://img.shields.io/badge/Required-blue) Property `schemaVersion`
 
@@ -377,7 +377,8 @@ Must be one of:
 | + [passed_scorecards](#playbooks_items_passed_scorecards ) | No      | integer         | No         | -          | Number of scorecards that passed.                                                            |
 | - [links](#playbooks_items_links )                         | No      | array of object | No         | -          | External links associated with this playbook result.                                         |
 | + [pages](#playbooks_items_pages )                         | No      | array of object | No         | -          | -                                                                                            |
-| - [mr_templates](#playbooks_items_mr_templates )           | No      | array of object | No         | -          | Cookiecutter templates to be run for MR descriptions.                                        |
+| - [checklists](#playbooks_items_checklists )               | No      | array of object | No         | -          | Resolved checklists surfaced to downstream integrations.                                     |
+| - [templates](#playbooks_items_templates )                 | No      | array of object | No         | -          | Cookiecutter templates surfaced to downstream integrations.                                  |
 
 #### <a name="playbooks_items_playbook_name"></a>10.1.1. Property `playbook_name`
 
@@ -1427,13 +1428,13 @@ Must be one of:
 
 **Description:** The actual value fetched after resolution.
 
-#### <a name="playbooks_items_mr_templates"></a>10.1.15. Property `mr_templates`
+#### <a name="playbooks_items_checklists"></a>10.1.15. Property `checklists`
 
 |          |                   |
 | -------- | ----------------- |
 | **Type** | `array of object` |
 
-**Description:** Cookiecutter templates to be run for MR descriptions.
+**Description:** Resolved checklists surfaced to downstream integrations.
 
 |                      | Array restrictions |
 | -------------------- | ------------------ |
@@ -1443,29 +1444,111 @@ Must be one of:
 | **Additional items** | False              |
 | **Tuple validation** | See below          |
 
-| Each item of this array must be                           | Description |
-| --------------------------------------------------------- | ----------- |
-| [mr_templates items](#playbooks_items_mr_templates_items) | -           |
+| Each item of this array must be                       | Description |
+| ----------------------------------------------------- | ----------- |
+| [checklists items](#playbooks_items_checklists_items) | -           |
 
-##### <a name="playbooks_items_mr_templates_items"></a>10.1.15.1. mr_templates items
+##### <a name="playbooks_items_checklists_items"></a>10.1.15.1. checklists items
 
 |                           |                                                                             |
 | ------------------------- | --------------------------------------------------------------------------- |
 | **Type**                  | `object`                                                                    |
 | **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
 
-| Property                                                      | Pattern | Type   | Deprecated | Definition | Title/Description |
-| ------------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
-| + [url](#playbooks_items_mr_templates_items_url )             | No      | string | No         | -          | -                 |
-| - [directory](#playbooks_items_mr_templates_items_directory ) | No      | string | No         | -          | -                 |
+| Property                                            | Pattern | Type            | Deprecated | Definition | Title/Description                |
+| --------------------------------------------------- | ------- | --------------- | ---------- | ---------- | -------------------------------- |
+| + [title](#playbooks_items_checklists_items_title ) | No      | string          | No         | -          | Display title for the checklist. |
+| + [items](#playbooks_items_checklists_items_items ) | No      | array of object | No         | -          | -                                |
 
-###### <a name="playbooks_items_mr_templates_items_url"></a>10.1.15.1.1. Property `url`
+###### <a name="playbooks_items_checklists_items_title"></a>10.1.15.1.1. Property `title`
 
 |          |          |
 | -------- | -------- |
 | **Type** | `string` |
 
-###### <a name="playbooks_items_mr_templates_items_directory"></a>10.1.15.1.2. Property `directory`
+**Description:** Display title for the checklist.
+
+###### <a name="playbooks_items_checklists_items_items"></a>10.1.15.1.2. Property `items`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                              | Description |
+| ------------------------------------------------------------ | ----------- |
+| [items items](#playbooks_items_checklists_items_items_items) | -           |
+
+###### <a name="playbooks_items_checklists_items_items_items"></a>10.1.15.1.2.1. items items
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+| Property                                                            | Pattern | Type    | Deprecated | Definition | Title/Description |
+| ------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------- |
+| + [label](#playbooks_items_checklists_items_items_items_label )     | No      | string  | No         | -          | -                 |
+| + [checked](#playbooks_items_checklists_items_items_items_checked ) | No      | boolean | No         | -          | -                 |
+
+###### <a name="playbooks_items_checklists_items_items_items_label"></a>10.1.15.1.2.1.1. Property `label`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+###### <a name="playbooks_items_checklists_items_items_items_checked"></a>10.1.15.1.2.1.2. Property `checked`
+
+|          |           |
+| -------- | --------- |
+| **Type** | `boolean` |
+
+#### <a name="playbooks_items_templates"></a>10.1.16. Property `templates`
+
+|          |                   |
+| -------- | ----------------- |
+| **Type** | `array of object` |
+
+**Description:** Cookiecutter templates surfaced to downstream integrations.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                     | Description |
+| --------------------------------------------------- | ----------- |
+| [templates items](#playbooks_items_templates_items) | -           |
+
+##### <a name="playbooks_items_templates_items"></a>10.1.16.1. templates items
+
+|                           |                                                                             |
+| ------------------------- | --------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                    |
+| **Additional properties** | ![Any type: allowed](https://img.shields.io/badge/Any%20type-allowed-green) |
+
+| Property                                                   | Pattern | Type   | Deprecated | Definition | Title/Description |
+| ---------------------------------------------------------- | ------- | ------ | ---------- | ---------- | ----------------- |
+| + [url](#playbooks_items_templates_items_url )             | No      | string | No         | -          | -                 |
+| - [directory](#playbooks_items_templates_items_directory ) | No      | string | No         | -          | -                 |
+
+###### <a name="playbooks_items_templates_items_url"></a>10.1.16.1.1. Property `url`
+
+|          |          |
+| -------- | -------- |
+| **Type** | `string` |
+
+###### <a name="playbooks_items_templates_items_directory"></a>10.1.16.1.2. Property `directory`
 
 |          |          |
 | -------- | -------- |
@@ -1791,4 +1874,4 @@ Must be one of:
 | **Maximum**  | &le; 100 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-05 at 14:44:19 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-06-06 at 19:49:32 +0200

--- a/docs/website/docs/roadmap.md
+++ b/docs/website/docs/roadmap.md
@@ -22,7 +22,7 @@ Regis categorizes its public interfaces into stability tiers so you can make inf
 
 The following are considered **stable** and safe to depend on in custom playbooks:
 
-- **Playbook definition schema** — `name`, `description`, `slug`, `sections`, `rules`, `conditions`, `tiers`, `links`, `labels`, `badge_labels`, `mr_description_checklists`
+- **Playbook definition schema** — `name`, `description`, `slug`, `sections`, `rules`, `conditions`, `tiers`, `links`, `labels`, `spec.presentation` (`badge_labels`, `checklists`, `templates`)
 - **Report JSON top-level fields** — `version`, `request`, `results`, `playbook`, `playbooks`, `rules`, `rules_summary`, `tier`, `badges`, `links`
 - **Rule result fields** — `slug`, `description`, `passed`, `status`, `message`, `level`, `tags`, `analyzers`
 - **Rules summary** — `score` (0-100), `total`, `passed`, `by_tag`

--- a/docs/website/static/schemas/playbook/result.schema.json
+++ b/docs/website/static/schemas/playbook/result.schema.json
@@ -374,7 +374,32 @@
         }
       }
     },
-    "mr_templates": {
+    "checklists": {
+      "type": "array",
+      "description": "Resolved checklists surfaced to downstream integrations.",
+      "items": {
+        "type": "object",
+        "required": ["title", "items"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Display title for the checklist."
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "checked"],
+              "properties": {
+                "label": { "type": "string" },
+                "checked": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "templates": {
       "type": "array",
       "items": {
         "type": "object",
@@ -384,7 +409,7 @@
           "directory": { "type": "string" }
         }
       },
-      "description": "Cookiecutter templates to be run for MR descriptions."
+      "description": "Cookiecutter templates surfaced to downstream integrations."
     }
   }
 }

--- a/docs/website/static/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/docs/website/static/schemas/playbook/v1alpha1/playbook.schema.json
@@ -56,7 +56,7 @@
     "spec": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Playbook body: rules, tiers, badges, integrations, links.",
+      "description": "Playbook body: rules, tiers, badges, presentation, links.",
       "properties": {
         "links": {
           "type": "array",
@@ -80,69 +80,54 @@
             }
           }
         },
-        "integrations": {
+        "presentation": {
           "type": "object",
-          "description": "Optional third-party platform integrations (e.g. GitLab, GitHub).",
+          "description": "Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).",
+          "additionalProperties": false,
           "properties": {
-            "gitlab": {
-              "type": "object",
-              "properties": {
-                "badges": {
-                  "type": "array",
-                  "description": "List of badge slugs to be imported as GitLab Merge Request labels.",
+            "badges": {
+              "type": "array",
+              "description": "Badge slugs to surface as labels for consuming integrations.",
+              "items": { "type": "string" }
+            },
+            "checklists": {
+              "type": "array",
+              "description": "Conditional checklists surfaced by integrations (e.g. in an MR/PR description).",
+              "items": {
+                "type": "object",
+                "required": ["items"],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "Display title for the checklist."
+                  },
                   "items": {
-                    "type": "string"
+                    "type": "array",
+                    "description": "Items in this checklist.",
+                    "items": { "$ref": "#/$defs/checklist_item" }
                   }
-                },
-                "checklist": {
-                  "type": "array",
-                  "description": "(Deprecated) Single checklist items added as checkboxes to the Merge Request description.",
-                  "items": {
-                    "$ref": "#/$defs/checklist_item"
-                  }
-                },
-                "checklists": {
-                  "type": "array",
-                  "description": "Configurable checklists added as checkboxes to the Merge Request description.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string",
-                        "description": "Display title for the checklist."
-                      },
-                      "items": {
-                        "type": "array",
-                        "description": "Items in this checklist.",
-                        "items": {
-                          "$ref": "#/$defs/checklist_item"
-                        }
-                      }
-                    },
-                    "required": ["items"]
-                  }
-                },
-                "templates": {
-                  "type": "array",
-                  "description": "URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch.",
-                  "items": {
-                    "type": "object",
-                    "required": ["url"],
-                    "additionalProperties": false,
-                    "properties": {
-                      "url": {
-                        "type": "string",
-                        "description": "Cookiecutter template URL or path."
-                      },
-                      "directory": {
-                        "type": "string",
-                        "description": "Optional subdirectory within the repository containing the template."
-                      },
-                      "condition": {
-                        "description": "JSON Logic expression to conditionally render the template.",
-                        "$ref": "../jsonlogic.schema.json"
-                      }
-                    }
+                }
+              }
+            },
+            "templates": {
+              "type": "array",
+              "description": "Conditional Cookiecutter templates surfaced to integrations.",
+              "items": {
+                "type": "object",
+                "required": ["url"],
+                "additionalProperties": false,
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "Cookiecutter template URL or path."
+                  },
+                  "directory": {
+                    "type": "string",
+                    "description": "Optional subdirectory containing the template."
+                  },
+                  "condition": {
+                    "description": "JSON Logic expression to conditionally surface the template.",
+                    "$ref": "../jsonlogic.schema.json"
                   }
                 }
               }

--- a/docs/website/static/schemas/report/report.schema.json
+++ b/docs/website/static/schemas/report/report.schema.json
@@ -9,7 +9,7 @@
     "schemaVersion": {
       "type": "integer",
       "minimum": 1,
-      "description": "Report-structure contract version. Consumers (e.g. the standalone dashboard) gate rendering on this. Distinct from `version` (package/snapshot)."
+      "description": "Report-structure contract version. Downstream consumers gate rendering on this. Distinct from `version` (package/snapshot)."
     },
     "version": {
       "type": ["string", "null"],

--- a/regis/cli.py
+++ b/regis/cli.py
@@ -19,7 +19,6 @@ from regis.utils.report import (
     escape_jinja,
     format_output_path,
     render_and_save_reports,
-    render_mr_templates,
     run_playbooks,
     set_nested_value,
     validate_report,
@@ -37,7 +36,6 @@ _escape_jinja = escape_jinja
 _run_playbooks = run_playbooks
 _validate_report = validate_report
 _render_and_save_reports = render_and_save_reports
-_render_mr_templates = render_mr_templates
 
 
 @click.group()

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -22,7 +22,7 @@ from regis.utils.report import (
     ensure_schema_version,
     format_output_path,
     render_and_save_reports,
-    render_mr_templates,
+    render_presentation_templates,
     run_playbooks,
     set_nested_value,
     validate_report,
@@ -635,7 +635,7 @@ def analyze(
         sections=sections,
     )
 
-    render_mr_templates(final_report, output_dir_template)
+    render_presentation_templates(final_report, output_dir_template)
 
     # Only print the summary when the user explicitly requested a playbook —
     # avoids changing stdout for default runs that auto-load the built-in playbook.
@@ -759,7 +759,7 @@ def evaluate_cmd(
         sections=sections,
     )
 
-    render_mr_templates(final_report, output_dir_template)
+    render_presentation_templates(final_report, output_dir_template)
 
 
 @click.command(name="list")

--- a/regis/commands/playbook.py
+++ b/regis/commands/playbook.py
@@ -135,6 +135,46 @@ def _migrate_rule_entry(entry: Any) -> None:
                 messages[key] = _migrate_message(value)
 
 
+def _migrate_integrations_to_presentation(container: Any) -> None:
+    """Move ``integrations.gitlab.{badges,checklist,checklists,templates}`` to a
+    platform-neutral ``presentation`` block on the same container. Idempotent.
+
+    Folds the deprecated singular ``checklist`` into ``checklists``.
+    """
+    if not isinstance(container, dict):
+        return
+    integrations = container.get("integrations")
+    if not isinstance(integrations, dict):
+        return
+    gitlab = integrations.get("gitlab")
+    if not isinstance(gitlab, dict):
+        return
+
+    presentation = container.get("presentation")
+    if not isinstance(presentation, dict):
+        presentation = {}
+
+    if "badges" in gitlab and "badges" not in presentation:
+        presentation["badges"] = gitlab["badges"]
+    if "templates" in gitlab and "templates" not in presentation:
+        presentation["templates"] = gitlab["templates"]
+
+    checklists = gitlab.get("checklists")
+    if not checklists and gitlab.get("checklist"):
+        # fold the deprecated singular `checklist` into the `checklists` shape
+        checklists = [{"items": gitlab["checklist"]}]
+    if checklists and "checklists" not in presentation:
+        presentation["checklists"] = checklists
+
+    if presentation:
+        container["presentation"] = presentation
+
+    # remove the now-migrated gitlab integration; drop `integrations` if empty
+    integrations.pop("gitlab", None)
+    if not integrations:
+        container.pop("integrations", None)
+
+
 def _migrate_playbook_data(data: Any) -> None:
     """Migrate a parsed playbook document in place (``rule`` → ``criterion``).
 
@@ -153,6 +193,12 @@ def _migrate_playbook_data(data: Any) -> None:
         return
     for entry in rules:
         _migrate_rule_entry(entry)
+
+    # presentation migration (integrations.gitlab -> presentation)
+    if isinstance(spec, dict):
+        _migrate_integrations_to_presentation(spec)
+    else:
+        _migrate_integrations_to_presentation(data)
 
 
 def _format_validation_error(error) -> str:
@@ -289,6 +335,8 @@ def migrate_playbook(path: Path, in_place: bool) -> None:
     2. ``rule.`` references in JSON-Logic ``condition`` trees and ``${rule.…}``
        interpolations in ``messages`` → ``criterion`` (``results.*`` metric
        paths are left untouched).
+    3. ``spec.integrations.gitlab`` → platform-neutral ``spec.presentation``
+       (folding the deprecated singular ``checklist`` into ``checklists``).
 
     Comments and formatting are preserved via round-trip YAML. The codemod is
     idempotent: running it on an already-migrated playbook is a no-op. By

--- a/regis/commands/playbook.py
+++ b/regis/commands/playbook.py
@@ -294,7 +294,7 @@ def upgrade_playbook(path: Path) -> None:
     metadata["labels"] = labels
 
     spec = CommentedMap()
-    for key in ("tiers", "rules", "badges", "integrations", "links"):
+    for key in ("tiers", "rules", "badges", "integrations", "presentation", "links"):
         if key in data:
             spec[key] = data[key]
 

--- a/regis/playbook/evaluator.py
+++ b/regis/playbook/evaluator.py
@@ -5,7 +5,7 @@ The ``evaluate`` function is the main entry point. It:
 2. Evaluates each page and section (scorecards, widgets).
 3. Assembles the result dict.
 4. Performs a final widget resolution pass using the full context.
-5. Resolves playbook-level links and GitLab integration directives.
+5. Resolves playbook-level links and presentation directives.
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ import logging
 from typing import Any
 
 from regis.playbook.context import NamedList, _build_context
-from regis.playbook.integrations.gitlab import resolve_gitlab_integration
+from regis.playbook.presentation import resolve_presentation
 from regis.playbook.sections import _evaluate_section, resolve_widgets_final
 from regis.playbook.templates import _resolve_template
 from regis.rules.evaluator import evaluate_rules
@@ -287,13 +287,13 @@ def evaluate(
             resolved_badges.append(badge_res)
         result["badges"] = resolved_badges
 
-    # Resolve sidebar, links, and GitLab integration
+    # Resolve sidebar, links, and presentation directives
     sidebar = playbook.get("sidebar")
     if sidebar:
         result["sidebar"] = sidebar
 
     _resolve_links(playbook, result, full_context, report)
-    result.update(resolve_gitlab_integration(playbook, full_context))
+    result.update(resolve_presentation(playbook, full_context))
 
     if source_name:
         result["_meta"] = {"source_name": source_name}

--- a/regis/playbook/integrations/__init__.py
+++ b/regis/playbook/integrations/__init__.py
@@ -1,1 +1,0 @@
-"""GitLab integration package for regis playbook engine."""

--- a/regis/playbook/presentation.py
+++ b/regis/playbook/presentation.py
@@ -19,7 +19,7 @@ def _resolve_badge_labels(
     integration: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Resolve explicit badge slugs to be imported as GitLab labels."""
+    """Resolve badge slugs to platform labels surfaced to downstream integrations."""
     badge_slugs = integration.get("badges", [])
     if not badge_slugs:
         return {}
@@ -49,7 +49,7 @@ def _resolve_checklists(
     integration: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Evaluate GitLab MR description checklist items."""
+    """Evaluate presentation checklist items against the evaluation context."""
     checklist_defs = integration.get("checklist")
     checklists_defs = integration.get("checklists", [])
 
@@ -104,7 +104,7 @@ def _resolve_templates(
     integration: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Evaluate GitLab MR template conditions and return resolved template entries."""
+    """Evaluate presentation template conditions and return resolved template entries."""
     template_defs = integration.get("templates", [])
     if not template_defs:
         return {}

--- a/regis/playbook/presentation.py
+++ b/regis/playbook/presentation.py
@@ -1,7 +1,8 @@
-"""GitLab integration resolvers for the playbook engine.
+"""Presentation resolvers for the playbook engine.
 
-Evaluates GitLab-specific playbook directives (labels, MR description
-checklists, MR templates) against the full evaluation context.
+Evaluates platform-neutral presentation directives (labels from badges,
+checklists, templates) against the full evaluation context. Consumed by
+downstream integrations (GitLab MR, GitHub PR, Backstage, …).
 """
 
 from __future__ import annotations
@@ -132,18 +133,20 @@ def _resolve_templates(
     return {}
 
 
-def resolve_gitlab_integration(
+def resolve_presentation(
     playbook: dict[str, Any],
     full_context: dict[str, Any],
 ) -> dict[str, Any]:
-    """Resolve all GitLab integration directives (badges, checklists, templates).
+    """Resolve all presentation directives (badges, checklists, templates).
 
-    Returns a dict merged into the evaluation result by the orchestrator.
+    Reads the normalized flat ``playbook["presentation"]`` (the loader projects
+    ``spec.presentation`` onto the top level). Returns a dict merged into the
+    evaluation result by the orchestrator.
     """
-    integration = playbook.get("integrations", {}).get("gitlab", {})
+    presentation = playbook.get("presentation", {})
     result: dict[str, Any] = {}
-    result.update(_resolve_badge_labels(integration, full_context))
-    result.update(_resolve_checklists(integration, full_context))
-    result.update(_resolve_templates(integration, full_context))
+    result.update(_resolve_badge_labels(presentation, full_context))
+    result.update(_resolve_checklists(presentation, full_context))
+    result.update(_resolve_templates(presentation, full_context))
 
     return result

--- a/regis/playbook/presentation.py
+++ b/regis/playbook/presentation.py
@@ -96,7 +96,7 @@ def _resolve_checklists(
             resolved_checklists.append({"title": title, "items": resolved_items})
 
     if resolved_checklists:
-        return {"mr_description_checklists": resolved_checklists}
+        return {"checklists": resolved_checklists}
     return {}
 
 
@@ -129,7 +129,7 @@ def _resolve_templates(
         resolved_templates.append(resolved_tmpl)
 
     if resolved_templates:
-        return {"mr_templates": resolved_templates}
+        return {"templates": resolved_templates}
     return {}
 
 

--- a/regis/playbooks/default/playbook.yaml
+++ b/regis/playbooks/default/playbook.yaml
@@ -150,31 +150,30 @@ spec:
         "!": [var: rules.age.passed]
       class: warning
 
-  integrations:
-    gitlab:
-      badges:
-        - score
-        - freshness
-        - cve-critical
-        - cve-high
-      checklists:
-        - title: 📝 Review Checklist
-          items:
-            - label: Revue de sécurité réalisée
-            - label: Aucune vulnérabilité CRITIQUE détectée
-              show_if: { "!!": [var: rules.cve-critical] }
-              check_if: { var: rules.cve-critical.passed }
-            - label: Image issue d'un registre de confiance
-              show_if: { "!!": [var: rules.registry-domain-whitelist] }
-              check_if: { var: rules.registry-domain-whitelist.passed }
-            - label: Image ne tourne pas en root
-              show_if: { "!!": [var: rules.no-root] }
-              check_if: { var: rules.no-root.passed }
-      templates:
-        - url: https://github.com/trivoallan/regis
-          directory: regis/cookiecutters/mr-evidence
-
   links:
     - label: Return to Merge Request
       url: "{{ request.metadata['gitlab.mr_url'] }}"
       condition: { "!!": [var: request.metadata.gitlab.mr_url] }
+  presentation:
+    badges:
+      - score
+      - freshness
+      - cve-critical
+      - cve-high
+    templates:
+      - url: https://github.com/trivoallan/regis
+        directory: regis/cookiecutters/mr-evidence
+
+    checklists:
+      - title: 📝 Review Checklist
+        items:
+          - label: Revue de sécurité réalisée
+          - label: Aucune vulnérabilité CRITIQUE détectée
+            show_if: { "!!": [var: rules.cve-critical] }
+            check_if: { var: rules.cve-critical.passed }
+          - label: Image issue d'un registre de confiance
+            show_if: { "!!": [var: rules.registry-domain-whitelist] }
+            check_if: { var: rules.registry-domain-whitelist.passed }
+          - label: Image ne tourne pas en root
+            show_if: { "!!": [var: rules.no-root] }
+            check_if: { var: rules.no-root.passed }

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -381,7 +381,10 @@
         "type": "object",
         "required": ["title", "items"],
         "properties": {
-          "title": { "type": "string", "description": "Display title for the checklist." },
+          "title": {
+            "type": "string",
+            "description": "Display title for the checklist."
+          },
           "items": {
             "type": "array",
             "items": {

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -374,7 +374,29 @@
         }
       }
     },
-    "mr_templates": {
+    "checklists": {
+      "type": "array",
+      "description": "Resolved checklists surfaced to downstream integrations.",
+      "items": {
+        "type": "object",
+        "required": ["title", "items"],
+        "properties": {
+          "title": { "type": "string", "description": "Display title for the checklist." },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "checked"],
+              "properties": {
+                "label": { "type": "string" },
+                "checked": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "templates": {
       "type": "array",
       "items": {
         "type": "object",
@@ -384,7 +406,7 @@
           "directory": { "type": "string" }
         }
       },
-      "description": "Cookiecutter templates to be run for MR descriptions."
+      "description": "Cookiecutter templates surfaced to downstream integrations."
     }
   }
 }

--- a/regis/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/regis/schemas/playbook/v1alpha1/playbook.schema.json
@@ -97,7 +97,10 @@
                 "type": "object",
                 "required": ["items"],
                 "properties": {
-                  "title": { "type": "string", "description": "Display title for the checklist." },
+                  "title": {
+                    "type": "string",
+                    "description": "Display title for the checklist."
+                  },
                   "items": {
                     "type": "array",
                     "description": "Items in this checklist.",
@@ -114,8 +117,14 @@
                 "required": ["url"],
                 "additionalProperties": false,
                 "properties": {
-                  "url": { "type": "string", "description": "Cookiecutter template URL or path." },
-                  "directory": { "type": "string", "description": "Optional subdirectory containing the template." },
+                  "url": {
+                    "type": "string",
+                    "description": "Cookiecutter template URL or path."
+                  },
+                  "directory": {
+                    "type": "string",
+                    "description": "Optional subdirectory containing the template."
+                  },
                   "condition": {
                     "description": "JSON Logic expression to conditionally surface the template.",
                     "$ref": "../jsonlogic.schema.json"

--- a/regis/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/regis/schemas/playbook/v1alpha1/playbook.schema.json
@@ -56,7 +56,7 @@
     "spec": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Playbook body: rules, tiers, badges, integrations, links.",
+      "description": "Playbook body: rules, tiers, badges, presentation, links.",
       "properties": {
         "links": {
           "type": "array",
@@ -80,69 +80,45 @@
             }
           }
         },
-        "integrations": {
+        "presentation": {
           "type": "object",
-          "description": "Optional third-party platform integrations (e.g. GitLab, GitHub).",
+          "description": "Platform-neutral presentation directives surfaced to downstream integrations (labels, checklists, templates).",
+          "additionalProperties": false,
           "properties": {
-            "gitlab": {
-              "type": "object",
-              "properties": {
-                "badges": {
-                  "type": "array",
-                  "description": "List of badge slugs to be imported as GitLab Merge Request labels.",
+            "badges": {
+              "type": "array",
+              "description": "Badge slugs to surface as labels for consuming integrations.",
+              "items": { "type": "string" }
+            },
+            "checklists": {
+              "type": "array",
+              "description": "Conditional checklists surfaced by integrations (e.g. in an MR/PR description).",
+              "items": {
+                "type": "object",
+                "required": ["items"],
+                "properties": {
+                  "title": { "type": "string", "description": "Display title for the checklist." },
                   "items": {
-                    "type": "string"
+                    "type": "array",
+                    "description": "Items in this checklist.",
+                    "items": { "$ref": "#/$defs/checklist_item" }
                   }
-                },
-                "checklist": {
-                  "type": "array",
-                  "description": "(Deprecated) Single checklist items added as checkboxes to the Merge Request description.",
-                  "items": {
-                    "$ref": "#/$defs/checklist_item"
-                  }
-                },
-                "checklists": {
-                  "type": "array",
-                  "description": "Configurable checklists added as checkboxes to the Merge Request description.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string",
-                        "description": "Display title for the checklist."
-                      },
-                      "items": {
-                        "type": "array",
-                        "description": "Items in this checklist.",
-                        "items": {
-                          "$ref": "#/$defs/checklist_item"
-                        }
-                      }
-                    },
-                    "required": ["items"]
-                  }
-                },
-                "templates": {
-                  "type": "array",
-                  "description": "URLs to Cookiecutter templates that will be rendered and added to the Merge Request branch.",
-                  "items": {
-                    "type": "object",
-                    "required": ["url"],
-                    "additionalProperties": false,
-                    "properties": {
-                      "url": {
-                        "type": "string",
-                        "description": "Cookiecutter template URL or path."
-                      },
-                      "directory": {
-                        "type": "string",
-                        "description": "Optional subdirectory within the repository containing the template."
-                      },
-                      "condition": {
-                        "description": "JSON Logic expression to conditionally render the template.",
-                        "$ref": "../jsonlogic.schema.json"
-                      }
-                    }
+                }
+              }
+            },
+            "templates": {
+              "type": "array",
+              "description": "Conditional Cookiecutter templates surfaced to integrations.",
+              "items": {
+                "type": "object",
+                "required": ["url"],
+                "additionalProperties": false,
+                "properties": {
+                  "url": { "type": "string", "description": "Cookiecutter template URL or path." },
+                  "directory": { "type": "string", "description": "Optional subdirectory containing the template." },
+                  "condition": {
+                    "description": "JSON Logic expression to conditionally surface the template.",
+                    "$ref": "../jsonlogic.schema.json"
                   }
                 }
               }

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -14,7 +14,7 @@ import jsonschema
 
 logger = logging.getLogger(__name__)
 
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 """Current report-structure contract version (see report.schema.json)."""
 
 

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -368,18 +368,18 @@ def render_and_save_reports(
             )
 
 
-def render_mr_templates(
+def render_presentation_templates(
     report: dict[str, Any], output_dir_template: str | None
 ) -> None:
-    """Execute Cookiecutter templates for Merge Requests."""
+    """Execute Cookiecutter templates surfaced by playbook presentation directives."""
     playbooks = report.get("playbooks", [])
-    valid_mr_templates = []
+    valid_templates = []
     for pb in playbooks:
         for tmpl in pb.get("templates", []):
-            if tmpl not in valid_mr_templates:
-                valid_mr_templates.append(tmpl)
+            if tmpl not in valid_templates:
+                valid_templates.append(tmpl)
 
-    if valid_mr_templates:
+    if valid_templates:
         try:
             from cookiecutter.main import cookiecutter
         except ImportError:
@@ -388,10 +388,12 @@ def render_mr_templates(
                 err=True,
             )
         else:
-            for tmpl_def in valid_mr_templates:
+            for tmpl_def in valid_templates:
                 tmpl_url = tmpl_def.get("url")
                 tmpl_dir = tmpl_def.get("directory")
-                click.echo(f"  Rendering MR template: {tmpl_url}...", err=True)
+                click.echo(
+                    f"  Rendering presentation template: {tmpl_url}...", err=True
+                )
                 try:
                     out_dir = format_output_path(
                         output_dir_template or ".", report, "json"

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -375,7 +375,7 @@ def render_mr_templates(
     playbooks = report.get("playbooks", [])
     valid_mr_templates = []
     for pb in playbooks:
-        for tmpl in pb.get("mr_templates", []):
+        for tmpl in pb.get("templates", []):
             if tmpl not in valid_mr_templates:
                 valid_mr_templates.append(tmpl)
 
@@ -384,7 +384,7 @@ def render_mr_templates(
             from cookiecutter.main import cookiecutter
         except ImportError:
             click.echo(
-                "  Warning: cookiecutter not found. Cannot evaluate mr_templates.",
+                "  Warning: cookiecutter not found. Cannot evaluate presentation templates.",
                 err=True,
             )
         else:

--- a/tests/commands/test_analyze_html.py
+++ b/tests/commands/test_analyze_html.py
@@ -59,7 +59,7 @@ def _mock_analyze_infra(tmp_path):
         ),
         patch("regis.commands.analyze.run_playbooks", return_value=_MINIMAL_REPORT),
         patch("regis.commands.analyze.validate_report"),
-        patch("regis.commands.analyze.render_mr_templates"),
+        patch("regis.commands.analyze.render_presentation_templates"),
         patch("regis.commands.analyze.render_and_save_reports") as mock_render,
     ):
         yield mock_render
@@ -102,7 +102,7 @@ def test_evaluate_cmd_html_flag(runner, tmp_path):
     with (
         patch("regis.commands.analyze.run_playbooks", return_value=_MINIMAL_REPORT),
         patch("regis.commands.analyze.validate_report"),
-        patch("regis.commands.analyze.render_mr_templates"),
+        patch("regis.commands.analyze.render_presentation_templates"),
         patch("regis.commands.analyze.render_and_save_reports") as mock_render,
     ):
         result = runner.invoke(
@@ -123,7 +123,7 @@ def test_evaluate_sections_forwarded_to_render(runner, tmp_path):
         patch("regis.commands.analyze.run_playbooks", return_value=_MINIMAL_REPORT),
         patch("regis.commands.analyze.validate_report"),
         patch("regis.commands.analyze.render_and_save_reports") as mock_render,
-        patch("regis.commands.analyze.render_mr_templates"),
+        patch("regis.commands.analyze.render_presentation_templates"),
     ):
         result = runner.invoke(
             evaluate_cmd,

--- a/tests/commands/test_playbook_migrate.py
+++ b/tests/commands/test_playbook_migrate.py
@@ -419,3 +419,18 @@ def test_migrate_presentation_is_idempotent():
     _migrate_playbook_data(data)
     assert data["spec"]["presentation"] == {"badges": ["score"]}
     assert "integrations" not in data["spec"]
+
+
+def test_migrate_leaves_non_gitlab_integration_untouched():
+    from regis.commands.playbook import _migrate_playbook_data
+
+    data = {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p"},
+        "spec": {"rules": [], "integrations": {"github": {"foo": "bar"}}},
+    }
+    _migrate_playbook_data(data)
+    # no gitlab sub-key: integrations is left as-is, no presentation created
+    assert data["spec"]["integrations"] == {"github": {"foo": "bar"}}
+    assert "presentation" not in data["spec"]

--- a/tests/commands/test_playbook_migrate.py
+++ b/tests/commands/test_playbook_migrate.py
@@ -385,7 +385,7 @@ def test_migrate_criterion_native_roundtrips_byte_identical(tmp_path: Path) -> N
 
 def test_migrate_integrations_gitlab_to_presentation():
     data = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {"name": "p"},
         "spec": {
@@ -411,7 +411,7 @@ def test_migrate_integrations_gitlab_to_presentation():
 
 def test_migrate_presentation_is_idempotent():
     data = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {"name": "p"},
         "spec": {"rules": [], "presentation": {"badges": ["score"]}},
@@ -425,7 +425,7 @@ def test_migrate_leaves_non_gitlab_integration_untouched():
     from regis.commands.playbook import _migrate_playbook_data
 
     data = {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {"name": "p"},
         "spec": {"rules": [], "integrations": {"github": {"foo": "bar"}}},

--- a/tests/commands/test_playbook_migrate.py
+++ b/tests/commands/test_playbook_migrate.py
@@ -381,3 +381,41 @@ def test_migrate_criterion_native_roundtrips_byte_identical(tmp_path: Path) -> N
     result = CliRunner().invoke(playbook_group, ["migrate", "-i", str(pb)])
     assert result.exit_code == 0, result.output
     assert pb.read_text(encoding="utf-8") == original
+
+
+def test_migrate_integrations_gitlab_to_presentation():
+    data = {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p"},
+        "spec": {
+            "rules": [],
+            "integrations": {
+                "gitlab": {
+                    "badges": ["score"],
+                    "checklist": [{"label": "legacy item"}],
+                    "templates": [{"url": "gh:org/t"}],
+                }
+            },
+        },
+    }
+    _migrate_playbook_data(data)
+
+    assert "integrations" not in data["spec"]
+    pres = data["spec"]["presentation"]
+    assert pres["badges"] == ["score"]
+    # the deprecated singular `checklist` is folded into `checklists`
+    assert pres["checklists"] == [{"items": [{"label": "legacy item"}]}]
+    assert pres["templates"] == [{"url": "gh:org/t"}]
+
+
+def test_migrate_presentation_is_idempotent():
+    data = {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p"},
+        "spec": {"rules": [], "presentation": {"badges": ["score"]}},
+    }
+    _migrate_playbook_data(data)
+    assert data["spec"]["presentation"] == {"badges": ["score"]}
+    assert "integrations" not in data["spec"]

--- a/tests/fixtures/report.v2.json
+++ b/tests/fixtures/report.v2.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 2,
+  "version": "0.33.0",
+  "snapshot_date": "2026-05-31",
+  "tier": "Gold",
+  "request": {
+    "url": "registry-1.docker.io/library/nginx:1.27",
+    "registry": "registry-1.docker.io",
+    "repository": "library/nginx",
+    "tag": "1.27",
+    "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "analyzers": ["cve", "oci"],
+    "timestamp": "2026-05-31T12:00:00+00:00"
+  },
+  "results": {
+    "oci": {
+      "analyzer": "oci",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "platforms": [{ "architecture": "amd64", "os": "linux" }]
+    },
+    "cve": {
+      "analyzer": "cve",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "scanner_version": "0.74.1",
+      "vulnerability_count": 17,
+      "critical_count": 0,
+      "high_count": 1,
+      "medium_count": 4,
+      "low_count": 12,
+      "negligible_count": 0,
+      "unknown_count": 0,
+      "fixed_count": 5,
+      "targets": []
+    }
+  },
+  "rules": [
+    {
+      "slug": "no-critical-cve",
+      "description": "No critical CVEs",
+      "level": "Gold",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "0 critical vulnerabilities found",
+      "analyzers": ["cve"]
+    }
+  ],
+  "rules_summary": {
+    "score": 100,
+    "total": ["no-critical-cve"],
+    "passed": ["no-critical-cve"],
+    "by_tag": {
+      "security": {
+        "rules": ["no-critical-cve"],
+        "passed_rules": ["no-critical-cve"],
+        "score": 100
+      }
+    }
+  }
+}

--- a/tests/test_analyze_rerun.py
+++ b/tests/test_analyze_rerun.py
@@ -350,4 +350,4 @@ class TestRerunBackfillsSchemaVersion:
             updated = json.loads(
                 (report_dir / "report.json").read_text(encoding="utf-8")
             )
-            assert updated["schemaVersion"] == 1
+            assert updated["schemaVersion"] == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -359,7 +359,7 @@ class TestAnalyzeCacheAndFail:
             # path must backfill it before validation, and the saved report
             # carries it.
             saved = json.loads((cache_dir / "report.json").read_text(encoding="utf-8"))
-            assert saved["schemaVersion"] == 1
+            assert saved["schemaVersion"] == 2
 
     @patch("regis.commands.analyze.render_mr_templates")
     @patch("regis.commands.analyze.render_and_save_reports")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,7 +361,7 @@ class TestAnalyzeCacheAndFail:
             saved = json.loads((cache_dir / "report.json").read_text(encoding="utf-8"))
             assert saved["schemaVersion"] == 2
 
-    @patch("regis.commands.analyze.render_mr_templates")
+    @patch("regis.commands.analyze.render_presentation_templates")
     @patch("regis.commands.analyze.render_and_save_reports")
     @patch("regis.commands.analyze.validate_report")
     @patch("regis.commands.analyze.run_playbooks")

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -326,8 +326,8 @@ class TestEvaluate:
         assert widgets[2]["resolved_value"] == "B"
 
 
-class TestGitLabChecklist:
-    """Test GitLab MR description checklist item evaluation."""
+class TestPresentationChecklists:
+    """Test presentation checklist item evaluation."""
 
     BASE_PLAYBOOK = {
         "schemaVersion": 1,
@@ -536,8 +536,8 @@ class TestGitLabChecklist:
         ]
 
 
-class TestGitLabTemplates:
-    """Test GitLab MR templates evaluation."""
+class TestPresentationTemplates:
+    """Test presentation templates evaluation."""
 
     BASE_PLAYBOOK = {
         "schemaVersion": 1,

--- a/tests/test_playbook_engine.py
+++ b/tests/test_playbook_engine.py
@@ -345,14 +345,14 @@ class TestGitLabChecklist:
         import copy
 
         pb: dict[str, Any] = copy.deepcopy(self.BASE_PLAYBOOK)
-        pb["integrations"] = {"gitlab": {"checklist": checklist}}
+        pb["presentation"] = {"checklist": checklist}
         return pb
 
     def test_unconditional_item_always_included(self):
         """Items with no condition are always added to the checklist."""
         pb = self._make_playbook([{"label": "Manual review done"}])
         result = evaluate(pb, {})
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [{"label": "Manual review done", "checked": False}],
@@ -371,7 +371,7 @@ class TestGitLabChecklist:
         )
         report = {"results": {"cve": {"critical_count": 0}}}
         result = evaluate(pb, report)
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [{"label": "No critical CVEs", "checked": False}],
@@ -390,7 +390,7 @@ class TestGitLabChecklist:
         )
         report = {"results": {"cve": {"critical_count": 5}}}
         result = evaluate(pb, report)
-        assert "mr_description_checklists" not in result
+        assert "checklists" not in result
 
     def test_missing_data_excludes_item(self):
         """Items whose condition references missing data are excluded."""
@@ -403,7 +403,7 @@ class TestGitLabChecklist:
             ]
         )
         result = evaluate(pb, {})
-        assert "mr_description_checklists" not in result
+        assert "checklists" not in result
 
     def test_mixed_items(self):
         """Mixed conditional and unconditional items produce correct subset."""
@@ -422,7 +422,7 @@ class TestGitLabChecklist:
         )
         report = {"results": {"ok": True}}
         result = evaluate(pb, report)
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [
@@ -444,7 +444,7 @@ class TestGitLabChecklist:
         )
         report = {"results": {"cve": {"critical_count": 0}}}
         result = evaluate(pb, report)
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [{"label": "No critical CVEs", "checked": True}],
@@ -463,7 +463,7 @@ class TestGitLabChecklist:
         )
         report = {"results": {"cve": {"critical_count": 3}}}
         result = evaluate(pb, report)
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [{"label": "No critical CVEs", "checked": False}],
@@ -481,7 +481,7 @@ class TestGitLabChecklist:
             ]
         )
         result = evaluate(pb, {})
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "📝 Review Checklist",
                 "items": [{"label": "Some item", "checked": False}],
@@ -489,44 +489,42 @@ class TestGitLabChecklist:
         ]
 
     def test_no_checklist_key_absent(self):
-        """When checklist is not defined, mr_description_checklists is absent."""
+        """When checklist is not defined, checklists is absent."""
         result = evaluate(self.BASE_PLAYBOOK, {})
-        assert "mr_description_checklists" not in result
+        assert "checklists" not in result
 
     def test_empty_checklist_key_absent(self):
-        """When checklist is an empty list, mr_description_checklists is absent."""
+        """When checklist is an empty list, checklists is absent."""
         pb = self._make_playbook([])
         result = evaluate(pb, {})
-        assert "mr_description_checklists" not in result
+        assert "checklists" not in result
 
     def test_multiple_checklists(self):
         import copy
 
         pb = copy.deepcopy(self.BASE_PLAYBOOK)
-        pb["integrations"] = {
-            "gitlab": {
-                "checklists": [
-                    {
-                        "title": "Security Checklist",
-                        "items": [
-                            {
-                                "label": "No critical CVEs",
-                                "check_if": {
-                                    "==": [{"var": "results.cve.critical_count"}, 0]
-                                },
-                            }
-                        ],
-                    },
-                    {
-                        "title": "Compliance Checklist",
-                        "items": [{"label": "Manual compliance check"}],
-                    },
-                ]
-            }
+        pb["presentation"] = {
+            "checklists": [
+                {
+                    "title": "Security Checklist",
+                    "items": [
+                        {
+                            "label": "No critical CVEs",
+                            "check_if": {
+                                "==": [{"var": "results.cve.critical_count"}, 0]
+                            },
+                        }
+                    ],
+                },
+                {
+                    "title": "Compliance Checklist",
+                    "items": [{"label": "Manual compliance check"}],
+                },
+            ]
         }
         report = {"results": {"cve": {"critical_count": 0}}}
         result = evaluate(pb, report)
-        assert result["mr_description_checklists"] == [
+        assert result["checklists"] == [
             {
                 "title": "Security Checklist",
                 "items": [{"label": "No critical CVEs", "checked": True}],
@@ -557,14 +555,14 @@ class TestGitLabTemplates:
         import copy
 
         pb: dict[str, Any] = copy.deepcopy(self.BASE_PLAYBOOK)
-        pb["integrations"] = {"gitlab": {"templates": templates}}
+        pb["presentation"] = {"templates": templates}
         return pb
 
     def test_unconditional_template_included(self):
         """Templates with no condition are always added."""
         pb = self._make_playbook([{"url": "https://example.com/template"}])
         result = evaluate(pb, {})
-        assert result["mr_templates"] == [{"url": "https://example.com/template"}]
+        assert result["templates"] == [{"url": "https://example.com/template"}]
 
     def test_truthy_condition_includes_template(self):
         """Templates whose condition evaluates to True are included."""
@@ -578,7 +576,7 @@ class TestGitLabTemplates:
         )
         report = {"results": {"ok": True}}
         result = evaluate(pb, report)
-        assert result["mr_templates"] == [{"url": "local/path/to/template"}]
+        assert result["templates"] == [{"url": "local/path/to/template"}]
 
     def test_falsy_condition_excludes_template(self):
         """Templates whose condition evaluates to False are excluded."""
@@ -592,7 +590,7 @@ class TestGitLabTemplates:
         )
         report = {"results": {"ok": True}}
         result = evaluate(pb, report)
-        assert "mr_templates" not in result
+        assert "templates" not in result
 
     def test_missing_data_excludes_template(self):
         """Templates whose condition references missing data are excluded."""
@@ -605,13 +603,13 @@ class TestGitLabTemplates:
             ]
         )
         result = evaluate(pb, {})
-        assert "mr_templates" not in result
+        assert "templates" not in result
 
     def test_empty_templates_absent(self):
-        """When templates is an empty list, mr_templates is absent."""
+        """When templates is an empty list, templates is absent."""
         pb = self._make_playbook([])
         result = evaluate(pb, {})
-        assert "mr_templates" not in result
+        assert "templates" not in result
 
 
 def test_evaluate_propagates_playbook_metadata() -> None:

--- a/tests/test_presentation_schema.py
+++ b/tests/test_presentation_schema.py
@@ -13,7 +13,7 @@ SCHEMA = json.loads(
 
 def _doc(spec_extra: dict) -> dict:
     return {
-        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "apiVersion": "regis.io/v1alpha1",
         "kind": "Playbook",
         "metadata": {"name": "p", "labels": {"app.kubernetes.io/version": "1.0.0"}},
         "spec": {"rules": [], **spec_extra},

--- a/tests/test_presentation_schema.py
+++ b/tests/test_presentation_schema.py
@@ -1,0 +1,39 @@
+"""Schema validation for the spec.presentation section."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA = json.loads(
+    Path("regis/schemas/playbook/v1alpha1/playbook.schema.json").read_text()
+)
+
+
+def _doc(spec_extra: dict) -> dict:
+    return {
+        "apiVersion": "regis.trivoallan.dev/v1alpha1",
+        "kind": "Playbook",
+        "metadata": {"name": "p", "labels": {"app.kubernetes.io/version": "1.0.0"}},
+        "spec": {"rules": [], **spec_extra},
+    }
+
+
+def test_presentation_section_validates():
+    doc = _doc(
+        {
+            "presentation": {
+                "badges": ["score"],
+                "checklists": [{"title": "T", "items": [{"label": "do X"}]}],
+                "templates": [{"url": "gh:org/tmpl"}],
+            }
+        }
+    )
+    jsonschema.Draft202012Validator(SCHEMA).validate(doc)
+
+
+def test_integrations_section_is_rejected():
+    doc = _doc({"integrations": {"gitlab": {"badges": ["score"]}}})
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(SCHEMA).validate(doc)

--- a/tests/test_report_schema_version.py
+++ b/tests/test_report_schema_version.py
@@ -61,10 +61,10 @@ class TestReportSchemaVersion:
 
 
 class TestEnsureSchemaVersion:
-    def test_constant_is_one(self):
+    def test_constant_is_two(self):
         from regis.utils.report import REPORT_SCHEMA_VERSION
 
-        assert REPORT_SCHEMA_VERSION == 1
+        assert REPORT_SCHEMA_VERSION == 2
 
     def test_sets_when_missing(self):
         from regis.utils.report import REPORT_SCHEMA_VERSION, ensure_schema_version
@@ -92,10 +92,10 @@ class TestContractFixture:
 
         from regis.utils.report import validate_report
 
-        fixture = Path(__file__).parent / "fixtures" / "report.v1.json"
+        fixture = Path(__file__).parent / "fixtures" / "report.v2.json"
         report = json.loads(fixture.read_text(encoding="utf-8"))
 
-        assert report["schemaVersion"] == 1
+        assert report["schemaVersion"] == 2
         validate_report(report)  # must not raise
 
     def test_analyzer_blobs_match_their_schemas(self):
@@ -104,7 +104,7 @@ class TestContractFixture:
 
         import jsonschema
 
-        fixtures = Path(__file__).parent / "fixtures" / "report.v1.json"
+        fixtures = Path(__file__).parent / "fixtures" / "report.v2.json"
         report = json.loads(fixtures.read_text(encoding="utf-8"))
 
         schema_dir = importlib.resources.files("regis.schemas.analyzer")


### PR DESCRIPTION
## Summary

Core sub-project #1 of generalizing the playbook integration layer: the playbook engine no longer knows any platform. GitLab-specific config and output naming become platform-neutral; each integration (regis-gitlab, regis-action, regis-backstage) renders the neutral data itself.

- **Playbook schema**: `spec.integrations.gitlab.{badges,checklist,checklists,templates}` → platform-neutral **`spec.presentation.{badges,checklists,templates}`** (drops the deprecated singular `checklist`).
- **Resolver**: `playbook/integrations/gitlab.py` → `playbook/presentation.py` (`resolve_presentation`, reads the normalized `playbook["presentation"]`); the `integrations/` package is removed and the evaluator no longer imports GitLab.
- **Report fields**: `mr_description_checklists` → `checklists`, `mr_templates` → `templates` (`badge_labels` unchanged). The core consumer `render_presentation_templates` (was `render_mr_templates`) reads the new field.
- **`REPORT_SCHEMA_VERSION` 1 → 2** (hard-cut).
- **Migration**: `regis playbook migrate` now moves `integrations.gitlab` → `presentation` (idempotent; folds singular `checklist`; leaves non-gitlab integrations untouched). Default playbook + cookiecutters dogfooded.

## Breaking changes

- Playbook authors: `spec.integrations.gitlab` is gone — run `regis playbook migrate <file> --in-place`.
- Report consumers: `mr_*` presentation fields renamed; `schemaVersion` is now `2`.

Pre-v1 → **minor** bump (`bump-minor-pre-major`).

## Follow-up sub-projects (consume the neutral contract)

- **#2 regis-gitlab**: template reads `.playbook.checklists`/`.playbook.templates`; widen schemaVersion gate.
- **#3 regis-backstage**: `regis-common` types/schema + rendering; accept `schemaVersion: 2`.
- **#4 regis-action**: consume `.playbook.badge_labels`/`.playbook.checklists` → GitHub PR parity.

Downstream degrades gracefully until updated (backstage gates on schemaVersion; the regis-gitlab template uses `// []`).

## Verification

- `pipenv run ruff check .` → clean; `pipenv run pytest` → 532 passed, coverage 92.11 %.
- No platform coupling remains in the engine (only the migrate codemod legitimately names `integrations.gitlab`).
- Rebased on `main` after #653 (API-group rename to `regis.io`); docs build green.

Spec: `docs/superpowers/specs/2026-06-06-playbook-presentation-generalization-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)