### PR TITLE
test(hadolint): mock tool resolution to stop flaky network fetch

### DIFF
--- a/tests/test_coverage_analyzers.py
+++ b/tests/test_coverage_analyzers.py
@@ -113,7 +113,9 @@ class TestHadolintCoverage:
         cl = MagicMock(registry="r", username="u", password="p")
         sk = json.dumps({"history": [{"created_by": "RUN echo 1"}]})
         ha = json.dumps([{"level": "warning", "message": "m"}])
-        with patch("subprocess.run") as m:
+        with patch(
+            "regis.analyzers.hadolint.ensure_tool", return_value="/usr/bin/hadolint"
+        ), patch("subprocess.run") as m:
             m.side_effect = [MagicMock(stdout=sk), MagicMock(stdout=ha)]
             r = a.analyze(cl, "r", "t")
             assert r["issues_by_level"]["warning"] == 1

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -14,9 +14,10 @@ class MockRegistryClient:
 
 
 class TestHadolintAnalyzer:
+    @patch("regis.analyzers.hadolint.ensure_tool", return_value="/usr/bin/hadolint")
     @patch("regis.analyzers.hadolint.subprocess.run")
     @patch("regis.analyzers.hadolint.run_regctl")
-    def test_hadolint_passes(self, mock_regctl, mock_run):
+    def test_hadolint_passes(self, mock_regctl, mock_run, mock_ensure_tool):
         # The config fetch goes through regctl; the linter stays on subprocess.run.
         mock_regctl.return_value = json.dumps(
             {
@@ -39,9 +40,10 @@ class TestHadolintAnalyzer:
         assert report["issues_by_level"]["error"] == 0
         assert report["issues_by_level"]["warning"] == 0
 
+    @patch("regis.analyzers.hadolint.ensure_tool", return_value="/usr/bin/hadolint")
     @patch("regis.analyzers.hadolint.subprocess.run")
     @patch("regis.analyzers.hadolint.run_regctl")
-    def test_hadolint_fails(self, mock_regctl, mock_run):
+    def test_hadolint_fails(self, mock_regctl, mock_run, mock_ensure_tool):
         mock_regctl.return_value = json.dumps(
             {
                 "history": [


### PR DESCRIPTION
## Summary

Three hadolint tests made a real, unmocked network call and flaked in CI with `urllib.error.HTTPError: HTTP Error 504: Gateway Time-out`:

- `tests/test_hadolint.py::TestHadolintAnalyzer::test_hadolint_passes`
- `tests/test_hadolint.py::TestHadolintAnalyzer::test_hadolint_fails`
- `tests/test_coverage_analyzers.py::TestHadolintCoverage::test_hadolint_full`

## Root cause

These tests patched `subprocess.run` and `run_regctl`, but `HadolintAnalyzer.analyze()` also calls `ensure_tool("hadolint")`, which downloads the hadolint binary via `urllib.request.urlopen(...)` in `regis/tools/fetcher.py`. That download was never mocked, so on runners without a cached binary it hit the real network and flaked on transient 5xx responses.

## Fix

Patch `regis.analyzers.hadolint.ensure_tool` (at the usage site, per the lazy-import patch conventions in `CLAUDE.md`) to return a fake path in the three affected tests.

## Scope check

Only `dockle` and `hadolint` analyzers use `ensure_tool`. Dockle's tests (`test_analyzer_dockle.py`) and the other hadolint test file (`test_analyzer_hadolint.py`) already stub it — these three were the only gaps.

## Verification

- Targeted tests: 9 passed, including a run with `socket.connect`/`create_connection` blocked, proving the fetcher download is no longer reached.
- Full suite: 532 passed, coverage 92.11% (≥ 90% gate respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)