### PR TITLE
docs(reference): correct default playbook and rules-list documentation

### DIFF
--- a/docs/website/docs/reference/cli.md
+++ b/docs/website/docs/reference/cli.md
@@ -120,7 +120,7 @@ Manage and evaluate rules against reports.
 
 ### `rules list`
 
-List all available default rules provided by analyzers, and optionally merge with overrides.
+List the available criteria catalogue (the reusable criterion templates you can bind from a playbook), and optionally merge with overrides.
 
 ```bash
 regis rules list [OPTIONS]

--- a/docs/website/docs/reference/playbooks/default/index.md
+++ b/docs/website/docs/reference/playbooks/default/index.md
@@ -24,11 +24,12 @@ Rules are evaluated automatically based on which analyzers are present in the re
 
 Failing any critical rule blocks the image from reaching a Gold or Silver tier.
 
-| Slug                        | Provider | Description                                                                          |
-| :-------------------------- | :------- | :----------------------------------------------------------------------------------- |
-| `registry-domain-whitelist` | `core`   | Image must originate from a trusted registry (docker.io, quay.io, ghcr.io, ghcr.io). |
-| `no-root`                   | `oci`    | Image must not be configured to run as the `root` user.                              |
-| `cve-critical`              | `cve`    | No `CRITICAL` CVEs allowed (max: 0).                                                 |
+| Slug                        | Provider  | Description                                                                                       |
+| :-------------------------- | :-------- | :------------------------------------------------------------------------------------------------ |
+| `registry-domain-whitelist` | `core`    | Image must originate from a trusted registry (docker.io, registry-1.docker.io, quay.io, ghcr.io). |
+| `no-root`                   | `oci`     | Image must not be configured to run as the `root` user.                                           |
+| `verified-secrets`          | `secrets` | No verified, active credentials may be embedded in the image.                                     |
+| `cve-critical`              | `cve`     | No `CRITICAL` CVEs allowed (max: 0).                                                              |
 
 ### Warning
 


### PR DESCRIPTION
## Summary

Three small, unrelated documentation-accuracy fixes spotted during review of the "remove implicit default-rule inheritance" work (out of that PR's scope).

- **`verified-secrets` missing from the Critical table** — `docs/website/docs/reference/playbooks/default/index.md`: the rule (provider `secrets`) is declared at the critical level in `regis/playbooks/default/playbook.yaml` (added by the verified/any secret-scan split, #660) but was never documented. Added a row; wording matches the `verified-secrets` criterion in `regis/analyzers/secrets.py` (`verified_count == 0`).
- **Duplicated domain in `registry-domain-whitelist`** — same file: `(docker.io, quay.io, ghcr.io, ghcr.io)` → the real list from `get_criterion_templates` in `regis/rules/evaluator.py`: `docker.io, registry-1.docker.io, quay.io, ghcr.io`.
- **Stale `regis rules list` description** — `docs/website/docs/reference/cli.md`: reworded from "List all available default rules provided by analyzers" to describe the criteria catalogue (reusable criterion templates you can bind from a playbook), matching the catalogue refactor where analyzer criteria are no longer auto-evaluated.

Verified each change against its source of truth. `trunk check` passes (it reflowed the Critical table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)