### PR TITLE
docs(rules): use criterion vocabulary in generated playbook examples

### DIFF
--- a/docs/website/docs/reference/rules/core/registry-domain-whitelist.md
+++ b/docs/website/docs/reference/rules/core/registry-domain-whitelist.md
@@ -30,7 +30,7 @@ Checks if requested image registry domain is in the domains list.
 ```yaml
 rules:
   - provider: core
-    rule: registry-domain-whitelist
+    criterion: registry-domain-whitelist
     options:
       domains:
         - docker.io

--- a/docs/website/docs/reference/rules/cve/cve-count.md
+++ b/docs/website/docs/reference/rules/cve/cve-count.md
@@ -31,7 +31,7 @@ Max allowed violations for a given severity level.
 ```yaml
 rules:
   - provider: cve
-    rule: cve-count
+    criterion: cve-count
     options:
       level: critical
       max_count: 0

--- a/docs/website/docs/reference/rules/cve/fix-available.md
+++ b/docs/website/docs/reference/rules/cve/fix-available.md
@@ -30,7 +30,7 @@ All vulnerabilities should be fixed if a patch exists.
 ```yaml
 rules:
   - provider: cve
-    rule: fix-available
+    criterion: fix-available
     options:
       max_count: 0
 ```

--- a/docs/website/docs/reference/rules/dockle/severity-count.md
+++ b/docs/website/docs/reference/rules/dockle/severity-count.md
@@ -31,7 +31,7 @@ Max allowed issues for a given severity level.
 ```yaml
 rules:
   - provider: dockle
-    rule: severity-count
+    criterion: severity-count
     options:
       level: FATAL
       max_count: 0

--- a/docs/website/docs/reference/rules/freshness/age.md
+++ b/docs/website/docs/reference/rules/freshness/age.md
@@ -30,7 +30,7 @@ Image should be less than expected days old.
 ```yaml
 rules:
   - provider: freshness
-    rule: age
+    criterion: age
     options:
       max_days: 30
 ```

--- a/docs/website/docs/reference/rules/hadolint/severity-count.md
+++ b/docs/website/docs/reference/rules/hadolint/severity-count.md
@@ -31,7 +31,7 @@ Max allowed violations for a given severity level.
 ```yaml
 rules:
   - provider: hadolint
-    rule: severity-count
+    criterion: severity-count
     options:
       level: error
       max_count: 0

--- a/docs/website/docs/reference/rules/oci/env-blacklist.md
+++ b/docs/website/docs/reference/rules/oci/env-blacklist.md
@@ -30,7 +30,7 @@ Image must not contain forbidden environment variables.
 ```yaml
 rules:
   - provider: oci
-    rule: env-blacklist
+    criterion: env-blacklist
     options:
       keys:
         - DEBUG

--- a/docs/website/docs/reference/rules/oci/exposed-ports-whitelist.md
+++ b/docs/website/docs/reference/rules/oci/exposed-ports-whitelist.md
@@ -30,7 +30,7 @@ Image exposes permitted ports.
 ```yaml
 rules:
   - provider: oci
-    rule: exposed-ports-whitelist
+    criterion: exposed-ports-whitelist
     options:
       allowed_ports:
         - "80"

--- a/docs/website/docs/reference/rules/oci/layers-count.md
+++ b/docs/website/docs/reference/rules/oci/layers-count.md
@@ -30,7 +30,7 @@ Image has an acceptable number of layers.
 ```yaml
 rules:
   - provider: oci
-    rule: layers-count
+    criterion: layers-count
     options:
       max_layers: 30
 ```

--- a/docs/website/docs/reference/rules/oci/max-size.md
+++ b/docs/website/docs/reference/rules/oci/max-size.md
@@ -30,7 +30,7 @@ Image size is within limits.
 ```yaml
 rules:
   - provider: oci
-    rule: max-size
+    criterion: max-size
     options:
       max_mb: 1000
 ```

--- a/docs/website/docs/reference/rules/oci/platforms-count.md
+++ b/docs/website/docs/reference/rules/oci/platforms-count.md
@@ -30,7 +30,7 @@ Image should support multiple platforms.
 ```yaml
 rules:
   - provider: oci
-    rule: platforms-count
+    criterion: platforms-count
     options:
       min_platforms: 2
 ```

--- a/docs/website/docs/reference/rules/oci/required-labels.md
+++ b/docs/website/docs/reference/rules/oci/required-labels.md
@@ -30,7 +30,7 @@ Image must have required OCI labels.
 ```yaml
 rules:
   - provider: oci
-    rule: required-labels
+    criterion: required-labels
     options:
       labels:
         - org.opencontainers.image.source

--- a/docs/website/docs/reference/rules/oci/tag-blacklist.md
+++ b/docs/website/docs/reference/rules/oci/tag-blacklist.md
@@ -24,7 +24,7 @@ Image tag should not be 'latest'.
 ```yaml
 rules:
   - provider: oci
-    rule: tag-blacklist
+    criterion: tag-blacklist
 ```
 
 ## Condition

--- a/docs/website/docs/reference/rules/oci/user-blacklist.md
+++ b/docs/website/docs/reference/rules/oci/user-blacklist.md
@@ -30,7 +30,7 @@ Image must not run as root.
 ```yaml
 rules:
   - provider: oci
-    rule: user-blacklist
+    criterion: user-blacklist
     options:
       forbidden_user: root
 ```

--- a/docs/website/docs/reference/rules/sbom/has-sbom.md
+++ b/docs/website/docs/reference/rules/sbom/has-sbom.md
@@ -24,7 +24,7 @@ Image must provide a Software Bill of Materials.
 ```yaml
 rules:
   - provider: sbom
-    rule: has-sbom
+    criterion: has-sbom
 ```
 
 ## Condition

--- a/docs/website/docs/reference/rules/sbom/license-blocklist.md
+++ b/docs/website/docs/reference/rules/sbom/license-blocklist.md
@@ -31,7 +31,7 @@ Image must not include components with licenses from the configured blocklist.
 ```yaml
 rules:
   - provider: sbom
-    rule: license-blocklist
+    criterion: license-blocklist
     options:
       blocklist: []
 ```

--- a/docs/website/docs/reference/rules/scorecarddev/min-score.md
+++ b/docs/website/docs/reference/rules/scorecarddev/min-score.md
@@ -30,7 +30,7 @@ OpenSSF Scorecard score is above the threshold.
 ```yaml
 rules:
   - provider: scorecarddev
-    rule: min-score
+    criterion: min-score
     options:
       min_score: 5.0
 ```

--- a/docs/website/docs/reference/rules/secrets/secret-scan.md
+++ b/docs/website/docs/reference/rules/secrets/secret-scan.md
@@ -30,7 +30,7 @@ No secrets or credentials should be embedded in the image.
 ```yaml
 rules:
   - provider: secrets
-    rule: secret-scan
+    criterion: secret-scan
     options:
       max_count: 0
 ```

--- a/regis/commands/rules.py
+++ b/regis/commands/rules.py
@@ -68,11 +68,11 @@ def _render_rule_markdown(rule: dict[str, Any]) -> str:
     lines.append("rules:")
     lines.append(f"  - provider: {provider}")
 
-    rule_name = slug
+    criterion_name = slug
     if "." in slug:
-        rule_name = slug.split(".", 1)[1]
+        criterion_name = slug.split(".", 1)[1]
 
-    lines.append(f"    rule: {rule_name}")
+    lines.append(f"    criterion: {criterion_name}")
 
     if params:
         lines.append("    options:")

--- a/tests/test_cli_rules_list.py
+++ b/tests/test_cli_rules_list.py
@@ -93,6 +93,11 @@ class TestCliRulesList:
             )
             assert "| core | Critical | security |" in rule_content
             assert "## Condition" in rule_content
+            # The playbook example must use the `criterion:` vocabulary, not the
+            # legacy `rule:` template key (renamed in #646).
+            assert "## Playbook Example" in rule_content
+            assert "criterion: registry-domain-whitelist" in rule_content
+            assert "\n    rule:" not in rule_content
 
 
 class TestCliRulesListFilters:


### PR DESCRIPTION
## Summary

The rule reference generator (`_render_rule_markdown` in `regis/commands/rules.py`) still emitted the legacy `rule:` template key in each rule's **Playbook Example**, even though the **Condition** section already used the new `criterion.*` namespace. This left every generated rule page (e.g. [secret-scan](https://trivoallan.github.io/regis/docs/next/reference/rules/secrets/secret-scan#playbook-example)) internally inconsistent after the `rule` → `criterion` rename (#646).

This switches the generated examples to `criterion:` and refreshes the 18 rule reference pages. The top-level `spec.rules` list key is unchanged (the schema only renamed the per-entry template reference).

## Changes

- `regis/commands/rules.py` — emit `criterion:` instead of the legacy `rule:` key in generated playbook examples
- `tests/test_cli_rules_list.py` — lock the generated example to `criterion:` (and assert the legacy `rule:` key is gone)
- `docs/website/docs/reference/rules/**` — 18 pages regenerated (one-line change each)

Versioned snapshots under `versioned_docs/` are intentionally left untouched (they reflect the vocabulary at release time).

## Test plan

- `pipenv run pytest` — 532 passed, coverage 92.11%
- `pipenv run ruff check` — clean
- `trunk fmt` applied to regenerated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)