### PR TITLE
feat(analyzer): add OCI platform whitelist/blacklist rules

### DIFF
--- a/docs/memory-bank/activeContext.md
+++ b/docs/memory-bank/activeContext.md
@@ -17,6 +17,11 @@ Voir `docs/memory-bank/roadmap.md` pour le détail complet.
 
 ## Recent Changes
 
+- [2026-06-08] **Règles d'identité de plateforme OCI** ([PR #661](https://github.com/trivoallan/regis/pull/661), `whats-new`, non cassant, opt-in):
+  - 3 criteria OCI (`platforms-required`/`-whitelist`/`-blacklist`) sur _quelles_ plateformes une image supporte, adossés à une nouvelle projection plate `results.oci.platforms_supported` (`os/arch[/variant]` canonique, dédupliquée). Réutilise `contains_all`/`subset`/`intersects` — aucun nouvel opérateur. Param uniforme `platforms`.
+  - **Premier criterion `enable:false` du cœur** : les 3 sont opt-in (désactivés par défaut, sinon bruyants) ; `merge_rules()` auto-active un criterion lié via `criterion:` (un `enable:false` explicite gagne ; un override par slug seul n'active pas). Détail dans `progress.md`. Pattern réutilisable pour de futures règles « politique » à ne pas activer par défaut.
+  - 6 tâches subagent-driven (revue spec+qualité par tâche + holistique). Suite 543 PASS, couverture 92.14 %. Spec/plan sous `docs/superpowers/`.
+
 - [2026-06-05] **Dégraissage pré-v1 : suppression de 3 features inutiles** (3 PR distinctes ; brainstorming → spec → plans → subagent-driven, revue conformité + qualité par PR):
   - **PR #648** (`chore(skills)`, non cassant) : suppression de la skill Claude `/create-playbook` (chevauchait `regis bootstrap playbook`). Doc `custom-playbook.md` recadrée sur le bootstrap CLI ; `/create-playbook` retiré de la liste project-skills de `CLAUDE.md`. Porte aussi les **design docs partagés** (spec + 3 plans). Résout le suivi « la skill émet encore `rule:` ».
   - **PR #649** (`feat(cli)!`, bump mineur) : suppression de la commande `regis github update-pr`, redondante depuis l'extraction de [`trivoallan/regis-action`](https://github.com/trivoallan/regis-action). Retrait `github_cli.py` + `test_github_cli.py` + wiring `cli.py` ; doc `integrations/github.md` / `roadmap.md` / `reference/cli.md` élaguée. `gitlab` **conservé** (extraction future notée).

--- a/docs/memory-bank/progress.md
+++ b/docs/memory-bank/progress.md
@@ -12,6 +12,12 @@
 
 ## Completed (Recent)
 
+- **Règles d'identité de plateforme OCI (2026-06-08, [PR #661](https://github.com/trivoallan/regis/pull/661), `whats-new`)** — non cassant, opt-in (brainstorming → writing-plans → subagent-driven, 6 tâches, revue spec+qualité par tâche + revue finale holistique):
+  - 3 nouveaux criteria OCI sur _quelles_ plateformes (le `platforms-count` existant ne compte que le nombre) : `platforms-required` (`contains_all` = au moins), `platforms-whitelist` (`subset` = uniquement), `platforms-blacklist` (`!intersects` = aucune). Param uniforme `platforms` (cf. `required-labels`/`labels`). Opérateurs JSON Logic **existants** — aucun nouvel opérateur.
+  - Nouvelle projection plate `results.oci.platforms_supported` = liste dédupliquée de chaînes canoniques `os/arch[/variant]` (filtre `unknown`, ordre préservé via `dict.fromkeys`) ; champ **optionnel** ajouté à `oci.schema.json` (`additionalProperties:false`). Matching par égalité stricte (`linux/arm64` ≠ `linux/arm64/v8`).
+  - **Opt-in** (décision post-revue) : les 3 criteria sont `enable: false` (sinon bruyants par défaut — whitelist échoue sur une image multi-arch large, required sur toute image mono-arch). `merge_rules()` auto-active un criterion instancié via une liaison `criterion:` (un `enable: false` explicite reste prioritaire) ; un override par slug seul (Case B) **n'active pas** un criterion opt-in. C'est le **premier** criterion `enable:false` du cœur — le mécanisme d'auto-activation est nouveau dans le moteur.
+  - Pages de référence régénérées depuis `default_criteria()` ; note opt-in dans `reference/analyzers/oci.md` + le spec. Suite 543 PASS, couverture 92.14 %. Spec : `docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md` ; plan : `docs/superpowers/plans/2026-06-08-oci-platforms-whitelist-blacklist.md`. **Reste** : merge de la PR (main protégée).
+
 - **Dégraissage pré-v1 — suppression de 3 features inutiles (2026-06-05)** — 3 PR distinctes (brainstorming → spec → plans → subagent-driven):
   - **PR #648** (`chore(skills)`, non cassant) — skill Claude `/create-playbook` retirée (chevauchait `regis bootstrap playbook`) ; `custom-playbook.md` + `CLAUDE.md` mis à jour ; porte les design docs partagés (spec + 3 plans).
   - **PR #649** (`feat(cli)!`, mineur) — commande `regis github` retirée (redondante depuis l'extraction de `trivoallan/regis-action`) ; `gitlab` conservé.

--- a/docs/superpowers/plans/2026-06-08-oci-platforms-whitelist-blacklist.md
+++ b/docs/superpowers/plans/2026-06-08-oci-platforms-whitelist-blacklist.md
@@ -1,0 +1,432 @@
+# OCI platform whitelist/blacklist rules — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three platform-identity criteria (`platforms-required`, `platforms-whitelist`, `platforms-blacklist`) to the OCI analyzer, backed by a new flat `results.oci.platforms_supported` projection.
+
+**Architecture:** A pure helper projects the list of platform objects into a deduplicated list of canonical `os/arch[/variant]` strings, emitted as a new optional field on the OCI analyzer output. Three new criteria in `default_criteria()` evaluate that field using the existing JSON Logic operators `contains_all`, `subset`, and `!`/`intersects` — no new operator, no engine change. Rule reference docs regenerate automatically from `default_criteria()`.
+
+**Tech Stack:** Python 3.11, `pytest`, JSON Schema (draft-07), JSON Logic (`regis/rules/evaluator.py`), `regctl`.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md`
+
+**Operator orientation (verified in `regis/rules/evaluator.py`):**
+- `contains_all([a], [b])` → all elements of `b` are in `a`.
+- `subset([a], [b])` → all elements of `a` are in `b`.
+- `intersects([a], [b])` → any element of `a` is in `b`.
+
+**Test commands:** `pipenv run pytest <path> -v --no-cov` for the fast loop; `pipenv run pytest` for the full coverage-gated run before the PR.
+
+---
+
+## File Structure
+
+- `regis/analyzers/oci.py` — add module-level `_platforms_supported()` helper; emit `platforms_supported` in `analyze()`; append three criteria to `default_criteria()`.
+- `regis/schemas/analyzer/oci.schema.json` — add the optional `platforms_supported` property (schema is `additionalProperties: false`, so this is mandatory for the field to validate).
+- `tests/test_oci_analyzer.py` — projection unit tests, analyze-level wiring test, and functional evaluation tests for the three criteria.
+- `docs/website/docs/reference/analyzers/oci.md` — document the new output field.
+- `docs/website/docs/reference/rules/oci/*.md` — regenerated, not hand-written.
+
+---
+
+## Task 1: Platform projection helper
+
+**Files:**
+- Modify: `regis/analyzers/oci.py` (add a module-level helper near the other module helpers, e.g. just above `class OciAnalyzer`)
+- Test: `tests/test_oci_analyzer.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_oci_analyzer.py`. Note the import update on line 12.
+
+```python
+# update the existing import line near the top of the file:
+from regis.analyzers.oci import OciAnalyzer, _platforms_supported
+
+
+def test_platforms_supported_dedup_and_order():
+    platforms = [
+        {"os": "linux", "architecture": "amd64"},
+        {"os": "linux", "architecture": "arm64"},
+        {"os": "linux", "architecture": "amd64"},  # duplicate
+    ]
+    assert _platforms_supported(platforms) == ["linux/amd64", "linux/arm64"]
+
+
+def test_platforms_supported_includes_variant():
+    platforms = [
+        {"os": "linux", "architecture": "arm64", "variant": "v8"},
+        {"os": "linux", "architecture": "arm", "variant": "v7"},
+    ]
+    assert _platforms_supported(platforms) == ["linux/arm64/v8", "linux/arm/v7"]
+
+
+def test_platforms_supported_skips_unknown_and_missing():
+    platforms = [
+        {"os": "unknown", "architecture": "unknown"},
+        {"os": "linux", "architecture": "unknown"},
+        {"os": "linux"},  # missing architecture
+        {"architecture": "amd64"},  # missing os
+        {"os": "linux", "architecture": "amd64"},
+    ]
+    assert _platforms_supported(platforms) == ["linux/amd64"]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py -k platforms_supported -v --no-cov`
+Expected: FAIL with `ImportError: cannot import name '_platforms_supported'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Add to `regis/analyzers/oci.py`, as a module-level function above `class OciAnalyzer` (the file already imports `Any` from `typing`):
+
+```python
+def _platforms_supported(platforms: list[dict[str, Any]]) -> list[str]:
+    """Project platform objects into canonical ``os/arch[/variant]`` strings.
+
+    Skips entries whose ``os`` or ``architecture`` is missing or ``"unknown"``.
+    Deduplicates while preserving first-seen order.
+    """
+    seen: list[str] = []
+    for platform in platforms:
+        os_name = platform.get("os")
+        arch = platform.get("architecture")
+        if not os_name or not arch or os_name == "unknown" or arch == "unknown":
+            continue
+        name = f"{os_name}/{arch}"
+        variant = platform.get("variant")
+        if variant:
+            name = f"{name}/{variant}"
+        if name not in seen:
+            seen.append(name)
+    return seen
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py -k platforms_supported -v --no-cov`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regis/analyzers/oci.py tests/test_oci_analyzer.py
+git commit -m "feat(analyzer): add platforms_supported projection helper"
+```
+
+---
+
+## Task 2: Emit `platforms_supported` in the analyzer output + schema
+
+**Files:**
+- Modify: `regis/analyzers/oci.py` (the `analyze()` return dict, currently `regis/analyzers/oci.py:253-258`)
+- Modify: `regis/schemas/analyzer/oci.schema.json`
+- Test: `tests/test_oci_analyzer.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_oci_analyzer.py`. It reuses the existing `_multiarch_dispatcher` and `_client` helpers already defined in the file.
+
+```python
+def test_oci_report_includes_platforms_supported():
+    with patch("regis.analyzers.oci.run_regctl", side_effect=_multiarch_dispatcher):
+        analyzer = OciAnalyzer()
+        report = analyzer.analyze(_client(), "library/alpine", "3.20.10")
+
+    # New field is present and schema-valid.
+    analyzer.validate(report)
+    assert "platforms_supported" in report
+    supported = report["platforms_supported"]
+    assert isinstance(supported, list)
+    assert all(isinstance(name, str) for name in supported)
+    # Multi-arch index resolves at least amd64 and arm64 linux platforms.
+    assert "linux/amd64" in supported
+    assert "linux/arm64" in supported
+    # No "unknown" platforms leak into the projection.
+    assert all("unknown" not in name for name in supported)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py::test_oci_report_includes_platforms_supported -v --no-cov`
+Expected: FAIL — `assert "platforms_supported" in report` (field not yet emitted). If the field were emitted without the schema change, `analyzer.validate(report)` would instead raise a `ValidationError` due to `additionalProperties: false`; either way the test is red until both edits below land.
+
+- [ ] **Step 3: Add the field to the analyzer output**
+
+In `regis/analyzers/oci.py`, update the `analyze()` return statement (currently `regis/analyzers/oci.py:253-258`):
+
+```python
+        return {
+            "analyzer": self.name,
+            "repository": repository,
+            "tag": tag,
+            "platforms": platforms,
+            "platforms_supported": _platforms_supported(platforms),
+            "tags": tags,
+        }
+```
+
+- [ ] **Step 4: Add the property to the schema**
+
+In `regis/schemas/analyzer/oci.schema.json`, add a `platforms_supported` property to the top-level `properties` object (alongside `platforms` and `tags`; do **not** add it to the top-level `required` array):
+
+```json
+    "platforms_supported": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Deduplicated canonical platform identifiers (os/arch[/variant]) supported by the image."
+    },
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py -v --no-cov`
+Expected: PASS (all OCI analyzer tests, including the new one).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add regis/analyzers/oci.py regis/schemas/analyzer/oci.schema.json tests/test_oci_analyzer.py
+git commit -m "feat(analyzer): emit platforms_supported on OCI report"
+```
+
+---
+
+## Task 3: Three platform-identity criteria
+
+**Files:**
+- Modify: `regis/analyzers/oci.py` (`OciAnalyzer.default_criteria()`, insert after the `platforms-count` entry which ends at `regis/analyzers/oci.py:121`)
+- Test: `tests/test_oci_analyzer.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_oci_analyzer.py`. Add this import near the top of the file:
+
+```python
+from regis.rules.evaluator import evaluate_rules
+```
+
+Then add the tests:
+
+```python
+def _oci_report(supported: list[str]) -> dict:
+    return {
+        "request": {"registry": "docker.io", "analyzers": ["oci"]},
+        "results": {"oci": {"platforms_supported": supported}},
+    }
+
+
+def _eval_oci_criterion(supported: list[str], criterion: str, platforms: list[str]):
+    rules_def = {
+        "rules": [
+            {
+                "provider": "oci",
+                "criterion": criterion,
+                "slug": "under-test",
+                "options": {"platforms": platforms},
+            }
+        ]
+    }
+    res = evaluate_rules(_oci_report(supported), rules_def)
+    return next(r for r in res["rules"] if r["slug"] == "under-test")
+
+
+def test_platforms_required_pass_and_fail():
+    # All required platforms are supported (extras allowed) -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64", "windows/amd64"],
+        "platforms-required",
+        ["linux/amd64", "linux/arm64"],
+    )
+    assert passed["passed"] is True
+
+    # A required platform is missing -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64"],
+        "platforms-required",
+        ["linux/amd64", "linux/arm64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_whitelist_pass_and_fail():
+    # Every supported platform is allowed -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-whitelist",
+        ["linux/amd64", "linux/arm64", "windows/amd64"],
+    )
+    assert passed["passed"] is True
+
+    # A supported platform is not in the allowed set -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-whitelist",
+        ["linux/amd64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_blacklist_pass_and_fail():
+    # No forbidden platform is supported -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-blacklist",
+        ["windows/amd64"],
+    )
+    assert passed["passed"] is True
+
+    # A forbidden platform is supported -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-blacklist",
+        ["linux/arm64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_required_fails_when_none_supported():
+    # Empty projection cannot satisfy a required platform -> fail.
+    failed = _eval_oci_criterion([], "platforms-required", ["linux/amd64"])
+    assert failed["passed"] is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py -k "platforms_required or platforms_whitelist or platforms_blacklist" -v --no-cov`
+Expected: FAIL — the criteria slugs don't exist yet, so `evaluate_rules` produces no rule with slug `under-test` and `next(...)` raises `StopIteration`.
+
+- [ ] **Step 3: Add the three criteria**
+
+In `regis/analyzers/oci.py`, inside `OciAnalyzer.default_criteria()`, insert these three dict entries immediately **after** the `platforms-count` entry (which ends with `},` at `regis/analyzers/oci.py:121`):
+
+```python
+            {
+                "slug": "platforms-required",
+                "description": "Image must support a required set of platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["linux/amd64", "linux/arm64"]},
+                "condition": {
+                    "contains_all": [
+                        {"var": "results.oci.platforms_supported"},
+                        {"var": "criterion.params.platforms"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image supports all required platforms.",  # nosec B105
+                    "fail": "Image is missing required platforms (supported: ${results.oci.platforms_supported}; required: ${criterion.params.platforms}).",
+                },
+            },
+            {
+                "slug": "platforms-whitelist",
+                "description": "Image must only support allowed platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["linux/amd64", "linux/arm64"]},
+                "condition": {
+                    "subset": [
+                        {"var": "results.oci.platforms_supported"},
+                        {"var": "criterion.params.platforms"},
+                    ]
+                },
+                "messages": {
+                    "pass": "All supported platforms are allowed.",  # nosec B105
+                    "fail": "Image supports disallowed platforms: ${results.oci.platforms_supported} (allowed: ${criterion.params.platforms}).",
+                },
+            },
+            {
+                "slug": "platforms-blacklist",
+                "description": "Image must not support forbidden platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["windows/amd64"]},
+                "condition": {
+                    "!": {
+                        "intersects": [
+                            {"var": "results.oci.platforms_supported"},
+                            {"var": "criterion.params.platforms"},
+                        ]
+                    }
+                },
+                "messages": {
+                    "pass": "Image supports no forbidden platforms.",  # nosec B105
+                    "fail": "Image supports forbidden platforms: ${results.oci.platforms_supported} (forbidden: ${criterion.params.platforms}).",
+                },
+            },
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pipenv run pytest tests/test_oci_analyzer.py -v --no-cov`
+Expected: PASS (all OCI analyzer tests, including the four new criteria tests). The existing `test_oci_default_criteria_use_oci_paths` still passes because the new conditions use `results.oci.` and `criterion.params.`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regis/analyzers/oci.py tests/test_oci_analyzer.py
+git commit -m "feat(analyzer): add platform required/whitelist/blacklist criteria"
+```
+
+---
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `docs/website/docs/reference/analyzers/oci.md`
+- Regenerate: `docs/website/docs/reference/rules/oci/*.md`
+
+- [ ] **Step 1: Document the new output field**
+
+Open `docs/website/docs/reference/analyzers/oci.md` and locate the section/table describing the analyzer output fields (where `platforms`, `tags`, etc. are listed). Add an entry for the new field, matching the surrounding prose/table style. Use exactly this description:
+
+> `platforms_supported` — Deduplicated canonical platform identifiers (`os/arch[/variant]`) supported by the image, e.g. `["linux/amd64", "linux/arm64"]`. Consumed by the `platforms-required`, `platforms-whitelist`, and `platforms-blacklist` rules.
+
+If the page renders output as a JSON example, also add `"platforms_supported": ["linux/amd64", "linux/arm64"]` to that example object.
+
+- [ ] **Step 2: Regenerate the rule reference pages**
+
+Run: `pipenv run regis rules list -f markdown -D docs/website/docs/reference/rules`
+Expected: three new files created — `docs/website/docs/reference/rules/oci/platforms-required.md`, `platforms-whitelist.md`, `platforms-blacklist.md` — plus an updated `oci/index.md` (this matches the CI command in `.github/workflows/cd-docs.yml`).
+
+- [ ] **Step 3: Verify the generated pages**
+
+Run: `git status --porcelain docs/website/docs/reference/rules/oci/`
+Expected: the three new `platforms-*.md` files (and possibly an updated index) appear. Spot-check `platforms-required.md` shows the `platforms` parameter with default `["linux/amd64", "linux/arm64"]`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/website/docs/reference/analyzers/oci.md docs/website/docs/reference/rules/oci/
+git commit -m "docs(analyzer): document platform identity rules"
+```
+
+---
+
+## Task 5: Full verification before PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite with coverage**
+
+Run: `pipenv run pytest`
+Expected: PASS, coverage ≥ 90% (the project gate).
+
+- [ ] **Step 2: Lint and format**
+
+Run: `pipenv run ruff check . && pipenv run ruff format --check .`
+Expected: no errors. If `ruff format --check` reports diffs, run `pipenv run ruff format .` and amend the relevant commit.
+
+- [ ] **Step 3: Confirm the working tree is clean**
+
+Run: `git status`
+Expected: clean (all changes committed).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** projection field (Task 1+2), `oci.schema.json` update (Task 2), three criteria with exact conditions/params/messages (Task 3), exact-match + variant identity (covered by the helper in Task 1 and the variant test), edge cases (empty-projection required-fail test in Task 3), generated reference docs + analyzer field doc (Task 4). `platforms-count` left untouched; default playbook unchanged; no new operator — all consistent with the spec's "Out of scope".
+- **Param name** is `platforms` uniformly across all three criteria and all tests.
+- **Operator orientation** verified against `regis/rules/evaluator.py`: `contains_all(supported, required)`, `subset(supported, allowed)`, `!(intersects(supported, forbidden))`.

--- a/docs/superpowers/plans/2026-06-08-oci-platforms-whitelist-blacklist.md
+++ b/docs/superpowers/plans/2026-06-08-oci-platforms-whitelist-blacklist.md
@@ -11,6 +11,7 @@
 **Reference spec:** `docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md`
 
 **Operator orientation (verified in `regis/rules/evaluator.py`):**
+
 - `contains_all([a], [b])` → all elements of `b` are in `a`.
 - `subset([a], [b])` → all elements of `a` are in `b`.
 - `intersects([a], [b])` → any element of `a` is in `b`.
@@ -32,6 +33,7 @@
 ## Task 1: Platform projection helper
 
 **Files:**
+
 - Modify: `regis/analyzers/oci.py` (add a module-level helper near the other module helpers, e.g. just above `class OciAnalyzer`)
 - Test: `tests/test_oci_analyzer.py`
 
@@ -120,6 +122,7 @@ git commit -m "feat(analyzer): add platforms_supported projection helper"
 ## Task 2: Emit `platforms_supported` in the analyzer output + schema
 
 **Files:**
+
 - Modify: `regis/analyzers/oci.py` (the `analyze()` return dict, currently `regis/analyzers/oci.py:253-258`)
 - Modify: `regis/schemas/analyzer/oci.schema.json`
 - Test: `tests/test_oci_analyzer.py`
@@ -196,6 +199,7 @@ git commit -m "feat(analyzer): emit platforms_supported on OCI report"
 ## Task 3: Three platform-identity criteria
 
 **Files:**
+
 - Modify: `regis/analyzers/oci.py` (`OciAnalyzer.default_criteria()`, insert after the `platforms-count` entry which ends at `regis/analyzers/oci.py:121`)
 - Test: `tests/test_oci_analyzer.py`
 
@@ -374,6 +378,7 @@ git commit -m "feat(analyzer): add platform required/whitelist/blacklist criteri
 ## Task 4: Documentation
 
 **Files:**
+
 - Modify: `docs/website/docs/reference/analyzers/oci.md`
 - Regenerate: `docs/website/docs/reference/rules/oci/*.md`
 

--- a/docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md
+++ b/docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md
@@ -55,6 +55,16 @@ Appended to `OciAnalyzer.default_criteria()`. Param name is `platforms` in all t
 `required-labels`, whose param is plainly `labels`). Tags `["compatibility"]`, default
 level `warning` (playbooks override level/tier per binding).
 
+**Opt-in activation (post-review decision).** Unlike the other OCI criteria, these three
+ship with `"enable": False`, so they are **disabled by default** and do not fire on every
+report. Rationale: every entry in `default_criteria()` is otherwise auto-evaluated by
+`get_default_rules()`, and the policy defaults above (require/allow `linux/amd64` +
+`linux/arm64`) would warn on common single-arch and broad multi-arch images out of the box.
+To keep "bind it = use it" ergonomic, `merge_rules()` sets `instance["enable"] = True` when
+a playbook instantiates a criterion via `criterion:` (an explicit `enable: false` in the
+binding still wins). A slug-only override (Case B) does **not** auto-activate an opt-in
+criterion — use `criterion:` to bind and enable.
+
 | Slug                  | Semantics                             | Default `platforms`              | Condition (JSON Logic)                          |
 | :-------------------- | :------------------------------------ | :------------------------------- | :---------------------------------------------- |
 | `platforms-required`  | image must support **at least** these | `["linux/amd64", "linux/arm64"]` | `contains_all(platforms_supported, platforms)`  |

--- a/docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md
+++ b/docs/superpowers/specs/2026-06-08-oci-platforms-whitelist-blacklist-design.md
@@ -1,0 +1,129 @@
+# OCI platform whitelist/blacklist rules — design
+
+**Date:** 2026-06-08
+**Status:** Approved (pending spec review)
+**Scope:** Add three platform-identity criteria to the OCI analyzer.
+
+## Problem
+
+The OCI analyzer ships a single platform-oriented criterion, `platforms-count`,
+which only checks the _number_ of supported platforms (`min_platforms`). There is
+no way to express requirements about _which_ platforms an image supports:
+
+- "the image must support at least `linux/amd64` and `linux/arm64`"
+- "the image must support _only_ an approved set of platforms"
+- "the image must not support a forbidden platform"
+
+## Constraints from the existing model
+
+- Each criterion in `default_criteria()` carries a **static** JSON Logic condition.
+  The playbook overrides `params`, severity and tier — never the operator. So each
+  distinct semantic needs its own slug.
+- `results.oci.platforms` is a list of **objects** `{os, architecture, variant?, …}`,
+  not strings, so it cannot be compared directly to a user-supplied string list.
+- Custom JSON Logic operators already available: `intersects`, `contains_all`,
+  `subset`, `keys`, `get`, `env_contains`. No new operator is needed.
+- Rule reference pages under `docs/website/docs/reference/rules/oci/` are **generated**
+  by `regis rules list -f markdown -D …` in CI (`cd-docs.yml`), straight from
+  `default_criteria()`. New criteria get their reference page automatically.
+
+## Design
+
+### 1. Flat platform projection in the analyzer output
+
+Add a new top-level field to the OCI analyzer result:
+
+```text
+results.oci.platforms_supported = ["linux/amd64", "linux/arm64", "linux/arm64/v8", …]
+```
+
+Built in `OciAnalyzer.analyze()` (`regis/analyzers/oci.py`) after the `platforms`
+list is assembled. For each platform object:
+
+- skip entries where `os` or `architecture` is missing or `"unknown"`;
+- canonical string = `f"{os}/{architecture}"`, plus `f"/{variant}"` when a truthy
+  `variant` is present;
+- deduplicate while preserving first-seen order.
+
+This mirrors `exposed_ports`, which is already a flat string list on each platform.
+The three criteria below consume this field through existing operators only.
+
+### 2. Three new criteria
+
+Appended to `OciAnalyzer.default_criteria()`. Param name is `platforms` in all three
+(the slug already carries the required/whitelist/blacklist intent — same convention as
+`required-labels`, whose param is plainly `labels`). Tags `["compatibility"]`, default
+level `warning` (playbooks override level/tier per binding).
+
+| Slug                  | Semantics                             | Default `platforms`              | Condition (JSON Logic)                          |
+| :-------------------- | :------------------------------------ | :------------------------------- | :---------------------------------------------- |
+| `platforms-required`  | image must support **at least** these | `["linux/amd64", "linux/arm64"]` | `contains_all(platforms_supported, platforms)`  |
+| `platforms-whitelist` | image must support **only** these     | `["linux/amd64", "linux/arm64"]` | `subset(platforms_supported, platforms)`        |
+| `platforms-blacklist` | image must support **none** of these  | `["windows/amd64"]`              | `!(intersects(platforms_supported, platforms))` |
+
+Operator orientation follows the existing siblings:
+
+- `contains_all(haystack, needles)` — as in `required-labels`
+  (`contains_all(keys(labels), params.labels)`).
+- `subset(small, big)` — as in `exposed-ports-whitelist`
+  (`subset(exposed_ports, allowed_ports)`).
+- `!(intersects(...))` — blacklist as the negation, mirroring `env-blacklist`'s
+  `!(env_contains(...))`.
+
+Each criterion carries `pass`/`fail` messages with interpolation, e.g.:
+
+- `platforms-required`
+  - pass: `Image supports all required platforms.`
+  - fail: `Image is missing required platforms (supported: ${results.oci.platforms_supported}; required: ${criterion.params.platforms}).`
+- `platforms-whitelist`
+  - pass: `All supported platforms are allowed.`
+  - fail: `Image supports disallowed platforms: ${results.oci.platforms_supported} (allowed: ${criterion.params.platforms}).`
+- `platforms-blacklist`
+  - pass: `Image supports no forbidden platforms.`
+  - fail: `Image supports forbidden platforms: ${results.oci.platforms_supported} (forbidden: ${criterion.params.platforms}).`
+
+### 3. Schema
+
+Add `platforms_supported` (array of string) to
+`regis/schemas/analyzer/oci.schema.json`. Required because the schema sets
+`additionalProperties: false`. The field is **optional** (not added to `required`),
+so existing hand-crafted fixtures remain valid.
+
+### 4. Identity & matching
+
+Platform identity is a **canonical string**, exact-match. `linux/arm64` does **not**
+match `linux/arm64/v8` — the variant is part of the identity when present. This
+matches the Docker `--platform` convention and keeps matching to plain set operators.
+
+## Edge cases (assumed behavior)
+
+- `platforms_supported` empty (no resolvable platform): `platforms-required` **fails**
+  (can't satisfy), `platforms-whitelist` **passes** (nothing disallowed),
+  `platforms-blacklist` **passes** (nothing forbidden present).
+- Empty `platforms` param:
+  - `platforms-required` → `contains_all(x, [])` is vacuously **true** → no-op pass.
+  - `platforms-whitelist` → `subset(x, [])` is true only when `x` is empty → **fails**
+    as soon as any platform exists ("nothing allowed"). Documented as a footgun.
+  - `platforms-blacklist` → `!(intersects(x, []))` → always **passes**.
+
+## Testing (TDD)
+
+- Analyzer: `platforms_supported` projection — multi-arch, variant suffix,
+  `unknown`/missing filtering, dedup/order preservation.
+- Rule evaluation: pass and fail paths for each of the three criteria, including the
+  empty-list edge cases above.
+
+## Out of scope
+
+- No new JSON Logic operator.
+- Default playbook left unchanged (these are opt-in policy rules).
+- `platforms-count` is untouched.
+
+## Touch list
+
+- `regis/analyzers/oci.py` — projection in `analyze()`, three entries in
+  `default_criteria()`.
+- `regis/schemas/analyzer/oci.schema.json` — `platforms_supported` property.
+- `docs/website/docs/reference/analyzers/oci.md` — document the new field.
+- Reference rule pages — generated, not hand-written.
+- Tests under the OCI analyzer / rules suites.

--- a/docs/website/docs/reference/analyzers/oci.md
+++ b/docs/website/docs/reference/analyzers/oci.md
@@ -41,3 +41,9 @@ The following rules are provided by default:
 | `exposed-ports-whitelist` | Image exposes permitted ports.                          | `warning`  |
 | `required-labels`         | Image must have required OCI labels.                    | `warning`  |
 | `env-blacklist`           | Image must not contain forbidden environment variables. | `critical` |
+
+:::note Opt-in rules
+
+`platforms-required`, `platforms-whitelist`, and `platforms-blacklist` ship **disabled by default** — their defaults are policy choices that would otherwise warn on common images. Activate one by binding its criterion in your playbook (for example `criterion: platforms-whitelist` with `options:`); binding a criterion enables it automatically. All other rules above run by default.
+
+:::

--- a/docs/website/docs/reference/analyzers/oci.md
+++ b/docs/website/docs/reference/analyzers/oci.md
@@ -22,6 +22,7 @@ This analyzer provides a comprehensive view of image metadata, including:
 - Per-platform details for multi-arch images (architecture, OS, size, layers).
 - Exposed ports and environment variables.
 - OCI labels.
+- Flat list of supported platform identifiers (`platforms_supported`), e.g. `["linux/amd64", "linux/arm64"]`.
 
 ## Default Rules
 
@@ -34,6 +35,9 @@ The following rules are provided by default:
 | `layers-count`            | Image has an acceptable number of layers.               | `warning`  |
 | `tag-blacklist`           | Image tag should not be 'latest'.                       | `warning`  |
 | `platforms-count`         | Image should support multiple platforms.                | `info`     |
+| `platforms-required`      | Image must support a required set of platforms.         | `warning`  |
+| `platforms-whitelist`     | Image must only support allowed platforms.              | `warning`  |
+| `platforms-blacklist`     | Image must not support forbidden platforms.             | `warning`  |
 | `exposed-ports-whitelist` | Image exposes permitted ports.                          | `warning`  |
 | `required-labels`         | Image must have required OCI labels.                    | `warning`  |
 | `env-blacklist`           | Image must not contain forbidden environment variables. | `critical` |

--- a/docs/website/docs/reference/rules/oci/platforms-blacklist.md
+++ b/docs/website/docs/reference/rules/oci/platforms-blacklist.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - compatibility
+  - rules
+---
+
+# platforms-blacklist
+
+Image must not support forbidden platforms.
+
+| Provider | Level   | Tags          |
+| :------- | :------ | :------------ |
+| oci      | Warning | compatibility |
+
+## Parameters
+
+| Name        | Default Value       | Description |
+| :---------- | :------------------ | :---------- |
+| `platforms` | `['windows/amd64']` | n/a         |
+
+## Messages
+
+| Type     | Message                                                                                                            |
+| :------- | :----------------------------------------------------------------------------------------------------------------- |
+| **Pass** | Image supports no forbidden platforms.                                                                             |
+| **Fail** | Image supports forbidden platforms: ${results.oci.platforms_supported} (forbidden: ${criterion.params.platforms}). |
+
+## Playbook Example
+
+```yaml
+rules:
+  - provider: oci
+    rule: platforms-blacklist
+    options:
+      platforms:
+        - windows/amd64
+```
+
+## Condition
+
+```json
+{
+  "!": {
+    "intersects": [
+      {
+        "var": "results.oci.platforms_supported"
+      },
+      {
+        "var": "criterion.params.platforms"
+      }
+    ]
+  }
+}
+```

--- a/docs/website/docs/reference/rules/oci/platforms-required.md
+++ b/docs/website/docs/reference/rules/oci/platforms-required.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - compatibility
+  - rules
+---
+
+# platforms-required
+
+Image must support a required set of platforms.
+
+| Provider | Level   | Tags          |
+| :------- | :------ | :------------ |
+| oci      | Warning | compatibility |
+
+## Parameters
+
+| Name        | Default Value                    | Description |
+| :---------- | :------------------------------- | :---------- |
+| `platforms` | `['linux/amd64', 'linux/arm64']` | n/a         |
+
+## Messages
+
+| Type     | Message                                                                                                                       |
+| :------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| **Pass** | Image supports all required platforms.                                                                                        |
+| **Fail** | Image is missing required platforms (supported: ${results.oci.platforms_supported}; required: ${criterion.params.platforms}). |
+
+## Playbook Example
+
+```yaml
+rules:
+  - provider: oci
+    rule: platforms-required
+    options:
+      platforms:
+        - linux/amd64
+        - linux/arm64
+```
+
+## Condition
+
+```json
+{
+  "contains_all": [
+    {
+      "var": "results.oci.platforms_supported"
+    },
+    {
+      "var": "criterion.params.platforms"
+    }
+  ]
+}
+```

--- a/docs/website/docs/reference/rules/oci/platforms-whitelist.md
+++ b/docs/website/docs/reference/rules/oci/platforms-whitelist.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - compatibility
+  - rules
+---
+
+# platforms-whitelist
+
+Image must only support allowed platforms.
+
+| Provider | Level   | Tags          |
+| :------- | :------ | :------------ |
+| oci      | Warning | compatibility |
+
+## Parameters
+
+| Name        | Default Value                    | Description |
+| :---------- | :------------------------------- | :---------- |
+| `platforms` | `['linux/amd64', 'linux/arm64']` | n/a         |
+
+## Messages
+
+| Type     | Message                                                                                                           |
+| :------- | :---------------------------------------------------------------------------------------------------------------- |
+| **Pass** | All supported platforms are allowed.                                                                              |
+| **Fail** | Image supports disallowed platforms: ${results.oci.platforms_supported} (allowed: ${criterion.params.platforms}). |
+
+## Playbook Example
+
+```yaml
+rules:
+  - provider: oci
+    rule: platforms-whitelist
+    options:
+      platforms:
+        - linux/amd64
+        - linux/arm64
+```
+
+## Condition
+
+```json
+{
+  "subset": [
+    {
+      "var": "results.oci.platforms_supported"
+    },
+    {
+      "var": "criterion.params.platforms"
+    }
+  ]
+}
+```

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -140,6 +140,59 @@ class OciAnalyzer(BaseAnalyzer):
                 },
             },
             {
+                "slug": "platforms-required",
+                "description": "Image must support a required set of platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["linux/amd64", "linux/arm64"]},
+                "condition": {
+                    "contains_all": [
+                        {"var": "results.oci.platforms_supported"},
+                        {"var": "criterion.params.platforms"},
+                    ]
+                },
+                "messages": {
+                    "pass": "Image supports all required platforms.",  # nosec B105
+                    "fail": "Image is missing required platforms (supported: ${results.oci.platforms_supported}; required: ${criterion.params.platforms}).",
+                },
+            },
+            {
+                "slug": "platforms-whitelist",
+                "description": "Image must only support allowed platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["linux/amd64", "linux/arm64"]},
+                "condition": {
+                    "subset": [
+                        {"var": "results.oci.platforms_supported"},
+                        {"var": "criterion.params.platforms"},
+                    ]
+                },
+                "messages": {
+                    "pass": "All supported platforms are allowed.",  # nosec B105
+                    "fail": "Image supports disallowed platforms: ${results.oci.platforms_supported} (allowed: ${criterion.params.platforms}).",
+                },
+            },
+            {
+                "slug": "platforms-blacklist",
+                "description": "Image must not support forbidden platforms.",
+                "level": "warning",
+                "tags": ["compatibility"],
+                "params": {"platforms": ["windows/amd64"]},
+                "condition": {
+                    "!": {
+                        "intersects": [
+                            {"var": "results.oci.platforms_supported"},
+                            {"var": "criterion.params.platforms"},
+                        ]
+                    }
+                },
+                "messages": {
+                    "pass": "Image supports no forbidden platforms.",  # nosec B105
+                    "fail": "Image supports forbidden platforms: ${results.oci.platforms_supported} (forbidden: ${criterion.params.platforms}).",
+                },
+            },
+            {
                 "slug": "exposed-ports-whitelist",
                 "description": "Image exposes permitted ports.",
                 "level": "warning",

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -275,6 +275,7 @@ class OciAnalyzer(BaseAnalyzer):
             "repository": repository,
             "tag": tag,
             "platforms": platforms,
+            "platforms_supported": _platforms_supported(platforms),
             "tags": tags,
         }
 

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -31,7 +31,7 @@ def _platforms_supported(platforms: list[dict[str, Any]]) -> list[str]:
     Skips entries whose ``os`` or ``architecture`` is missing or ``"unknown"``.
     Deduplicates while preserving first-seen order.
     """
-    seen: list[str] = []
+    names: list[str] = []
     for platform in platforms:
         os_name = platform.get("os")
         arch = platform.get("architecture")
@@ -41,9 +41,8 @@ def _platforms_supported(platforms: list[dict[str, Any]]) -> list[str]:
         variant = platform.get("variant")
         if variant:
             name = f"{name}/{variant}"
-        if name not in seen:
-            seen.append(name)
-    return seen
+        names.append(name)
+    return list(dict.fromkeys(names))
 
 
 class OciAnalyzer(BaseAnalyzer):

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -141,6 +141,7 @@ class OciAnalyzer(BaseAnalyzer):
             },
             {
                 "slug": "platforms-required",
+                "enable": False,
                 "description": "Image must support a required set of platforms.",
                 "level": "warning",
                 "tags": ["compatibility"],
@@ -158,6 +159,7 @@ class OciAnalyzer(BaseAnalyzer):
             },
             {
                 "slug": "platforms-whitelist",
+                "enable": False,
                 "description": "Image must only support allowed platforms.",
                 "level": "warning",
                 "tags": ["compatibility"],
@@ -175,6 +177,7 @@ class OciAnalyzer(BaseAnalyzer):
             },
             {
                 "slug": "platforms-blacklist",
+                "enable": False,
                 "description": "Image must not support forbidden platforms.",
                 "level": "warning",
                 "tags": ["compatibility"],

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -25,6 +25,27 @@ def _norm(registry: str) -> str:
     return "docker.io" if registry == "registry-1.docker.io" else registry
 
 
+def _platforms_supported(platforms: list[dict[str, Any]]) -> list[str]:
+    """Project platform objects into canonical ``os/arch[/variant]`` strings.
+
+    Skips entries whose ``os`` or ``architecture`` is missing or ``"unknown"``.
+    Deduplicates while preserving first-seen order.
+    """
+    seen: list[str] = []
+    for platform in platforms:
+        os_name = platform.get("os")
+        arch = platform.get("architecture")
+        if not os_name or not arch or os_name == "unknown" or arch == "unknown":
+            continue
+        name = f"{os_name}/{arch}"
+        variant = platform.get("variant")
+        if variant:
+            name = f"{name}/{variant}"
+        if name not in seen:
+            seen.append(name)
+    return seen
+
+
 class OciAnalyzer(BaseAnalyzer):
     """Fetch OCI metadata for an image using regctl: per-platform details and tags."""
 

--- a/regis/rules/evaluator.py
+++ b/regis/rules/evaluator.py
@@ -213,9 +213,9 @@ def merge_rules(
                     processed_custom.append(rule_def)
 
         # Case B: Standard override or new rule
-            # Note: a slug-only override here does NOT activate an opt-in
-            # criterion (one shipped with `enable: False`); only a `criterion:`
-            # binding (Case A) auto-enables. Use `criterion:` to bind + activate.
+        # Note: a slug-only override here does NOT activate an opt-in
+        # criterion (one shipped with `enable: False`); only a `criterion:`
+        # binding (Case A) auto-enables. Use `criterion:` to bind + activate.
         else:
             rule_id = (
                 rule_def.get("criterion")

--- a/regis/rules/evaluator.py
+++ b/regis/rules/evaluator.py
@@ -213,6 +213,9 @@ def merge_rules(
                     processed_custom.append(rule_def)
 
         # Case B: Standard override or new rule
+            # Note: a slug-only override here does NOT activate an opt-in
+            # criterion (one shipped with `enable: False`); only a `criterion:`
+            # binding (Case A) auto-enables. Use `criterion:` to bind + activate.
         else:
             rule_id = (
                 rule_def.get("criterion")

--- a/regis/rules/evaluator.py
+++ b/regis/rules/evaluator.py
@@ -184,6 +184,11 @@ def merge_rules(
                         slug = f"{template_name}.{len(processed_custom)}"
 
                 instance["slug"] = slug
+                # Binding a criterion template in a playbook activates it by
+                # default; criteria shipped with `enable: False` (opt-in) become
+                # active when referenced. An explicit `enable: false` in the rule
+                # definition still wins via the overrides applied below.
+                instance["enable"] = True
                 # Merge overrides from the custom rule definition itself
                 overrides = {
                     k: v

--- a/regis/schemas/analyzer/oci.schema.json
+++ b/regis/schemas/analyzer/oci.schema.json
@@ -76,6 +76,11 @@
         }
       }
     },
+    "platforms_supported": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Deduplicated canonical platform identifiers (os/arch[/variant]) supported by the image."
+    },
     "tags": {
       "type": "array",
       "items": { "type": "string" },

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -269,3 +269,7 @@ def test_platforms_supported_skips_unknown_and_missing():
         {"os": "linux", "architecture": "amd64"},
     ]
     assert _platforms_supported(platforms) == ["linux/amd64"]
+
+
+def test_platforms_supported_empty():
+    assert _platforms_supported([]) == []

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -305,7 +305,9 @@ def _oci_report(supported: list[str]) -> dict[str, Any]:
     }
 
 
-def _eval_oci_criterion(supported: list[str], criterion: str, platforms: list[str]) -> dict[str, Any]:
+def _eval_oci_criterion(
+    supported: list[str], criterion: str, platforms: list[str]
+) -> dict[str, Any]:
     rules_def = {
         "rules": [
             {

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -392,6 +392,8 @@ def test_platform_criteria_are_opt_in_by_default():
     assert "platforms-whitelist" not in slugs
     assert "platforms-blacklist" not in slugs
     # Sanity: an always-active OCI criterion (platforms-count) is still present.
+    # (It evaluates as "incomplete" here since _oci_report omits results.oci.platforms,
+    # but incomplete rules still appear in res["rules"], so presence is what we assert.)
     assert "platforms-count" in slugs
 
 

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -273,3 +273,22 @@ def test_platforms_supported_skips_unknown_and_missing():
 
 def test_platforms_supported_empty():
     assert _platforms_supported([]) == []
+
+
+def test_oci_report_includes_platforms_supported():
+    with patch("regis.analyzers.oci.run_regctl", side_effect=_multiarch_dispatcher):
+        analyzer = OciAnalyzer()
+        report = analyzer.analyze(_client(), "library/alpine", "3.20.10")
+
+    # New field is present and schema-valid.
+    analyzer.validate(report)
+    assert "platforms_supported" in report
+    supported = report["platforms_supported"]
+    assert isinstance(supported, list)
+    assert all(isinstance(name, str) for name in supported)
+    # Multi-arch index resolves at least amd64 and arm64 linux platforms.
+    assert "linux/amd64" in supported
+    # arm64 entry in the fixture carries variant "v8", so expect the full form.
+    assert any(name.startswith("linux/arm64") for name in supported)
+    # No "unknown" platforms leak into the projection.
+    assert all("unknown" not in name for name in supported)

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import jsonschema
 
-from regis.analyzers.oci import OciAnalyzer
+from regis.analyzers.oci import OciAnalyzer, _platforms_supported
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "regctl"
 
@@ -241,3 +241,31 @@ def test_oci_docker_hub_registry_normalized_in_tag_ls():
     assert tag_calls, "expected a tag ls call"
     # registry-1.docker.io must be normalized to docker.io.
     assert tag_calls[0][2] == "docker.io/library/nginx"
+
+
+def test_platforms_supported_dedup_and_order():
+    platforms = [
+        {"os": "linux", "architecture": "amd64"},
+        {"os": "linux", "architecture": "arm64"},
+        {"os": "linux", "architecture": "amd64"},  # duplicate
+    ]
+    assert _platforms_supported(platforms) == ["linux/amd64", "linux/arm64"]
+
+
+def test_platforms_supported_includes_variant():
+    platforms = [
+        {"os": "linux", "architecture": "arm64", "variant": "v8"},
+        {"os": "linux", "architecture": "arm", "variant": "v7"},
+    ]
+    assert _platforms_supported(platforms) == ["linux/arm64/v8", "linux/arm/v7"]
+
+
+def test_platforms_supported_skips_unknown_and_missing():
+    platforms = [
+        {"os": "unknown", "architecture": "unknown"},
+        {"os": "linux", "architecture": "unknown"},
+        {"os": "linux"},  # missing architecture
+        {"architecture": "amd64"},  # missing os
+        {"os": "linux", "architecture": "amd64"},
+    ]
+    assert _platforms_supported(platforms) == ["linux/amd64"]

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from importlib import resources
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import jsonschema
@@ -297,14 +298,14 @@ def test_oci_report_includes_platforms_supported():
     assert len(supported) == 8
 
 
-def _oci_report(supported: list[str]) -> dict:
+def _oci_report(supported: list[str]) -> dict[str, Any]:
     return {
         "request": {"registry": "docker.io", "analyzers": ["oci"]},
         "results": {"oci": {"platforms_supported": supported}},
     }
 
 
-def _eval_oci_criterion(supported: list[str], criterion: str, platforms: list[str]):
+def _eval_oci_criterion(supported: list[str], criterion: str, platforms: list[str]) -> dict[str, Any]:
     rules_def = {
         "rules": [
             {

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -380,3 +380,32 @@ def test_platforms_required_fails_when_none_supported():
     # Empty projection cannot satisfy a required platform -> fail.
     failed = _eval_oci_criterion([], "platforms-required", ["linux/amd64"])
     assert failed["passed"] is False
+
+
+def test_platform_criteria_are_opt_in_by_default():
+    # With no playbook rules binding them, the three platform-identity criteria
+    # must NOT be evaluated (they ship with enable: False).
+    report = _oci_report(["linux/amd64"])
+    res = evaluate_rules(report)  # no rules_def -> only default-active rules run
+    slugs = {r["slug"] for r in res["rules"]}
+    assert "platforms-required" not in slugs
+    assert "platforms-whitelist" not in slugs
+    assert "platforms-blacklist" not in slugs
+    # Sanity: an always-active OCI criterion (platforms-count) is still present.
+    assert "platforms-count" in slugs
+
+
+def test_platforms_binding_can_be_explicitly_disabled():
+    rules_def = {
+        "rules": [
+            {
+                "provider": "oci",
+                "criterion": "platforms-required",
+                "slug": "under-test",
+                "enable": False,
+                "options": {"platforms": ["linux/amd64"]},
+            }
+        ]
+    }
+    res = evaluate_rules(_oci_report(["linux/amd64"]), rules_def)
+    assert not any(r["slug"] == "under-test" for r in res["rules"])

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -292,3 +292,5 @@ def test_oci_report_includes_platforms_supported():
     assert any(name.startswith("linux/arm64") for name in supported)
     # No "unknown" platforms leak into the projection.
     assert all("unknown" not in name for name in supported)
+    # The fixture resolves exactly 8 real platforms (8 unknown/unknown filtered out).
+    assert len(supported) == 8

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import jsonschema
 
 from regis.analyzers.oci import OciAnalyzer, _platforms_supported
+from regis.rules.evaluator import evaluate_rules
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "regctl"
 
@@ -294,3 +295,85 @@ def test_oci_report_includes_platforms_supported():
     assert all("unknown" not in name for name in supported)
     # The fixture resolves exactly 8 real platforms (8 unknown/unknown filtered out).
     assert len(supported) == 8
+
+
+def _oci_report(supported: list[str]) -> dict:
+    return {
+        "request": {"registry": "docker.io", "analyzers": ["oci"]},
+        "results": {"oci": {"platforms_supported": supported}},
+    }
+
+
+def _eval_oci_criterion(supported: list[str], criterion: str, platforms: list[str]):
+    rules_def = {
+        "rules": [
+            {
+                "provider": "oci",
+                "criterion": criterion,
+                "slug": "under-test",
+                "options": {"platforms": platforms},
+            }
+        ]
+    }
+    res = evaluate_rules(_oci_report(supported), rules_def)
+    return next(r for r in res["rules"] if r["slug"] == "under-test")
+
+
+def test_platforms_required_pass_and_fail():
+    # All required platforms are supported (extras allowed) -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64", "windows/amd64"],
+        "platforms-required",
+        ["linux/amd64", "linux/arm64"],
+    )
+    assert passed["passed"] is True
+
+    # A required platform is missing -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64"],
+        "platforms-required",
+        ["linux/amd64", "linux/arm64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_whitelist_pass_and_fail():
+    # Every supported platform is allowed -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-whitelist",
+        ["linux/amd64", "linux/arm64", "windows/amd64"],
+    )
+    assert passed["passed"] is True
+
+    # A supported platform is not in the allowed set -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-whitelist",
+        ["linux/amd64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_blacklist_pass_and_fail():
+    # No forbidden platform is supported -> pass.
+    passed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-blacklist",
+        ["windows/amd64"],
+    )
+    assert passed["passed"] is True
+
+    # A forbidden platform is supported -> fail.
+    failed = _eval_oci_criterion(
+        ["linux/amd64", "linux/arm64"],
+        "platforms-blacklist",
+        ["linux/arm64"],
+    )
+    assert failed["passed"] is False
+
+
+def test_platforms_required_fails_when_none_supported():
+    # Empty projection cannot satisfy a required platform -> fail.
+    failed = _eval_oci_criterion([], "platforms-required", ["linux/amd64"])
+    assert failed["passed"] is False


### PR DESCRIPTION
## Summary

Adds three opt-in OCI policy rules that check **which platforms** an image supports (the existing `platforms-count` only counted them):

- **`platforms-required`** — image must support *at least* the listed platforms (e.g. require `linux/amd64` **and** `linux/arm64`).
- **`platforms-whitelist`** — image must support *only* platforms from an allowed set.
- **`platforms-blacklist`** — image must support *none* of a forbidden set.

Platforms are matched as canonical `os/arch[/variant]` strings (e.g. `linux/arm64/v8`), exposed on the OCI report as a new `results.oci.platforms_supported` list. Each rule takes a single `platforms` parameter.

These three rules are **disabled by default** (their policy defaults would otherwise warn on common single-arch and broad multi-arch images). Enable one by binding its criterion in your playbook — binding a criterion via `criterion:` now activates it automatically:

```yaml
rules:
  - provider: oci
    criterion: platforms-whitelist
    options:
      platforms: [linux/amd64, linux/arm64]
```

## Implementation notes

- New `results.oci.platforms_supported` projection (deduplicated, order-preserving, skips `unknown`/missing); declared as an optional field in `oci.schema.json`.
- The three criteria reuse existing JSON Logic operators (`contains_all`, `subset`, `!`/`intersects`) — no new operator, no engine semantics change.
- `merge_rules()` now sets `enable: true` on a criterion instantiated from a playbook binding (an explicit `enable: false` in the binding still wins). Slug-only overrides (Case B) do not auto-activate opt-in criteria.
- Reference rule pages regenerated from `default_criteria()`.

## Test Plan

- [x] Full suite green: 543 passed, coverage 92.14% (≥90% gate)
- [x] `ruff check` clean
- [x] Unit tests: projection (multi-arch, variant, unknown filtering, dedup, empty)
- [x] Functional tests via the evaluator: pass/fail for all three rules + empty-projection edge
- [x] Opt-in behavior: rules absent by default; binding activates; explicit `enable: false` still disables

🤖 Generated with [Claude Code](https://claude.com/claude-code)