### PR TITLE
ci(lint): exclude all external links from docs link check

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -96,13 +96,8 @@ jobs:
             --exclude-path docs/website/versioned_docs
             --exclude-path docs/website/node_modules
             --exclude 'pathname:///'
-            --exclude 'http://localhost'
-            --exclude 'https://example.com'
-            --exclude 'regis\.example\.com'
-            --exclude 'my-private-registry\.example\.com'
-            --exclude 'host\.example\.com'
             --exclude '\.schema\.md'
-            --exclude '^https?://claude\.ai'
+            --exclude '^https?://'
             docs/website/docs/
           fail: true
 


### PR DESCRIPTION
## Summary

Makes the **Docs Link Check** CI job deterministic by excluding **all** external `http(s)` links rather than maintaining a per-host allow-list.

External hosts (observed: `https://scorecard.dev/` in `scorecarddev.md`) intermittently return `Network error: Connection failed` from the GitHub runner — a false positive that a plain rerun clears. For a blocking PR check this is noise. The links that *should* block a PR are the internal/relative ones that break during docs refactors, and those remain fully checked.

## Changes

`.github/workflows/ci-lint.yml` — lychee step:

- Replaced the brittle external-host excludes (`localhost`, `example.com`, `regis.example.com`, `claude.ai`, …) with a single `--exclude '^https?://'`.
- Kept relative-link excludes (`pathname:///`, `\.schema\.md`) and the `--exclude-path` entries (`versioned_docs`, `node_modules`).
- `fail: true` retained — internal link breakage still blocks the PR.

## Reviewer notes

- `^https?://` matches every external URL while leaving lychee's relative file-link resolution untouched (chosen over `--offline` to avoid changing resolution semantics).
- `versioned_docs/` is untouched; `trunk check` is unaffected (GitHub Actions YAML only).
- YAML validated locally.