### PR TITLE
feat(rules)!: first-class metadata.* namespace — helpers, optional namespace, real well-known validation

### DIFF
--- a/docs/superpowers/plans/2026-06-08-meta-rules-ux.md
+++ b/docs/superpowers/plans/2026-06-08-meta-rules-ux.md
@@ -1050,7 +1050,7 @@ it (`request` is `additionalProperties: false`).
   will fail validation if re-validated; regenerate them with `regis analyze`.
 
 There is no automated migration: reports are generated output, not user config.
-````
+```
 
 - [ ] **Step 4: Vérifier le build doc (lien/markdown)**
 

--- a/docs/superpowers/plans/2026-06-08-meta-rules-ux.md
+++ b/docs/superpowers/plans/2026-06-08-meta-rules-ux.md
@@ -1,0 +1,1086 @@
+# UX du `meta` dans les règles — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Faire du `metadata.*` un namespace de première classe pour les règles : helpers JSON Logic ergonomiques, absence de meta testable sans `incomplete`, emplacement report unique documenté, et validation well-known qui fonctionne réellement.
+
+**Architecture:** Cinq changements indépendants puis un volet doc. (1) Des prédicats purs partagés (`regis/utils/predicates.py`) alimentent à la fois de nouveaux opérateurs JSON Logic et le format-checker du schéma. (2) `MissingDataTracker` exempte le namespace `metadata.*` du marquage `incomplete`. (3) Le schéma well-known passe en structure imbriquée (cohérente avec le meta réellement stocké) et `MetadataAnalyzer` est retravaillé en conséquence. (4) Le report cesse de dupliquer le meta : top-level `metadata.*` devient l'unique emplacement (`request.metadata` retiré), `REPORT_SCHEMA_VERSION` 2 → 3.
+
+**Tech Stack:** Python 3.11, `json-logic-qubit`, `jsonschema` (Draft 2020-12), pytest. Spec : `docs/superpowers/specs/2026-06-08-meta-rules-ux-design.md`.
+
+**Référence de commandes :** `pipenv run pytest --no-cov <path>` pour la boucle rapide ; `pipenv run pytest` (couverture ≥ 90 %) avant PR ; `pipenv run ruff format . && pipenv run ruff check .` avant chaque commit.
+
+---
+
+## File Structure
+
+| Fichier                                                  | Rôle                                                                                            | Action                                                 |
+| :------------------------------------------------------- | :---------------------------------------------------------------------------------------------- | :----------------------------------------------------- |
+| `regis/utils/predicates.py`                              | Prédicats purs (truthy/falsy/url/empty/matches), sans dépendance json_logic                     | **Créer**                                              |
+| `regis/rules/evaluator.py`                               | Enregistre les prédicats comme opérateurs JSON Logic                                            | Modifier (`_add_custom_operations`)                    |
+| `regis/playbook/context.py`                              | `MissingDataTracker` : exemption namespace `metadata.*`                                         | Modifier                                               |
+| `regis/schemas/meta/well-known.schema.json`              | Schéma meta well-known                                                                          | Réécrire (imbriqué)                                    |
+| `regis/analyzers/metadata.py`                            | Validation meta : schéma imbriqué + format `uri` réel + `metadata_validation` par chemin pointé | Réécrire `analyze()` + helpers                         |
+| `regis/schemas/report/report.schema.json`                | Enveloppe report                                                                                | Modifier (retrait `request.metadata`)                  |
+| `regis/commands/analyze.py`                              | Producteur report                                                                               | Modifier (2 sites : ne plus écrire `request.metadata`) |
+| `regis/utils/report.py`                                  | `REPORT_SCHEMA_VERSION`                                                                         | Modifier (2 → 3)                                       |
+| `tests/fixtures/report.v3.json`                          | Fixture contrat v3                                                                              | **Créer**                                              |
+| `tests/test_predicates.py`                               | Tests unitaires prédicats purs                                                                  | **Créer**                                              |
+| `tests/test_rules_evaluator.py`                          | Opérateurs via json_logic + exemption namespace + e2e                                           | Modifier (ajouts)                                      |
+| `tests/test_analyzer_metadata.py`                        | Validation imbriquée + format uri                                                               | Réécrire                                               |
+| `tests/test_report_schema_version.py`                    | Bump version + rejet `request.metadata` + fixture v3                                            | Modifier                                               |
+| `tests/test_gh_env.py`                                   | Assert `request.metadata` absent                                                                | Modifier (1 assert)                                    |
+| `docs/website/docs/concepts/rules.md`                    | Section « Référencer le meta » + table opérateurs                                               | Modifier                                               |
+| `docs/website/docs/upgrade/report-metadata-namespace.md` | Note de migration                                                                               | **Créer**                                              |
+
+> Les `.md` de référence de schéma (`docs/website/docs/reference/schemas/meta/...`) et les copies `docs/website/static/schemas/...` sont **régénérés en CI** (`cd-docs.yml`, `generate-schema-doc` + `cp -rv regis/schemas/*`). Ne pas les éditer à la main : seule la source `regis/schemas/...` est modifiée.
+
+---
+
+## Task 1 : Prédicats purs partagés
+
+Fonctions pures, sans json_logic, réutilisées par les opérateurs (Task 2) et le format-checker meta (Task 4).
+
+**Files:**
+
+- Create: `regis/utils/predicates.py`
+- Test: `tests/test_predicates.py`
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Créer `tests/test_predicates.py` :
+
+```python
+"""Tests for shared rule/meta predicate helpers."""
+
+import pytest
+
+from regis.utils.predicates import is_empty, is_falsy, is_truthy, is_url, matches
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "On", " true "])
+def test_is_truthy_true(value):
+    assert is_truthy(value) is True
+
+
+def test_is_truthy_bool():
+    assert is_truthy(True) is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "maybe", "", None, 1, 0])
+def test_is_truthy_false(value):
+    assert is_truthy(value) is False
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "Off", " false "])
+def test_is_falsy_true(value):
+    assert is_falsy(value) is True
+
+
+def test_is_falsy_bool():
+    assert is_falsy(False) is True
+
+
+@pytest.mark.parametrize("value", ["true", "1", "maybe", "", None, 0])
+def test_is_falsy_false(value):
+    assert is_falsy(value) is False
+
+
+@pytest.mark.parametrize(
+    "value", ["http://x.io", "https://github.com/org/repo/actions/runs/1"]
+)
+def test_is_url_true(value):
+    assert is_url(value) is True
+
+
+@pytest.mark.parametrize(
+    "value", ["not a url", "ftp://x.io", "github.com", "", None, 123, "https://"]
+)
+def test_is_url_false(value):
+    assert is_url(value) is False
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_is_empty_true(value):
+    assert is_empty(value) is True
+
+
+@pytest.mark.parametrize("value", ["x", "0", 0, False])
+def test_is_empty_false(value):
+    assert is_empty(value) is False
+
+
+def test_matches_hit():
+    assert matches("job-42", r"^job-[0-9]+$") is True
+
+
+def test_matches_miss():
+    assert matches("job-x", r"^job-[0-9]+$") is False
+
+
+def test_matches_invalid_regex_is_false():
+    assert matches("anything", r"[unclosed") is False
+
+
+@pytest.mark.parametrize("value", [None, 123])
+def test_matches_non_string_is_false(value):
+    assert matches(value, r".*") is False
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `pipenv run pytest --no-cov tests/test_predicates.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'regis.utils.predicates'`.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Créer `regis/utils/predicates.py` :
+
+```python
+"""Pure predicate helpers shared by rule operators and meta validation.
+
+These functions are intentionally free of any ``json_logic`` dependency so they
+can be reused by :mod:`regis.analyzers.metadata` (format checking) and unit-tested
+in isolation. They follow a defensive style: unexpected input types yield a falsy
+result rather than raising.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"true", "1", "yes", "on"}
+_FALSY = {"false", "0", "no", "off"}
+
+
+def is_truthy(value: Any) -> bool:
+    """True for boolean ``True`` or a truthy string (true/1/yes/on, case-insensitive)."""
+    if value is True:
+        return True
+    return isinstance(value, str) and value.strip().lower() in _TRUTHY
+
+
+def is_falsy(value: Any) -> bool:
+    """True for boolean ``False`` or a falsy string (false/0/no/off, case-insensitive).
+
+    Not the strict complement of :func:`is_truthy`: a junk string ("maybe") is
+    neither truthy nor falsy.
+    """
+    if value is False:
+        return True
+    return isinstance(value, str) and value.strip().lower() in _FALSY
+
+
+def is_url(value: Any) -> bool:
+    """True if ``value`` is a well-formed http/https URL (scheme + netloc)."""
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = urlparse(value)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def is_empty(value: Any) -> bool:
+    """True if ``value`` is None, an empty string, or whitespace-only."""
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+def matches(value: Any, pattern: Any) -> bool:
+    """True if ``value`` (a string) matches the regular expression ``pattern``.
+
+    Non-string input or an invalid regex yields ``False`` (a warning is logged for
+    the latter).
+    """
+    if not isinstance(value, str) or not isinstance(pattern, str):
+        return False
+    try:
+        return bool(re.search(pattern, value))
+    except re.error:
+        logger.warning("matches: invalid regex pattern %r", pattern)
+        return False
+```
+
+- [ ] **Step 4: Lancer pour vérifier le succès**
+
+Run: `pipenv run pytest --no-cov tests/test_predicates.py -q`
+Expected: PASS (tous les cas).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+pipenv run ruff format regis/utils/predicates.py tests/test_predicates.py
+pipenv run ruff check regis/utils/predicates.py tests/test_predicates.py
+git add regis/utils/predicates.py tests/test_predicates.py
+git commit -m "feat(rules): shared pure predicate helpers (truthy/falsy/url/empty/matches)"
+```
+
+---
+
+## Task 2 : Opérateurs JSON Logic
+
+Enregistrer les prédicats comme opérateurs, à côté de `intersects`/`env_contains`.
+
+**Files:**
+
+- Modify: `regis/rules/evaluator.py` (imports en tête + `_add_custom_operations`, ~ligne 285)
+- Test: `tests/test_rules_evaluator.py` (ajouts)
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Ajouter à la fin de `tests/test_rules_evaluator.py` :
+
+```python
+def test_helper_operators_registered():
+    """The new helper operators evaluate through json_logic."""
+    import regis.rules.evaluator  # noqa: F401  (registers operators on import)
+    from json_logic import jsonLogic
+
+    assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "yes"}) is True
+    assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "nope"}) is False
+    assert jsonLogic({"is_false": [{"var": "v"}]}, {"v": "off"}) is True
+    assert jsonLogic({"is_url": [{"var": "v"}]}, {"v": "https://x.io"}) is True
+    assert jsonLogic({"is_url": [{"var": "v"}]}, {"v": "x.io"}) is False
+    assert jsonLogic({"is_empty": [{"var": "v"}]}, {"v": ""}) is True
+    assert jsonLogic({"is_set": [{"var": "v"}]}, {"v": "x"}) is True
+    assert jsonLogic({"matches": [{"var": "v"}, "^job-[0-9]+$"]}, {"v": "job-7"}) is True
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `pipenv run pytest --no-cov tests/test_rules_evaluator.py::test_helper_operators_registered -q`
+Expected: FAIL — `Unrecognized operation is_true` (ou KeyError équivalent).
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Dans `regis/rules/evaluator.py`, ajouter l'import en tête (sous `from regis.playbook.context import ...`) :
+
+```python
+from regis.utils.predicates import is_empty, is_falsy, is_truthy, is_url, matches
+```
+
+Puis, à la fin de `_add_custom_operations()` (juste avant la fin de la fonction, après le bloc `env_contains`), ajouter :
+
+```python
+    # Meta/string helpers — meta values arrive as strings, so these make rule
+    # conditions over `metadata.*` ergonomic. All are defensive (falsy on
+    # unexpected input). See regis/utils/predicates.py.
+    json_logic.add_operation("is_true", is_truthy)
+    json_logic.add_operation("is_false", is_falsy)
+    json_logic.add_operation("is_url", is_url)
+    json_logic.add_operation("is_empty", is_empty)
+    json_logic.add_operation("is_set", lambda a: not is_empty(a))
+    json_logic.add_operation("matches", matches)
+```
+
+- [ ] **Step 4: Lancer pour vérifier le succès**
+
+Run: `pipenv run pytest --no-cov tests/test_rules_evaluator.py -q`
+Expected: PASS (le nouveau test + les existants).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+pipenv run ruff format regis/rules/evaluator.py tests/test_rules_evaluator.py
+pipenv run ruff check regis/rules/evaluator.py tests/test_rules_evaluator.py
+git add regis/rules/evaluator.py tests/test_rules_evaluator.py
+git commit -m "feat(rules): register is_true/is_false/is_url/is_empty/is_set/matches operators"
+```
+
+---
+
+## Task 3 : Namespace `metadata.*` optionnel (fix `incomplete`)
+
+Une clé manquante sous `metadata.*` ne doit plus marquer la règle `incomplete` (le meta est fourni par l'utilisateur, son absence est un état testable). Les accès `results.*` manquants restent `incomplete`.
+
+**Files:**
+
+- Modify: `regis/playbook/context.py` (`MissingDataTracker.__getitem__` et `__contains__`)
+- Test: `tests/test_rules_evaluator.py` (ajouts)
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Ajouter à la fin de `tests/test_rules_evaluator.py` :
+
+```python
+def test_missing_metadata_does_not_mark_incomplete():
+    """A rule referencing an absent metadata.* key resolves to a clean fail/pass."""
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["metadata"]},
+        "results": {},
+        "metadata": {},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "gate-must-be-set",
+                "condition": {"is_set": [{"var": "metadata.gate.enabled"}]},
+                "messages": {"pass": "set", "fail": "not set"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "gate-must-be-set")
+    assert rule["status"] == "failed"  # absent -> failed, NOT incomplete
+    assert rule["passed"] is False
+
+
+def test_present_metadata_evaluates_normally():
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["metadata"]},
+        "results": {},
+        "metadata": {"ci": {"job": {"url": "https://ci.example/run/1"}}},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "job-url-valid",
+                "condition": {"is_url": [{"var": "metadata.ci.job.url"}]},
+                "messages": {"pass": "ok", "fail": "bad"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "job-url-valid")
+    assert rule["status"] == "passed"
+
+
+def test_missing_results_still_incomplete():
+    """Non-metadata missing data must still yield incomplete (no regression)."""
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["cve"]},
+        "results": {},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "needs-cve",
+                "condition": {"==": [{"var": "results.cve.critical_count"}, 0]},
+                "messages": {"pass": "ok", "fail": "bad"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "needs-cve")
+    assert rule["status"] == "incomplete"
+```
+
+- [ ] **Step 2: Lancer pour vérifier l'échec**
+
+Run: `pipenv run pytest --no-cov tests/test_rules_evaluator.py::test_missing_metadata_does_not_mark_incomplete tests/test_rules_evaluator.py::test_present_metadata_evaluates_normally tests/test_rules_evaluator.py::test_missing_results_still_incomplete -q`
+Expected: `test_missing_metadata_does_not_mark_incomplete` FAIL (status == "incomplete"). Les deux autres peuvent déjà passer.
+
+- [ ] **Step 3: Écrire l'implémentation**
+
+Dans `regis/playbook/context.py`, ajouter un helper module-level (juste avant `class MissingDataTracker`) :
+
+```python
+def _is_optional_namespace(full_key: str) -> bool:
+    """Keys under the user-supplied ``metadata`` namespace are optional.
+
+    Their absence is a legitimate, testable state (via is_set/is_empty), not a
+    "an analyzer did not run" condition, so it must not mark a rule incomplete.
+    """
+    return full_key == "metadata" or full_key.startswith("metadata.")
+```
+
+Dans `MissingDataTracker.__getitem__`, remplacer les deux affectations `self.root.missing_accessed = True` par une garde. Le corps devient :
+
+```python
+    def __getitem__(self, key: str) -> Any:
+        full_key = f"{self.path}.{key}" if self.path else key
+        self.accessed_keys.add(full_key)
+        try:
+            val = super().__getitem__(key)
+        except KeyError:
+            if not _is_optional_namespace(full_key):
+                self.root.missing_accessed = True
+            raise
+
+        if val is None:
+            if not _is_optional_namespace(full_key):
+                self.root.missing_accessed = True
+            return None
+
+        if isinstance(val, dict):
+            return MissingDataTracker(val, full_key, self.root)
+        return val
+```
+
+Et dans `__contains__`, garder l'affectation de la même manière :
+
+```python
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str):
+            full_key = f"{self.path}.{key}" if self.path else key
+            self.accessed_keys.add(full_key)
+        if not super().__contains__(key):
+            if not (isinstance(key, str) and _is_optional_namespace(
+                f"{self.path}.{key}" if self.path else key
+            )):
+                self.root.missing_accessed = True
+            return False
+        return True
+```
+
+- [ ] **Step 4: Lancer pour vérifier le succès**
+
+Run: `pipenv run pytest --no-cov tests/test_rules_evaluator.py tests/test_playbook_engine.py -q`
+Expected: PASS (nouveaux tests + non-régression du moteur playbook).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+pipenv run ruff format regis/playbook/context.py tests/test_rules_evaluator.py
+pipenv run ruff check regis/playbook/context.py tests/test_rules_evaluator.py
+git add regis/playbook/context.py tests/test_rules_evaluator.py
+git commit -m "fix(rules): exempt metadata.* namespace from incomplete-tracking"
+```
+
+---
+
+## Task 4 : Schéma well-known imbriqué + `MetadataAnalyzer`
+
+Le meta est stocké imbriqué (`{ci:{job:{url}}}`) ; le schéma doit l'être aussi pour que `enum`/`uri` s'appliquent vraiment. Le format `uri` est rendu déterministe via un `FormatChecker` local réutilisant `is_url`. La sortie `metadata_validation` est indexée par chemin pointé.
+
+**Files:**
+
+- Modify (rewrite): `regis/schemas/meta/well-known.schema.json`
+- Modify (rewrite `analyze()` + helpers): `regis/analyzers/metadata.py`
+- Test (rewrite): `tests/test_analyzer_metadata.py`
+
+- [ ] **Step 1: Réécrire les tests (qui échouent)**
+
+Remplacer **tout** le contenu de `tests/test_analyzer_metadata.py` par :
+
+```python
+"""Tests for MetadataAnalyzer (nested well-known schema + format checking)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from regis.analyzers.metadata import MetadataAnalyzer
+
+
+class TestMetadataAnalyzerWellKnownOnly:
+    """Tests without a playbook meta_schema_path. Meta is nested, as in production."""
+
+    def test_empty_metadata_valid(self):
+        analyzer = MetadataAnalyzer(metadata={})
+        result = analyzer.analyze()
+        assert result["analyzer"] == "metadata"
+        assert result["valid"] is True
+        # Every known leaf field is reported valid when absent (optional).
+        for v in result["metadata_validation"].values():
+            assert v == {"valid": True}
+        # Known leaf paths are dotted.
+        assert "ci.platform" in result["metadata_validation"]
+        assert "ci.job.url" in result["metadata_validation"]
+
+    def test_valid_well_known_field(self):
+        analyzer = MetadataAnalyzer(metadata={"ci": {"platform": "github"}})
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata"]["ci"]["platform"] == "github"
+        assert result["metadata_validation"]["ci.platform"] == {"valid": True}
+
+    def test_invalid_well_known_enum_value(self):
+        analyzer = MetadataAnalyzer(metadata={"ci": {"platform": "bitbucket"}})
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["ci.platform"]["valid"] is False
+        assert "error" in result["metadata_validation"]["ci.platform"]
+
+    def test_valid_well_known_uri(self):
+        analyzer = MetadataAnalyzer(
+            metadata={"ci": {"job": {"url": "https://ci.example/run/9"}}}
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata_validation"]["ci.job.url"] == {"valid": True}
+
+    def test_invalid_well_known_uri(self):
+        analyzer = MetadataAnalyzer(metadata={"ci": {"job": {"url": "not a url"}}})
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["ci.job.url"]["valid"] is False
+
+    def test_unknown_keys_passthrough_not_in_validation(self):
+        analyzer = MetadataAnalyzer(
+            metadata={"custom": {"key": "value"}, "ci": {"platform": "github"}}
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata"]["custom"]["key"] == "value"
+        assert "custom.key" not in result["metadata_validation"]
+        assert "ci.platform" in result["metadata_validation"]
+
+    def test_analyze_ignores_positional_args(self):
+        analyzer = MetadataAnalyzer(metadata={"ci": {"job": {"id": "123"}}})
+        client = MagicMock()
+        result = analyzer.analyze(client, "repo/name", "latest", "linux/amd64")
+        assert result["valid"] is True
+        assert result["metadata"]["ci"]["job"]["id"] == "123"
+
+    def test_validate_is_noop(self):
+        analyzer = MetadataAnalyzer(metadata={})
+        analyzer.validate({})  # should not raise
+
+
+class TestMetadataAnalyzerWithPlaybookSchema:
+    """Tests with a custom playbook meta_schema_path (merged via allOf)."""
+
+    def _write_schema(self, tmp_path: Path, schema: dict) -> Path:
+        p = tmp_path / "meta.schema.json"
+        p.write_text(json.dumps(schema))
+        return p
+
+    def test_required_field_present(self, tmp_path):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["PROJECT_ID"],
+            "properties": {"PROJECT_ID": {"type": "string"}},
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(
+            metadata={"PROJECT_ID": "PROJ-42"}, meta_schema_path=schema_path
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata"]["PROJECT_ID"] == "PROJ-42"
+        assert result["metadata_validation"]["PROJECT_ID"] == {"valid": True}
+
+    def test_required_field_missing(self, tmp_path):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["PROJECT_ID"],
+            "properties": {"PROJECT_ID": {"type": "string"}},
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(metadata={}, meta_schema_path=schema_path)
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["PROJECT_ID"]["valid"] is False
+        assert "error" in result["metadata_validation"]["PROJECT_ID"]
+
+    def test_required_field_wrong_type(self, tmp_path):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["PROJECT_ID"],
+            "properties": {"PROJECT_ID": {"type": "string"}},
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(
+            metadata={"PROJECT_ID": 42}, meta_schema_path=schema_path
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["PROJECT_ID"]["valid"] is False
+
+    def test_optional_field_absent(self, tmp_path):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"OPTIONAL_FIELD": {"type": "string"}},
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(metadata={}, meta_schema_path=schema_path)
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert "OPTIONAL_FIELD" not in result["metadata"]
+        assert result["metadata_validation"]["OPTIONAL_FIELD"] == {"valid": True}
+
+    def test_nonexistent_schema_path_falls_back_to_well_known(self, tmp_path):
+        nonexistent = tmp_path / "does_not_exist.json"
+        analyzer = MetadataAnalyzer(
+            metadata={"ci": {"platform": "github"}}, meta_schema_path=nonexistent
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+
+    def test_combined_well_known_and_playbook_fields(self, tmp_path):
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["PROJECT_ID"],
+            "properties": {"PROJECT_ID": {"type": "string"}},
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(
+            metadata={"PROJECT_ID": "PROJ-1", "ci": {"platform": "gitlab"}},
+            meta_schema_path=schema_path,
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata_validation"]["PROJECT_ID"] == {"valid": True}
+        assert result["metadata_validation"]["ci.platform"] == {"valid": True}
+
+    def test_none_metadata_defaults_to_empty(self):
+        analyzer = MetadataAnalyzer(metadata=None)
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata"] == {}
+```
+
+- [ ] **Step 2: Réécrire le schéma well-known**
+
+Remplacer **tout** le contenu de `regis/schemas/meta/well-known.schema.json` par :
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://regis/schemas/meta/well-known.schema.json",
+  "title": "Regis Well-Known Metadata",
+  "description": "Standard metadata fields recognized by regis across all playbooks.",
+  "type": "object",
+  "properties": {
+    "ci": {
+      "type": "object",
+      "description": "Continuous-integration context for the analysis run.",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": ["github", "gitlab"],
+          "description": "CI platform running the analysis"
+        },
+        "job": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique identifier of the CI job"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to the CI job run"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}
+```
+
+- [ ] **Step 3: Lancer pour vérifier l'échec**
+
+Run: `pipenv run pytest --no-cov tests/test_analyzer_metadata.py -q`
+Expected: FAIL — les cas `test_valid_well_known_field` / `test_invalid_well_known_enum_value` / `*_uri` échouent (l'`analyze()` actuel suppose des propriétés plates et n'active pas le format checker).
+
+- [ ] **Step 4: Réécrire `MetadataAnalyzer`**
+
+Dans `regis/analyzers/metadata.py`, remplacer les imports en tête et la méthode `analyze()` + les helpers internes. Garder `__init__`, `validate`, `_build_combined_schema`, `_load_well_known_schema` inchangés sauf indication. Imports en tête (après `import jsonschema`) :
+
+```python
+from regis.utils.predicates import is_url
+```
+
+Ajouter, au niveau module (après `logger = logging.getLogger(__name__)`) :
+
+```python
+# A local format checker so `format: uri` is enforced deterministically
+# (jsonschema's default does nothing for "uri" without an optional dependency).
+_FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+@_FORMAT_CHECKER.checks("uri")
+def _check_uri(value: object) -> bool:
+    # Format checks run only on string instances; non-strings are caught by `type`.
+    return is_url(value) if isinstance(value, str) else True
+
+
+def _collect_leaf_paths(schema: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    """Recursively collect dotted leaf paths from a schema's ``properties``.
+
+    A leaf is any property that is not an object-with-properties. Returns a mapping
+    of ``dotted.path -> subschema`` (subschema currently unused but kept for clarity).
+    """
+    paths: dict[str, Any] = {}
+    for name, sub in schema.get("properties", {}).items():
+        path = f"{prefix}.{name}" if prefix else name
+        if isinstance(sub, dict) and sub.get("type") == "object" and "properties" in sub:
+            paths.update(_collect_leaf_paths(sub, path))
+        else:
+            paths[path] = sub
+    return paths
+```
+
+Remplacer le corps de `analyze()` (de la ligne `combined_schema = self._build_combined_schema()` jusqu'au `return {...}` final) par :
+
+```python
+        combined_schema = self._build_combined_schema()
+
+        # Known leaf fields (dotted) across the well-known + playbook schemas.
+        leaf_paths: dict[str, Any] = {}
+        for sub in combined_schema.get("allOf", []):
+            leaf_paths.update(_collect_leaf_paths(sub))
+
+        validator = jsonschema.Draft202012Validator(
+            combined_schema, format_checker=_FORMAT_CHECKER
+        )
+        errors = list(validator.iter_errors(self._metadata))
+
+        # metadata_validation: one entry per known leaf path, valid by default.
+        metadata_validation: dict[str, Any] = {
+            path: {"valid": True} for path in leaf_paths
+        }
+        for error in errors:
+            if error.validator == "required":
+                base = list(error.absolute_path)
+                for missing in error.validator_value:
+                    dotted = ".".join([*map(str, base), str(missing)])
+                    metadata_validation[dotted] = {
+                        "valid": False,
+                        "error": error.message,
+                    }
+            else:
+                dotted = ".".join(str(p) for p in error.absolute_path)
+                if dotted:
+                    metadata_validation[dotted] = {
+                        "valid": False,
+                        "error": error.message,
+                    }
+
+        return {
+            "analyzer": self.name,
+            "metadata": dict(self._metadata),
+            "metadata_validation": metadata_validation,
+            "valid": not errors,
+        }
+```
+
+> Note de contrat : `metadata` reflète désormais le dict meta utilisateur **tel quel** (imbriqué), sans synthèse de `null` pour les champs absents (cette synthèse était incohérente avec la structure imbriquée). `metadata_validation` reste `{chemin: {"valid": bool, "error"?: str}}`, indexé par chemin pointé.
+
+- [ ] **Step 5: Lancer pour vérifier le succès**
+
+Run: `pipenv run pytest --no-cov tests/test_analyzer_metadata.py -q`
+Expected: PASS (tous les cas, enum **et** uri réellement rejetés).
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+pipenv run ruff format regis/analyzers/metadata.py tests/test_analyzer_metadata.py
+pipenv run ruff check regis/analyzers/metadata.py tests/test_analyzer_metadata.py
+git add regis/analyzers/metadata.py regis/schemas/meta/well-known.schema.json tests/test_analyzer_metadata.py
+git commit -m "fix(metadata): nested well-known schema with real enum/uri enforcement"
+```
+
+---
+
+## Task 5 : Normalisation report (rupture, `request.metadata` retiré)
+
+Emplacement unique `metadata.*` ; `request.metadata` supprimé du schéma et du producteur ; `REPORT_SCHEMA_VERSION` 2 → 3 ; fixture contrat v3.
+
+**Files:**
+
+- Modify: `regis/schemas/report/report.schema.json` (retrait `request.properties.metadata`, description top-level `metadata`)
+- Modify: `regis/commands/analyze.py` (2 sites)
+- Modify: `regis/utils/report.py` (`REPORT_SCHEMA_VERSION = 3`)
+- Create: `tests/fixtures/report.v3.json`
+- Modify: `tests/test_report_schema_version.py`
+- Modify: `tests/test_gh_env.py` (1 assert)
+
+- [ ] **Step 1: Écrire/мettre à jour les tests qui échouent**
+
+Dans `tests/test_report_schema_version.py` :
+
+(a) Remplacer `test_constant_is_two` par :
+
+```python
+    def test_constant_is_three(self):
+        from regis.utils.report import REPORT_SCHEMA_VERSION
+
+        assert REPORT_SCHEMA_VERSION == 3
+```
+
+(b) Ajouter à la classe `TestReportSchemaVersion` :
+
+```python
+    def test_rejects_request_metadata(self):
+        """request.metadata was removed; request has additionalProperties:false."""
+        report = _minimal_report()
+        report["request"]["metadata"] = {"ci": {"platform": "github"}}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=report, schema=_report_schema())
+
+    def test_accepts_top_level_metadata(self):
+        report = _minimal_report(metadata={"ci": {"platform": "github"}})
+        jsonschema.validate(instance=report, schema=_report_schema())
+```
+
+(c) Dans `TestContractFixture`, repointer les deux méthodes sur `report.v3.json` et l'assertion de version :
+
+```python
+    def test_fixture_validates_against_real_validator(self):
+        import json
+        from pathlib import Path
+
+        from regis.utils.report import validate_report
+
+        fixture = Path(__file__).parent / "fixtures" / "report.v3.json"
+        report = json.loads(fixture.read_text(encoding="utf-8"))
+
+        assert report["schemaVersion"] == 3
+        validate_report(report)  # must not raise
+
+    def test_analyzer_blobs_match_their_schemas(self):
+        import json
+        from pathlib import Path
+
+        import jsonschema
+
+        fixtures = Path(__file__).parent / "fixtures" / "report.v3.json"
+        report = json.loads(fixtures.read_text(encoding="utf-8"))
+
+        schema_dir = importlib.resources.files("regis.schemas.analyzer")
+        for slug in ("cve", "oci"):
+            schema = json.loads(
+                schema_dir.joinpath(f"{slug}.schema.json").read_text(encoding="utf-8")
+            )
+            jsonschema.validate(instance=report["results"][slug], schema=schema)
+```
+
+Dans `tests/test_gh_env.py`, ajouter après l'assert `report["metadata"]["ci"]["job_id"] == "999"` (≈ ligne 83) :
+
+```python
+            # Canonical location only: request.metadata was removed.
+            assert "metadata" not in report["request"]
+```
+
+- [ ] **Step 2: Créer la fixture v3**
+
+```bash
+cp tests/fixtures/report.v2.json tests/fixtures/report.v3.json
+```
+
+Puis, dans `tests/fixtures/report.v3.json`, passer `"schemaVersion": 2` → `"schemaVersion": 3` et ajouter une clé top-level `"metadata"` (canonique) juste après la ligne `schemaVersion`. Vérifier qu'aucune clé `metadata` n'existe sous `request` (la copie de v2 n'en a pas). Le bloc d'en-tête doit ressembler à :
+
+```json
+{
+  "schemaVersion": 3,
+  "metadata": { "ci": { "platform": "github" } },
+```
+
+(le reste du fichier — `version`, `request`, `results`, blobs `cve`/`oci` — est conservé tel quel depuis v2).
+
+- [ ] **Step 3: Lancer pour vérifier l'échec**
+
+Run: `pipenv run pytest --no-cov tests/test_report_schema_version.py tests/test_gh_env.py -q`
+Expected: FAIL — `test_constant_is_three` (constante = 2), `test_rejects_request_metadata` (schéma accepte encore), `test_gh_env` (écrit encore `request.metadata`).
+
+- [ ] **Step 4: Implémenter les changements producteur + schéma**
+
+Dans `regis/utils/report.py` ligne 17 :
+
+```python
+REPORT_SCHEMA_VERSION = 3
+```
+
+Dans `regis/schemas/report/report.schema.json` :
+
+- Préciser la description du top-level `metadata` (≈ ligne 56-59) :
+
+```json
+    "metadata": {
+      "type": "object",
+      "description": "Arbitrary user-provided metadata (from --meta). Optional namespace exposed to rules as metadata.*.",
+      "additionalProperties": true
+    },
+```
+
+- Supprimer entièrement la propriété `metadata` du bloc `request.properties` (≈ lignes 123-127), de sorte que la dernière propriété de `request` reste `timestamp` et que `"additionalProperties": false` rejette désormais `request.metadata`.
+
+Dans `regis/commands/analyze.py`, supprimer les deux écritures de `request.metadata` :
+
+- Flux rerun (≈ ligne 371), supprimer la ligne :
+
+```python
+            existing_report.setdefault("request", {})["metadata"] = metadata_dict
+```
+
+- Flux normal (≈ ligne 593), supprimer la ligne :
+
+```python
+            analysis_report["request"]["metadata"] = metadata_dict
+```
+
+- [ ] **Step 5: Lancer pour vérifier le succès**
+
+Run: `pipenv run pytest --no-cov tests/test_report_schema_version.py tests/test_gh_env.py tests/test_analyze_rerun.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+pipenv run ruff format regis/commands/analyze.py regis/utils/report.py tests/test_report_schema_version.py tests/test_gh_env.py
+pipenv run ruff check regis/commands/analyze.py regis/utils/report.py tests/test_report_schema_version.py tests/test_gh_env.py
+git add regis/commands/analyze.py regis/utils/report.py regis/schemas/report/report.schema.json tests/fixtures/report.v3.json tests/test_report_schema_version.py tests/test_gh_env.py
+git commit -m "feat(schema)!: single canonical metadata.* location, bump report schema 2->3"
+```
+
+---
+
+## Task 6 : Documentation
+
+Documenter le namespace `metadata.*`, le comportement optionnel, les champs well-known, les helpers ; note de migration.
+
+**Files:**
+
+- Modify: `docs/website/docs/concepts/rules.md`
+- Create: `docs/website/docs/upgrade/report-metadata-namespace.md`
+
+- [ ] **Step 1: Étendre la table des opérateurs**
+
+Dans `docs/website/docs/concepts/rules.md`, dans la table « Regis adds several custom operators » (≈ ligne 233), ajouter ces lignes sous `env_contains` :
+
+```markdown
+| `is_true` | `true` if the value is a truthy string (`true`/`1`/`yes`/`on`, case-insensitive) or boolean `true`. |
+| `is_false` | `true` if the value is a falsy string (`false`/`0`/`no`/`off`) or boolean `false`. |
+| `is_url` | `true` if the value is a well-formed `http`/`https` URL. |
+| `is_empty` | `true` if the value is null, empty, or whitespace-only. |
+| `is_set` | `true` if the value is present and non-empty (complement of `is_empty`). |
+| `matches` | `true` if the string value matches a regular expression: `{"matches": [{"var": "..."}, "^pattern$"]}`. |
+```
+
+- [ ] **Step 2: Ajouter la section « Référencer le meta dans les règles »**
+
+Dans `docs/website/docs/concepts/rules.md`, juste avant `## Rule evaluation mechanics` (≈ ligne 222), insérer :
+
+## Référencer le meta dans les règles
+
+Les valeurs passées via `regis analyze --meta <clé>=<valeur>` sont exposées aux
+règles sous le namespace **`metadata.*`** (chemin canonique). La notation pointée
+de la clé devient une structure imbriquée :
+
+```bash
+regis analyze nginx:latest \
+  --meta ci.platform=github \
+  --meta ci.job.url=https://github.com/org/repo/actions/runs/42
+```
+
+s'adresse en règle par `{"var": "metadata.ci.platform"}` et
+`{"var": "metadata.ci.job.url"}`.
+
+### Namespace optionnel
+
+Le meta est fourni par l'utilisateur : une clé `metadata.*` absente résout à
+`null` **sans** marquer la règle `incomplete` (contrairement à un `results.*`
+manquant, qui signifie « un analyzer n'a pas tourné »). On peut donc tester la
+présence d'un meta de façon fiable :
+
+```yaml
+spec:
+  rules:
+    - slug: ci-job-url-required
+      description: A CI job URL must be provided and well-formed.
+      level: warning
+      tags: [provenance]
+      condition:
+        and:
+          - { "is_set": [{ "var": "metadata.ci.job.url" }] }
+          - { "is_url": [{ "var": "metadata.ci.job.url" }] }
+      messages:
+        pass: "CI job URL is present and valid."
+        fail: "Provide a valid --meta ci.job.url."
+```
+
+Comme toutes les valeurs `--meta` sont des chaînes, les helpers `is_true` /
+`is_false` interprètent les drapeaux booléens :
+
+```yaml
+condition: { "is_true": [{ "var": "metadata.gate.enabled" }] }
+```
+
+### Champs well-known
+
+Regis reconnaît ces champs standard (validés contre
+`schemas/meta/well-known.schema.json`) ; tout autre champ est accepté tel quel :
+
+| Champ                  | Type         | Notes                  |
+| :--------------------- | :----------- | :--------------------- |
+| `metadata.ci.platform` | enum         | `github` ou `gitlab`.  |
+| `metadata.ci.job.id`   | string       | Identifiant du job CI. |
+| `metadata.ci.job.url`  | string (uri) | URL du run CI.         |
+
+- [ ] **Step 3: Créer la note de migration**
+
+Créer `docs/website/docs/upgrade/report-metadata-namespace.md` :
+
+```markdown
+---
+title: Report metadata namespace (schemaVersion 3)
+---
+
+# Report metadata namespace — `schemaVersion` 3
+
+Starting with report `schemaVersion: 3`, user metadata (`--meta`) lives at a
+**single canonical location**: the top-level `metadata` object. The duplicate
+`request.metadata` field has been **removed**, and the report schema now rejects
+it (`request` is `additionalProperties: false`).
+
+## What changed
+
+- `report.metadata.*` is the only place user metadata is written.
+- Rules reference it as `{"var": "metadata.<key>"}` (e.g. `metadata.ci.job.url`).
+- `request.metadata` is gone.
+
+## Action required
+
+- **Rule authors:** use `metadata.*` paths. Any rule that referenced
+  `request.metadata.*` must switch to `metadata.*`.
+- **Downstream consumers** (dashboards, plugins) reading `request.metadata` must
+  read top-level `metadata` instead, and gate on `schemaVersion >= 3`.
+- **Stored reports** produced before this change that contain `request.metadata`
+  will fail validation if re-validated; regenerate them with `regis analyze`.
+
+There is no automated migration: reports are generated output, not user config.
+````
+
+- [ ] **Step 4: Vérifier le build doc (lien/markdown)**
+
+Run: `pipenv run pytest --no-cov tests/test_rules_evaluator.py tests/test_analyzer_metadata.py -q`
+Expected: PASS (garde-fou : la doc n'introduit pas de régression ; pas de build Docusaurus requis localement).
+
+> Le `_category_.json` de `upgrade/` liste-t-il explicitement les pages ? Vérifier `docs/website/docs/upgrade/_category_.json` : s'il fixe un ordre via `position`, aucun ajout par page n'est nécessaire (tri par défaut). Ne pas modifier sauf si un index manuel y référence chaque page.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/website/docs/concepts/rules.md docs/website/docs/upgrade/report-metadata-namespace.md
+git commit -m "docs(rules): document metadata.* namespace, helpers, and schema-3 migration"
+```
+
+---
+
+## Self-Review (effectuée)
+
+**Couverture spec :**
+
+- §1 Normalisation namespace → Task 5. ✅
+- §2 Helpers JSON Logic → Tasks 1 + 2. ✅
+- §3 Namespace `metadata.*` optionnel → Task 3. ✅
+- §4 Schéma well-known corrigé + metadata.py → Task 4. ✅
+- §5 Documentation → Task 6 (+ note upgrade). ✅
+- §6 Tests TDD → intégrés à chaque task. ✅
+
+**Cohérence des types/noms :** prédicats purs `is_truthy`/`is_falsy`/`is_url`/`is_empty`/`matches` (Task 1) ; opérateurs `is_true`/`is_false`/`is_url`/`is_empty`/`is_set`/`matches` (Task 2) ; `_is_optional_namespace` (Task 3) ; `_collect_leaf_paths`/`_FORMAT_CHECKER` (Task 4) ; `REPORT_SCHEMA_VERSION = 3` cohérent entre `report.py`, tests, fixture v3.
+
+**Hors périmètre confirmé :** `is_semver`, `to_number`, migration outillée des reports existants.
+
+**Coordination :** la rupture report (`feat(schema)!`, Task 5) est à séquencer avec la file « presentation generalization » ; le bump 2 → 3 doit être le bump report en vigueur au merge (vérifier qu'aucune autre PR en file ne vise aussi 2 → 3 pour éviter un double bump). La couverture globale doit rester ≥ 90 % (`pipenv run pytest`).

--- a/docs/superpowers/specs/2026-06-08-meta-rules-ux-design.md
+++ b/docs/superpowers/specs/2026-06-08-meta-rules-ux-design.md
@@ -1,0 +1,205 @@
+# Spec — UX du `meta` dans les règles
+
+- **Date** : 2026-06-08
+- **Statut** : validé (brainstorming) — prêt pour plan d'exécution
+- **Type** : feature transverse (rupture report) + helpers + doc
+- **Scope** : `regis/rules/evaluator.py`, `regis/playbook/context.py`,
+  `regis/analyzers/metadata.py`, `regis/commands/analyze.py`,
+  `regis/schemas/meta/well-known.schema.json`,
+  `regis/schemas/report/report.schema.json`, `regis/utils/report.py`,
+  doc `docs/website/docs/concepts/rules.md` (+ référence, upgrade).
+
+## Problème
+
+Écrire une règle qui consomme une valeur `--meta` est aujourd'hui pénible et
+mal outillé :
+
+1. **Chemin incohérent et non documenté.** `regis analyze --meta k=v` écrit le
+   même dict à **deux** endroits du rapport : top-level `metadata.*` **et**
+   `request.metadata.*` (cf. `analyze.py` flux normal et flux `--rerun`). Aucune
+   page de doc ne montre comment référencer une valeur meta dans une condition
+   JSON Logic.
+2. **Valeurs toujours chaînes.** `_parse_meta` produit des chaînes (une clé sans
+   `=` vaut `"true"`). Tester un drapeau booléen impose
+   `{"==": [{"var": "..."}, "true"]}` ; valider une URL est impossible sans
+   opérateur dédié.
+3. **`incomplete` parasite.** `MissingDataTracker` marque une règle `incomplete`
+   dès qu'une condition accède à une clé manquante. Tester l'absence d'un meta
+   (le cas d'usage de `is_set`/`is_empty`) rend donc la règle `incomplete` au
+   lieu de produire un pass/fail propre. Or `incomplete` signifie « un analyzer
+   n'a pas tourné », pas « l'utilisateur n'a pas passé ce meta ».
+4. **Schéma well-known inerte.** `--meta ci.job.url=x` produit la structure
+   imbriquée `{ci: {job: {url: x}}}`, mais `well-known.schema.json` déclare des
+   propriétés à **clés plates pointées** (`"ci.job.url"`) qui ne matchent jamais
+   cette structure. Conséquence : `enum` sur `ci.platform` et `format: uri` sur
+   `ci.job.url` ne s'appliquent **jamais**.
+
+## Objectif
+
+Faire du `metadata.*` un namespace de première classe pour les règles :
+chemin unique documenté, helpers ergonomiques pour les valeurs-chaînes, absence
+testable sans `incomplete`, et validation well-known qui fonctionne réellement.
+
+## Décisions (issues du brainstorming)
+
+| Sujet | Décision |
+|:--|:--|
+| Namespace meta | **Normaliser à la source** : un seul emplacement, top-level `metadata.*`. |
+| Emplacement canonique | **Top-level `metadata.*`** ; `request.metadata` supprimé. |
+| Helpers retenus | `is_true` / `is_false`, `is_url`, `is_empty` / `is_set`, `matches`. |
+| Helpers écartés | `is_semver`, `to_number` (YAGNI). |
+| Absence de meta | `metadata.*` est un **namespace optionnel** : clé manquante → `null` sans `incomplete`. |
+| Schéma well-known | **Corrigé dans ce lot** (structure imbriquée, enum/format réellement appliqués). |
+
+## Design
+
+### 1. Normalisation du namespace (rupture report)
+
+- `analyze.py` cesse d'écrire `request["metadata"]` (flux normal **et** flux
+  `--rerun`). Seul `report["metadata"]` est peuplé.
+- `report.schema.json` : suppression de `request.properties.metadata` ; le
+  top-level `metadata` est conservé et sa description précisée (« métadonnées
+  utilisateur arbitraires, namespace optionnel exposé aux règles sous
+  `metadata.*` »).
+- `REPORT_SCHEMA_VERSION` **2 → 3** (`regis/utils/report.py`). Mise à jour de la
+  fixture contrat `tests/fixtures/report.v1.json` et de tout test asséné sur la
+  version.
+- **Coordination** : rupture d'enveloppe report à séquencer avec la file
+  « presentation generalization » (consommateurs aval : regis-gitlab,
+  regis-backstage, regis-action). Une note `upgrade/` documente le retrait de
+  `request.metadata`.
+- Chemin canonique en règle : `{"var": "metadata.ci.job.url"}`.
+
+### 2. Helpers JSON Logic
+
+Enregistrés dans `_add_custom_operations()` (`regis/rules/evaluator.py`), au
+même titre que `intersects` / `env_contains`. Génériques (s'appliquent à
+n'importe quel `var`), mais pensés pour les valeurs-chaînes du meta.
+
+| Opérateur | Arité | Sémantique |
+|:--|:--|:--|
+| `is_true` | `[x]` | `True` si `x` ∈ {`true`,`1`,`yes`,`on`} (casse ignorée) ou booléen `True`. Sinon `False`. |
+| `is_false` | `[x]` | `True` si `x` ∈ {`false`,`0`,`no`,`off`} (casse ignorée) ou booléen `False`. Sinon `False`. |
+| `is_url` | `[x]` | `True` si `x` est une URL `http`/`https` bien formée (`urllib.parse`, `scheme` ∈ {http,https} **et** `netloc` non vide). |
+| `is_empty` | `[x]` | `True` si `x` est `None`, `""`, ou chaîne de blancs. |
+| `is_set` | `[x]` | Complément de `is_empty` : `True` si `x` présent et non vide. |
+| `matches` | `[x, pattern]` | `re.search(pattern, x)` truthy. `x` non-string ou regex invalide → `False` (warning loggué). |
+
+Règles transverses :
+
+- `is_true` et `is_false` ne sont **pas** stricts complémentaires : une valeur
+  parasite (`"maybe"`) n'est ni l'un ni l'autre. Intentionnel.
+- Entrée non-string / `None` → `False` partout, sauf `is_empty` (→ `True` sur
+  `None`/`""`) et `is_set` (→ `False`).
+- Style défensif aligné sur les opérateurs existants (jamais d'exception qui
+  remonte ; valeurs inattendues → résultat falsy).
+
+### 3. Namespace `metadata.*` optionnel (fix `incomplete`)
+
+- `MissingDataTracker` (`regis/playbook/context.py`) : un accès manquant ou
+  `None` dont le **chemin complet** appartient au namespace `metadata` (égal à
+  `metadata` ou commençant par `metadata.`) **n'arme plus** `missing_accessed`.
+- La clé reste enregistrée dans `accessed_keys` (l'attribution d'analyzers et le
+  reporting de couverture sont inchangés).
+- Doit être épinglé par TDD pour les **deux** chemins de résolution employés par
+  le moteur : clé aplatie (`metadata.ci.job.url` présente à plat dans le
+  contexte aplati) **et** traversée imbriquée segment par segment.
+- Sémantique : le meta est fourni par l'utilisateur ; son absence est un état
+  testable (`is_set`/`is_empty`), pas un « analyzer absent ».
+
+### 4. Schéma well-known corrigé
+
+- `well-known.schema.json` réécrit en **structure imbriquée** :
+
+  ```json
+  {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://regis/schemas/meta/well-known.schema.json",
+    "title": "Regis Well-Known Metadata",
+    "description": "Standard metadata fields recognized by regis across all playbooks.",
+    "type": "object",
+    "properties": {
+      "ci": {
+        "type": "object",
+        "properties": {
+          "platform": {
+            "type": "string",
+            "enum": ["github", "gitlab"],
+            "description": "CI platform running the analysis"
+          },
+          "job": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "description": "Unique identifier of the CI job" },
+              "url": { "type": "string", "format": "uri", "description": "URL to the CI job run" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "additionalProperties": true
+  }
+  ```
+
+- `metadata.py` : la construction de `metadata_validation` et le mapping
+  d'erreurs jsonschema supposent aujourd'hui des **propriétés plates top-level**
+  (itération sur `schema_properties`, `error.path[0]`). Retravaillé pour les
+  chemins imbriqués : `metadata_validation` reste indexé par **clé pointée**
+  (ex. `"ci.job.url"`) en aplatissant le chemin d'erreur jsonschema
+  (`".".join(map(str, error.path))`), et la collecte des propriétés du schéma
+  parcourt récursivement les `properties` imbriquées. Le contrat de sortie
+  (`{field: {"valid": bool, "error"?: str}}`) est préservé.
+- L'extension de bundle `meta.schema.json` (fusionnée en `allOf`) suit la même
+  forme imbriquée ; la doc d'extension est mise à jour en conséquence.
+
+### 5. Documentation
+
+- `docs/website/docs/concepts/rules.md` : nouvelle section **« Référencer le
+  meta dans les règles »** —
+  - chemin canonique `metadata.*` ;
+  - comportement namespace optionnel (absent → `null`, jamais `incomplete`) ;
+  - table des champs well-known (`ci.platform`, `ci.job.id`, `ci.job.url`) ;
+  - exemples concrets avec helpers, dont « `metadata.ci.job.url` doit être une
+    URL valide lorsqu'il est fourni » et un drapeau `is_true`.
+- Table des opérateurs personnalisés étendue avec les 6 nouvelles lignes.
+- Référence schéma well-known régénérée (`reference/schemas/meta/...`).
+- Aide `--meta` / `configuration.md` ajustées si nécessaire.
+- Note `docs/website/docs/upgrade/` pour le retrait de `request.metadata` et le
+  bump `REPORT_SCHEMA_VERSION 2 → 3`.
+
+### 6. Tests (TDD)
+
+- Unitaires par helper : `is_true`/`is_false` (toutes formes + parasites +
+  non-string), `is_url` (http/https valides, schéma absent, netloc vide,
+  non-string), `is_empty`/`is_set` (None/""/blancs/valeur), `matches` (match,
+  non-match, regex invalide, non-string).
+- Exemption tracker `metadata.*` : règle référençant un meta absent → `failed`
+  ou `passed` selon la condition, **jamais** `incomplete` ; un accès `results.*`
+  manquant reste `incomplete` (non-régression).
+- Validation well-known imbriquée : `ci.platform` hors enum → erreur ;
+  `ci.job.url` non-uri → erreur ; cas valides → `valid: true`. (Garde anti-
+  régression : la version plate antérieure laissait tout passer.)
+- Mapping d'erreurs `metadata.py` : `metadata_validation` indexé par clé pointée.
+- End-to-end : `evaluate_rules` sur un rapport portant `metadata.*`, règles
+  utilisant les helpers → statuts et messages attendus.
+- Rupture report : `analyze` n'écrit plus `request.metadata` ; `metadata`
+  top-level présent ; `schemaVersion == 3` ; fixture mise à jour.
+
+## Hors périmètre
+
+- `is_semver`, `to_number` (YAGNI).
+- Migration outillée des rapports existants (sortie générée, pas de la config
+  utilisateur ; les consommateurs aval s'adaptent via la version de schéma).
+- Refonte du flux `--rerun metadata` au-delà du retrait de `request.metadata`.
+
+## Risques / coordination
+
+- **Rupture d'enveloppe report** : à séquencer avec la file « presentation
+  generalization » pour éviter deux bumps non coordonnés vus des consommateurs
+  aval.
+- **Réécriture well-known + `metadata.py`** : le mapping d'erreurs est le point
+  le plus délicat ; couverture TDD avant refactor.
+- **Exemption tracker** : doit couvrir les deux chemins de résolution `var`,
+  sinon `is_set`/`is_empty` restent piégés par `incomplete`.

--- a/docs/superpowers/specs/2026-06-08-meta-rules-ux-design.md
+++ b/docs/superpowers/specs/2026-06-08-meta-rules-ux-design.md
@@ -42,14 +42,14 @@ testable sans `incomplete`, et validation well-known qui fonctionne réellement.
 
 ## Décisions (issues du brainstorming)
 
-| Sujet | Décision |
-|:--|:--|
-| Namespace meta | **Normaliser à la source** : un seul emplacement, top-level `metadata.*`. |
-| Emplacement canonique | **Top-level `metadata.*`** ; `request.metadata` supprimé. |
-| Helpers retenus | `is_true` / `is_false`, `is_url`, `is_empty` / `is_set`, `matches`. |
-| Helpers écartés | `is_semver`, `to_number` (YAGNI). |
-| Absence de meta | `metadata.*` est un **namespace optionnel** : clé manquante → `null` sans `incomplete`. |
-| Schéma well-known | **Corrigé dans ce lot** (structure imbriquée, enum/format réellement appliqués). |
+| Sujet                 | Décision                                                                                |
+| :-------------------- | :-------------------------------------------------------------------------------------- |
+| Namespace meta        | **Normaliser à la source** : un seul emplacement, top-level `metadata.*`.               |
+| Emplacement canonique | **Top-level `metadata.*`** ; `request.metadata` supprimé.                               |
+| Helpers retenus       | `is_true` / `is_false`, `is_url`, `is_empty` / `is_set`, `matches`.                     |
+| Helpers écartés       | `is_semver`, `to_number` (YAGNI).                                                       |
+| Absence de meta       | `metadata.*` est un **namespace optionnel** : clé manquante → `null` sans `incomplete`. |
+| Schéma well-known     | **Corrigé dans ce lot** (structure imbriquée, enum/format réellement appliqués).        |
 
 ## Design
 
@@ -76,14 +76,14 @@ Enregistrés dans `_add_custom_operations()` (`regis/rules/evaluator.py`), au
 même titre que `intersects` / `env_contains`. Génériques (s'appliquent à
 n'importe quel `var`), mais pensés pour les valeurs-chaînes du meta.
 
-| Opérateur | Arité | Sémantique |
-|:--|:--|:--|
-| `is_true` | `[x]` | `True` si `x` ∈ {`true`,`1`,`yes`,`on`} (casse ignorée) ou booléen `True`. Sinon `False`. |
-| `is_false` | `[x]` | `True` si `x` ∈ {`false`,`0`,`no`,`off`} (casse ignorée) ou booléen `False`. Sinon `False`. |
-| `is_url` | `[x]` | `True` si `x` est une URL `http`/`https` bien formée (`urllib.parse`, `scheme` ∈ {http,https} **et** `netloc` non vide). |
-| `is_empty` | `[x]` | `True` si `x` est `None`, `""`, ou chaîne de blancs. |
-| `is_set` | `[x]` | Complément de `is_empty` : `True` si `x` présent et non vide. |
-| `matches` | `[x, pattern]` | `re.search(pattern, x)` truthy. `x` non-string ou regex invalide → `False` (warning loggué). |
+| Opérateur  | Arité          | Sémantique                                                                                                               |
+| :--------- | :------------- | :----------------------------------------------------------------------------------------------------------------------- |
+| `is_true`  | `[x]`          | `True` si `x` ∈ {`true`,`1`,`yes`,`on`} (casse ignorée) ou booléen `True`. Sinon `False`.                                |
+| `is_false` | `[x]`          | `True` si `x` ∈ {`false`,`0`,`no`,`off`} (casse ignorée) ou booléen `False`. Sinon `False`.                              |
+| `is_url`   | `[x]`          | `True` si `x` est une URL `http`/`https` bien formée (`urllib.parse`, `scheme` ∈ {http,https} **et** `netloc` non vide). |
+| `is_empty` | `[x]`          | `True` si `x` est `None`, `""`, ou chaîne de blancs.                                                                     |
+| `is_set`   | `[x]`          | Complément de `is_empty` : `True` si `x` présent et non vide.                                                            |
+| `matches`  | `[x, pattern]` | `re.search(pattern, x)` truthy. `x` non-string ou regex invalide → `False` (warning loggué).                             |
 
 Règles transverses :
 
@@ -130,8 +130,15 @@ Règles transverses :
           "job": {
             "type": "object",
             "properties": {
-              "id": { "type": "string", "description": "Unique identifier of the CI job" },
-              "url": { "type": "string", "format": "uri", "description": "URL to the CI job run" }
+              "id": {
+                "type": "string",
+                "description": "Unique identifier of the CI job"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "URL to the CI job run"
+              }
             },
             "additionalProperties": true
           }

--- a/docs/website/docs/concepts/playbooks.md
+++ b/docs/website/docs/concepts/playbooks.md
@@ -341,7 +341,7 @@ regis analyze myimage:latest \
   -m ci.platform=github
 ```
 
-Metadata is stored in the report under `metadata` and `request.metadata`, making it accessible in all rule conditions, badges, and template expressions.
+Metadata is stored in the report under the top-level `metadata` namespace, making it accessible in all rule conditions, badges, and template expressions (for example `{"var": "metadata.ci.platform"}`).
 
 ### Deferred metadata (--rerun)
 

--- a/docs/website/docs/concepts/rules.md
+++ b/docs/website/docs/concepts/rules.md
@@ -219,6 +219,62 @@ spec:
         fail: "Missing 'my-company.owner' label."
 ```
 
+## Référencer le meta dans les règles
+
+Les valeurs passées via `regis analyze --meta <clé>=<valeur>` sont exposées aux
+règles sous le namespace **`metadata.*`** (chemin canonique). La notation pointée
+de la clé devient une structure imbriquée :
+
+```bash
+regis analyze nginx:latest \
+  --meta ci.platform=github \
+  --meta ci.job.url=https://github.com/org/repo/actions/runs/42
+```
+
+s'adresse en règle par `{"var": "metadata.ci.platform"}` et
+`{"var": "metadata.ci.job.url"}`.
+
+### Namespace optionnel
+
+Le meta est fourni par l'utilisateur : une clé `metadata.*` absente résout à
+`null` **sans** marquer la règle `incomplete` (contrairement à un `results.*`
+manquant, qui signifie « un analyzer n'a pas tourné »). On peut donc tester la
+présence d'un meta de façon fiable :
+
+```yaml
+spec:
+  rules:
+    - slug: ci-job-url-required
+      description: A CI job URL must be provided and well-formed.
+      level: warning
+      tags: [provenance]
+      condition:
+        and:
+          - { "is_set": [{ "var": "metadata.ci.job.url" }] }
+          - { "is_url": [{ "var": "metadata.ci.job.url" }] }
+      messages:
+        pass: "CI job URL is present and valid."
+        fail: "Provide a valid --meta ci.job.url."
+```
+
+Comme toutes les valeurs `--meta` sont des chaînes, les helpers `is_true` /
+`is_false` interprètent les drapeaux booléens :
+
+```yaml
+condition: { "is_true": [{ "var": "metadata.gate.enabled" }] }
+```
+
+### Champs well-known
+
+Regis reconnaît ces champs standard (validés contre
+`schemas/meta/well-known.schema.json`) ; tout autre champ est accepté tel quel :
+
+| Champ                  | Type         | Notes                  |
+| :--------------------- | :----------- | :--------------------- |
+| `metadata.ci.platform` | enum         | `github` ou `gitlab`.  |
+| `metadata.ci.job.id`   | string       | Identifiant du job CI. |
+| `metadata.ci.job.url`  | string (uri) | URL du run CI.         |
+
 ## Rule evaluation mechanics
 
 ### JSON Logic conditions
@@ -230,14 +286,20 @@ evaluation context exposes the full, flattened analysis report. Analyzer
 
 Regis adds several custom operators on top of the standard set:
 
-| Operator       | Description                                                      |
-| :------------- | :--------------------------------------------------------------- |
-| `intersects`   | `true` if any element of list _a_ is present in list _b_.        |
-| `contains_all` | `true` if all elements of list _b_ are present in list _a_.      |
-| `subset`       | `true` if all elements of list _a_ are also in list _b_.         |
-| `keys`         | Returns the keys of a dictionary.                                |
-| `get`          | Gets a value from a dictionary by a computed key.                |
-| `env_contains` | `true` if any string in _b_ is a substring of any string in _a_. |
+| Operator       | Description                                                                                         |
+| :------------- | :-------------------------------------------------------------------------------------------------- |
+| `intersects`   | `true` if any element of list _a_ is present in list _b_.                                           |
+| `contains_all` | `true` if all elements of list _b_ are present in list _a_.                                         |
+| `subset`       | `true` if all elements of list _a_ are also in list _b_.                                            |
+| `keys`         | Returns the keys of a dictionary.                                                                   |
+| `get`          | Gets a value from a dictionary by a computed key.                                                   |
+| `env_contains` | `true` if any string in _b_ is a substring of any string in _a_.                                    |
+| `is_true`      | `true` if the value is a truthy string (`true`/`1`/`yes`/`on`, case-insensitive) or boolean `true`. |
+| `is_false`     | `true` if the value is a falsy string (`false`/`0`/`no`/`off`) or boolean `false`.                  |
+| `is_url`       | `true` if the value is a well-formed `http`/`https` URL.                                            |
+| `is_empty`     | `true` if the value is null, empty, or whitespace-only.                                             |
+| `is_set`       | `true` if the value is present and non-empty (complement of `is_empty`).                            |
+| `matches`      | `true` if the string value matches a regex: `{"matches": [{"var": "..."}, "^pattern$"]}`.           |
 
 The bound criterion's options are accessible under `criterion.params.*` (for
 example, `{"var": "criterion.params.max_count"}`).

--- a/docs/website/docs/upgrade/report-metadata-namespace.md
+++ b/docs/website/docs/upgrade/report-metadata-namespace.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 5
+---
+
+# Report metadata namespace — `schemaVersion` 3
+
+Starting with report `schemaVersion: 3`, user metadata (`--meta`) lives at a
+**single canonical location**: the top-level `metadata` object. The duplicate
+`request.metadata` field has been **removed**, and the report schema now rejects
+it (`request` is `additionalProperties: false`).
+
+## What changed
+
+- `report.metadata.*` is the only place user metadata is written.
+- Rules reference it as `{"var": "metadata.<key>"}` (e.g. `metadata.ci.job.url`).
+- `request.metadata` is gone.
+
+## Action required
+
+- **Rule authors:** use `metadata.*` paths. Any rule that referenced
+  `request.metadata.*` must switch to `metadata.*`.
+- **Downstream consumers** (dashboards, plugins) reading `request.metadata` must
+  read top-level `metadata` instead, and gate on `schemaVersion >= 3`.
+- **Stored reports** produced before this change that contain `request.metadata`
+  will fail validation if re-validated; regenerate them with `regis analyze`.
+
+There is no automated migration: reports are generated output, not user config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,14 @@ ignore_missing_imports = true
 # regis.analyzers.base is included because it imports the stdlib `warnings`
 # module (added for the default_rules deprecation shim), which trips the same
 # cross-ref AssertionError when downstream analyzer modules are linted alone.
+# regis.utils.predicates is included because it is imported by metadata.py and
+# evaluator.py (and reached transitively from analyze.py via the report engine),
+# which triggers the same cross-ref AssertionError when those importers are
+# linted in isolation.
 [[tool.mypy.overrides]]
-module = ["regis.playbook.schema_registry", "regis.analyzers.base"]
+module = [
+  "regis.playbook.schema_registry",
+  "regis.analyzers.base",
+  "regis.utils.predicates",
+]
 follow_imports = "skip"

--- a/regis/analyzers/metadata.py
+++ b/regis/analyzers/metadata.py
@@ -22,7 +22,13 @@ _FORMAT_CHECKER = jsonschema.FormatChecker()
 
 @_FORMAT_CHECKER.checks("uri")
 def _check_uri(value: object) -> bool:
-    # Format checks run only on string instances; non-strings are caught by `type`.
+    """Validate a `format: uri` field.
+
+    Deliberately narrowed to http/https URLs (via :func:`is_url`), which is the
+    intended shape for the well-known `ci.job.url` field. This is stricter than
+    RFC-3986 `uri` (no ftp/urn/mailto). Format checks run only on string
+    instances; non-strings are caught by the schema's `type`.
+    """
     return is_url(value) if isinstance(value, str) else True
 
 
@@ -116,19 +122,26 @@ class MetadataAnalyzer(BaseAnalyzer):
         for error in errors:
             if error.validator == "required":
                 base = list(error.absolute_path)
-                for missing in error.validator_value:
-                    dotted = ".".join([*map(str, base), str(missing)])
+                # Navigate to the object the `required` constraint applies to so we
+                # only flag fields that are genuinely absent (validator_value lists
+                # ALL required fields, including present ones).
+                obj: Any = self._metadata
+                for key in base:
+                    obj = obj.get(key, {}) if isinstance(obj, dict) else {}
+                for field in error.validator_value:
+                    if isinstance(obj, dict) and field in obj:
+                        continue
+                    dotted = ".".join([*map(str, base), str(field)])
                     metadata_validation[dotted] = {
                         "valid": False,
                         "error": error.message,
                     }
             else:
                 dotted = ".".join(str(p) for p in error.absolute_path)
-                if dotted:
-                    metadata_validation[dotted] = {
-                        "valid": False,
-                        "error": error.message,
-                    }
+                metadata_validation[dotted or "_schema"] = {
+                    "valid": False,
+                    "error": error.message,
+                }
 
         return {
             "analyzer": self.name,

--- a/regis/analyzers/metadata.py
+++ b/regis/analyzers/metadata.py
@@ -11,8 +11,39 @@ from typing import Any
 import jsonschema
 
 from regis.analyzers.base import AnalyzerError, BaseAnalyzer
+from regis.utils.predicates import is_url
 
 logger = logging.getLogger(__name__)
+
+# A local format checker so `format: uri` is enforced deterministically
+# (jsonschema's default does nothing for "uri" without an optional dependency).
+_FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+@_FORMAT_CHECKER.checks("uri")
+def _check_uri(value: object) -> bool:
+    # Format checks run only on string instances; non-strings are caught by `type`.
+    return is_url(value) if isinstance(value, str) else True
+
+
+def _collect_leaf_paths(schema: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    """Recursively collect dotted leaf paths from a schema's ``properties``.
+
+    A leaf is any property that is not an object-with-properties. Returns a mapping
+    of ``dotted.path -> subschema`` (subschema currently unused but kept for clarity).
+    """
+    paths: dict[str, Any] = {}
+    for name, sub in schema.get("properties", {}).items():
+        path = f"{prefix}.{name}" if prefix else name
+        if (
+            isinstance(sub, dict)
+            and sub.get("type") == "object"
+            and "properties" in sub
+        ):
+            paths.update(_collect_leaf_paths(sub, path))
+        else:
+            paths[path] = sub
+    return paths
 
 
 class MetadataAnalyzer(BaseAnalyzer):
@@ -67,67 +98,43 @@ class MetadataAnalyzer(BaseAnalyzer):
             and ``valid``.
         """
         combined_schema = self._build_combined_schema()
-        schema_properties: dict[str, Any] = {}
-        required_fields: set[str] = set()
+
+        # Known leaf fields (dotted) across the well-known + playbook schemas.
+        leaf_paths: dict[str, Any] = {}
         for sub in combined_schema.get("allOf", []):
-            schema_properties.update(sub.get("properties", {}))
-            required_fields.update(sub.get("required", []))
+            leaf_paths.update(_collect_leaf_paths(sub))
 
-        # Build per-field error map from jsonschema.
-        validator = jsonschema.Draft202012Validator(combined_schema)
-        field_errors: dict[str, str] = {}
-        for error in validator.iter_errors(self._metadata):
-            # Map the error back to the field it concerns.
-            if error.path:
-                field = str(error.path[0])
-            elif error.validator == "required":
-                # "required" errors report the missing field name in the message.
-                # Extract field name from the validator_value list when possible.
+        validator = jsonschema.Draft202012Validator(
+            combined_schema, format_checker=_FORMAT_CHECKER
+        )
+        errors = list(validator.iter_errors(self._metadata))
+
+        # metadata_validation: one entry per known leaf path, valid by default.
+        metadata_validation: dict[str, Any] = {
+            path: {"valid": True} for path in leaf_paths
+        }
+        for error in errors:
+            if error.validator == "required":
+                base = list(error.absolute_path)
                 for missing in error.validator_value:
-                    if missing not in self._metadata:
-                        field_errors[missing] = error.message
-                        break
-                continue
+                    dotted = ".".join([*map(str, base), str(missing)])
+                    metadata_validation[dotted] = {
+                        "valid": False,
+                        "error": error.message,
+                    }
             else:
-                continue
-            field_errors[field] = error.message
-
-        # Build the output metadata dict: user-supplied values + null for schema
-        # properties that are absent.
-        out_metadata: dict[str, Any] = {}
-        for key, value in self._metadata.items():
-            out_metadata[key] = value
-        for field in schema_properties:
-            if field not in out_metadata:
-                out_metadata[field] = None
-
-        # Build per-field validation results — only for schema-defined properties.
-        metadata_validation: dict[str, Any] = {}
-        for field in schema_properties:
-            if field in field_errors:
-                metadata_validation[field] = {
-                    "valid": False,
-                    "error": field_errors[field],
-                }
-            else:
-                metadata_validation[field] = {"valid": True}
-
-        # Also report errors for required fields that are missing (not in schema_properties
-        # explicitly but listed as required).
-        for field in required_fields:
-            if field not in metadata_validation and field in field_errors:
-                metadata_validation[field] = {
-                    "valid": False,
-                    "error": field_errors[field],
-                }
-
-        valid = len(field_errors) == 0
+                dotted = ".".join(str(p) for p in error.absolute_path)
+                if dotted:
+                    metadata_validation[dotted] = {
+                        "valid": False,
+                        "error": error.message,
+                    }
 
         return {
             "analyzer": self.name,
-            "metadata": out_metadata,
+            "metadata": dict(self._metadata),
             "metadata_validation": metadata_validation,
-            "valid": valid,
+            "valid": not errors,
         }
 
     def validate(self, report: dict[str, Any]) -> None:

--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -360,7 +360,6 @@ def analyze(
             if merge_meta and existing_report.get("metadata"):
                 metadata_dict = {**existing_report["metadata"], **metadata_dict}
             existing_report["metadata"] = metadata_dict
-            existing_report.setdefault("request", {})["metadata"] = metadata_dict
 
         formats = ["json"]
         if markdown:
@@ -582,7 +581,6 @@ def analyze(
         }
         if metadata_dict:
             analysis_report["metadata"] = metadata_dict
-            analysis_report["request"]["metadata"] = metadata_dict
 
         try:
             from importlib.resources import files as _res_files

--- a/regis/playbook/context.py
+++ b/regis/playbook/context.py
@@ -79,6 +79,15 @@ class NamedList(list):
         return super().__getitem__(key)
 
 
+def _is_optional_namespace(full_key: str) -> bool:
+    """Keys under the user-supplied ``metadata`` namespace are optional.
+
+    Their absence is a legitimate, testable state (via is_set/is_empty), not a
+    "an analyzer did not run" condition, so it must not mark a rule incomplete.
+    """
+    return full_key == "metadata" or full_key.startswith("metadata.")
+
+
 class MissingDataTracker(dict):
     """A dictionary wrapper that tracks which keys were accessed and if they were missing."""
 
@@ -106,11 +115,13 @@ class MissingDataTracker(dict):
         try:
             val = super().__getitem__(key)
         except KeyError:
-            self.root.missing_accessed = True
+            if not _is_optional_namespace(full_key):
+                self.root.missing_accessed = True
             raise
 
         if val is None:
-            self.root.missing_accessed = True
+            if not _is_optional_namespace(full_key):
+                self.root.missing_accessed = True
             return None
 
         if isinstance(val, dict):
@@ -128,6 +139,10 @@ class MissingDataTracker(dict):
             full_key = f"{self.path}.{key}" if self.path else key
             self.accessed_keys.add(full_key)
         if not super().__contains__(key):
-            self.root.missing_accessed = True
+            if not (
+                isinstance(key, str)
+                and _is_optional_namespace(f"{self.path}.{key}" if self.path else key)
+            ):
+                self.root.missing_accessed = True
             return False
         return True

--- a/regis/playbooks/default/playbook.yaml
+++ b/regis/playbooks/default/playbook.yaml
@@ -176,8 +176,8 @@ spec:
 
   links:
     - label: Return to Merge Request
-      url: "{{ request.metadata['gitlab.mr_url'] }}"
-      condition: { "!!": [var: request.metadata.gitlab.mr_url] }
+      url: "{{ metadata.gitlab.mr_url }}"
+      condition: { "!!": [var: metadata.gitlab.mr_url] }
   presentation:
     badges:
       - score

--- a/regis/rules/evaluator.py
+++ b/regis/rules/evaluator.py
@@ -11,6 +11,7 @@ import json_logic
 from json_logic import jsonLogic
 
 from regis.playbook.context import MissingDataTracker, _build_context
+from regis.utils.predicates import is_empty, is_falsy, is_truthy, is_url, matches
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +341,16 @@ def _add_custom_operations():
             else False
         ),
     )
+
+    # Meta/string helpers — meta values arrive as strings, so these make rule
+    # conditions over `metadata.*` ergonomic. All are defensive (falsy on
+    # unexpected input). See regis/utils/predicates.py.
+    json_logic.add_operation("is_true", is_truthy)
+    json_logic.add_operation("is_false", is_falsy)
+    json_logic.add_operation("is_url", is_url)
+    json_logic.add_operation("is_empty", is_empty)
+    json_logic.add_operation("is_set", lambda a: not is_empty(a))
+    json_logic.add_operation("matches", matches)
 
 
 _add_custom_operations()

--- a/regis/schemas/meta/well-known.schema.json
+++ b/regis/schemas/meta/well-known.schema.json
@@ -5,19 +5,32 @@
   "description": "Standard metadata fields recognized by regis across all playbooks.",
   "type": "object",
   "properties": {
-    "ci.platform": {
-      "type": "string",
-      "enum": ["github", "gitlab"],
-      "description": "CI platform running the analysis"
-    },
-    "ci.job.id": {
-      "type": "string",
-      "description": "Unique identifier of the CI job"
-    },
-    "ci.job.url": {
-      "type": "string",
-      "format": "uri",
-      "description": "URL to the CI job run"
+    "ci": {
+      "type": "object",
+      "description": "Continuous-integration context for the analysis run.",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": ["github", "gitlab"],
+          "description": "CI platform running the analysis"
+        },
+        "job": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique identifier of the CI job"
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL to the CI job run"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
     }
   },
   "additionalProperties": true

--- a/regis/schemas/report/report.schema.json
+++ b/regis/schemas/report/report.schema.json
@@ -55,7 +55,7 @@
     },
     "metadata": {
       "type": "object",
-      "description": "Arbitrary user-provided metadata.",
+      "description": "Arbitrary user-provided metadata (from --meta). Optional namespace exposed to rules as metadata.*.",
       "additionalProperties": true
     },
     "links": {
@@ -119,11 +119,6 @@
           "type": "string",
           "format": "date-time",
           "description": "ISO 8601 UTC timestamp of the analysis."
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Arbitrary user-provided metadata.",
-          "additionalProperties": true
         }
       },
       "additionalProperties": false

--- a/regis/utils/predicates.py
+++ b/regis/utils/predicates.py
@@ -1,0 +1,68 @@
+"""Pure predicate helpers shared by rule operators and meta validation.
+
+These functions are intentionally free of any ``json_logic`` dependency so they
+can be reused by :mod:`regis.analyzers.metadata` (format checking) and unit-tested
+in isolation. They follow a defensive style: unexpected input types yield a falsy
+result rather than raising.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"true", "1", "yes", "on"}
+_FALSY = {"false", "0", "no", "off"}
+
+
+def is_truthy(value: Any) -> bool:
+    """True for boolean ``True`` or a truthy string (true/1/yes/on, case-insensitive)."""
+    if value is True:
+        return True
+    return isinstance(value, str) and value.strip().lower() in _TRUTHY
+
+
+def is_falsy(value: Any) -> bool:
+    """True for boolean ``False`` or a falsy string (false/0/no/off, case-insensitive).
+
+    Not the strict complement of :func:`is_truthy`: a junk string ("maybe") is
+    neither truthy nor falsy.
+    """
+    if value is False:
+        return True
+    return isinstance(value, str) and value.strip().lower() in _FALSY
+
+
+def is_url(value: Any) -> bool:
+    """True if ``value`` is a well-formed http/https URL (scheme + netloc)."""
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = urlparse(value)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def is_empty(value: Any) -> bool:
+    """True if ``value`` is None, an empty string, or whitespace-only."""
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+def matches(value: Any, pattern: Any) -> bool:
+    """True if ``value`` (a string) matches the regular expression ``pattern``.
+
+    Non-string input or an invalid regex yields ``False`` (a warning is logged for
+    the latter).
+    """
+    if not isinstance(value, str) or not isinstance(pattern, str):
+        return False
+    try:
+        return bool(re.search(pattern, value))
+    except re.error:
+        logger.warning("matches: invalid regex pattern %r", pattern)
+        return False

--- a/regis/utils/predicates.py
+++ b/regis/utils/predicates.py
@@ -38,14 +38,21 @@ def is_falsy(value: Any) -> bool:
 
 
 def is_url(value: Any) -> bool:
-    """True if ``value`` is a well-formed http/https URL (scheme + netloc)."""
+    """True if ``value`` is a well-formed http/https URL (scheme + netloc).
+
+    Relies on ``urllib.parse.urlparse`` but additionally rejects a ``netloc``
+    containing whitespace (urlparse otherwise accepts such malformed values),
+    so it is suitable as a ``format: uri`` checker for well-formed URL fields.
+    """
     if not isinstance(value, str):
         return False
     try:
         parsed = urlparse(value)
     except (ValueError, AttributeError):
         return False
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    return not any(ch.isspace() for ch in parsed.netloc)
 
 
 def is_empty(value: Any) -> bool:

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -14,7 +14,7 @@ import jsonschema
 
 logger = logging.getLogger(__name__)
 
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
 """Current report-structure contract version (see report.schema.json)."""
 
 

--- a/tests/fixtures/report.v3.json
+++ b/tests/fixtures/report.v3.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 3,
+  "metadata": { "ci": { "platform": "github" } },
+  "version": "0.33.0",
+  "snapshot_date": "2026-05-31",
+  "tier": "Gold",
+  "request": {
+    "url": "registry-1.docker.io/library/nginx:1.27",
+    "registry": "registry-1.docker.io",
+    "repository": "library/nginx",
+    "tag": "1.27",
+    "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "analyzers": ["cve", "oci"],
+    "timestamp": "2026-05-31T12:00:00+00:00"
+  },
+  "results": {
+    "oci": {
+      "analyzer": "oci",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "platforms": [{ "architecture": "amd64", "os": "linux" }]
+    },
+    "cve": {
+      "analyzer": "cve",
+      "repository": "library/nginx",
+      "tag": "1.27",
+      "scanner_version": "0.74.1",
+      "vulnerability_count": 17,
+      "critical_count": 0,
+      "high_count": 1,
+      "medium_count": 4,
+      "low_count": 12,
+      "negligible_count": 0,
+      "unknown_count": 0,
+      "fixed_count": 5,
+      "targets": []
+    }
+  },
+  "rules": [
+    {
+      "slug": "no-critical-cve",
+      "description": "No critical CVEs",
+      "level": "Gold",
+      "tags": ["security"],
+      "passed": true,
+      "status": "passed",
+      "message": "0 critical vulnerabilities found",
+      "analyzers": ["cve"]
+    }
+  ],
+  "rules_summary": {
+    "score": 100,
+    "total": ["no-critical-cve"],
+    "passed": ["no-critical-cve"],
+    "by_tag": {
+      "security": {
+        "rules": ["no-critical-cve"],
+        "passed_rules": ["no-critical-cve"],
+        "score": 100
+      }
+    }
+  }
+}

--- a/tests/test_analyze_rerun.py
+++ b/tests/test_analyze_rerun.py
@@ -350,4 +350,4 @@ class TestRerunBackfillsSchemaVersion:
             updated = json.loads(
                 (report_dir / "report.json").read_text(encoding="utf-8")
             )
-            assert updated["schemaVersion"] == 2
+            assert updated["schemaVersion"] == 3

--- a/tests/test_analyzer_metadata.py
+++ b/tests/test_analyzer_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for MetadataAnalyzer."""
+"""Tests for MetadataAnalyzer (nested well-known schema + format checking)."""
 
 from __future__ import annotations
 
@@ -10,67 +10,72 @@ from regis.analyzers.metadata import MetadataAnalyzer
 
 
 class TestMetadataAnalyzerWellKnownOnly:
-    """Tests without a playbook meta_schema_path."""
+    """Tests without a playbook meta_schema_path. Meta is nested, as in production."""
 
     def test_empty_metadata_valid(self):
         analyzer = MetadataAnalyzer(metadata={})
         result = analyzer.analyze()
         assert result["analyzer"] == "metadata"
         assert result["valid"] is True
-        # Schema-defined optional fields appear as null when absent
-        assert result["metadata"].get("ci.platform") is None
-        assert result["metadata"].get("ci.job.id") is None
-        # All schema-defined fields should be valid (they're optional)
+        # Every known leaf field is reported valid when absent (optional).
         for v in result["metadata_validation"].values():
             assert v == {"valid": True}
+        # Known leaf paths are dotted.
+        assert "ci.platform" in result["metadata_validation"]
+        assert "ci.job.url" in result["metadata_validation"]
 
     def test_valid_well_known_field(self):
-        analyzer = MetadataAnalyzer(metadata={"ci.platform": "github"})
+        analyzer = MetadataAnalyzer(metadata={"ci": {"platform": "github"}})
         result = analyzer.analyze()
         assert result["valid"] is True
-        assert result["metadata"]["ci.platform"] == "github"
+        assert result["metadata"]["ci"]["platform"] == "github"
         assert result["metadata_validation"]["ci.platform"] == {"valid": True}
 
     def test_invalid_well_known_enum_value(self):
-        analyzer = MetadataAnalyzer(metadata={"ci.platform": "bitbucket"})
+        analyzer = MetadataAnalyzer(metadata={"ci": {"platform": "bitbucket"}})
         result = analyzer.analyze()
         assert result["valid"] is False
         assert result["metadata_validation"]["ci.platform"]["valid"] is False
         assert "error" in result["metadata_validation"]["ci.platform"]
 
-    def test_optional_field_absent_appears_as_null(self):
-        analyzer = MetadataAnalyzer(metadata={})
-        result = analyzer.analyze()
-        # Optional schema-defined fields absent from input appear as null in metadata
-        assert result["metadata"].get("ci.platform") is None
-        assert result["metadata_validation"].get("ci.platform") == {"valid": True}
-
-    def test_unknown_keys_passthrough_in_metadata_not_in_validation(self):
+    def test_valid_well_known_uri(self):
         analyzer = MetadataAnalyzer(
-            metadata={"custom.key": "value", "ci.platform": "github"}
+            metadata={"ci": {"job": {"url": "https://ci.example/run/9"}}}
         )
         result = analyzer.analyze()
         assert result["valid"] is True
-        assert result["metadata"]["custom.key"] == "value"
+        assert result["metadata_validation"]["ci.job.url"] == {"valid": True}
+
+    def test_invalid_well_known_uri(self):
+        analyzer = MetadataAnalyzer(metadata={"ci": {"job": {"url": "not a url"}}})
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["ci.job.url"]["valid"] is False
+
+    def test_unknown_keys_passthrough_not_in_validation(self):
+        analyzer = MetadataAnalyzer(
+            metadata={"custom": {"key": "value"}, "ci": {"platform": "github"}}
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is True
+        assert result["metadata"]["custom"]["key"] == "value"
         assert "custom.key" not in result["metadata_validation"]
         assert "ci.platform" in result["metadata_validation"]
 
     def test_analyze_ignores_positional_args(self):
-        """analyze() should work when called with client/repo/tag args (BaseAnalyzer compat)."""
-        analyzer = MetadataAnalyzer(metadata={"ci.job.id": "123"})
+        analyzer = MetadataAnalyzer(metadata={"ci": {"job": {"id": "123"}}})
         client = MagicMock()
         result = analyzer.analyze(client, "repo/name", "latest", "linux/amd64")
         assert result["valid"] is True
-        assert result["metadata"]["ci.job.id"] == "123"
+        assert result["metadata"]["ci"]["job"]["id"] == "123"
 
     def test_validate_is_noop(self):
-        """validate() should not raise."""
         analyzer = MetadataAnalyzer(metadata={})
         analyzer.validate({})  # should not raise
 
 
 class TestMetadataAnalyzerWithPlaybookSchema:
-    """Tests with a custom playbook meta_schema_path."""
+    """Tests with a custom playbook meta_schema_path (merged via allOf)."""
 
     def _write_schema(self, tmp_path: Path, schema: dict) -> Path:
         p = tmp_path / "meta.schema.json"
@@ -82,14 +87,11 @@ class TestMetadataAnalyzerWithPlaybookSchema:
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "required": ["PROJECT_ID"],
-            "properties": {
-                "PROJECT_ID": {"type": "string"},
-            },
+            "properties": {"PROJECT_ID": {"type": "string"}},
         }
         schema_path = self._write_schema(tmp_path, schema)
         analyzer = MetadataAnalyzer(
-            metadata={"PROJECT_ID": "PROJ-42"},
-            meta_schema_path=schema_path,
+            metadata={"PROJECT_ID": "PROJ-42"}, meta_schema_path=schema_path
         )
         result = analyzer.analyze()
         assert result["valid"] is True
@@ -101,20 +103,12 @@ class TestMetadataAnalyzerWithPlaybookSchema:
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "required": ["PROJECT_ID"],
-            "properties": {
-                "PROJECT_ID": {"type": "string"},
-            },
+            "properties": {"PROJECT_ID": {"type": "string"}},
         }
         schema_path = self._write_schema(tmp_path, schema)
-        analyzer = MetadataAnalyzer(
-            metadata={},
-            meta_schema_path=schema_path,
-        )
+        analyzer = MetadataAnalyzer(metadata={}, meta_schema_path=schema_path)
         result = analyzer.analyze()
         assert result["valid"] is False
-        # PROJECT_ID should appear as null in metadata
-        assert result["metadata"].get("PROJECT_ID") is None
-        # And it should be reported as invalid
         assert result["metadata_validation"]["PROJECT_ID"]["valid"] is False
         assert "error" in result["metadata_validation"]["PROJECT_ID"]
 
@@ -123,45 +117,33 @@ class TestMetadataAnalyzerWithPlaybookSchema:
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "required": ["PROJECT_ID"],
-            "properties": {
-                "PROJECT_ID": {"type": "string"},
-            },
+            "properties": {"PROJECT_ID": {"type": "string"}},
         }
         schema_path = self._write_schema(tmp_path, schema)
         analyzer = MetadataAnalyzer(
-            metadata={"PROJECT_ID": 42},  # int instead of str
-            meta_schema_path=schema_path,
+            metadata={"PROJECT_ID": 42}, meta_schema_path=schema_path
         )
         result = analyzer.analyze()
         assert result["valid"] is False
         assert result["metadata_validation"]["PROJECT_ID"]["valid"] is False
 
-    def test_optional_field_absent_appears_as_null(self, tmp_path):
+    def test_optional_field_absent(self, tmp_path):
         schema = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
-            "properties": {
-                "ci.platform": {"type": "string"},
-                "OPTIONAL_FIELD": {"type": "string"},
-            },
+            "properties": {"OPTIONAL_FIELD": {"type": "string"}},
         }
         schema_path = self._write_schema(tmp_path, schema)
-        analyzer = MetadataAnalyzer(
-            metadata={},
-            meta_schema_path=schema_path,
-        )
+        analyzer = MetadataAnalyzer(metadata={}, meta_schema_path=schema_path)
         result = analyzer.analyze()
         assert result["valid"] is True
-        assert result["metadata"].get("OPTIONAL_FIELD") is None
-        assert (
-            result["metadata_validation"].get("OPTIONAL_FIELD", {}).get("valid") is True
-        )
+        assert "OPTIONAL_FIELD" not in result["metadata"]
+        assert result["metadata_validation"]["OPTIONAL_FIELD"] == {"valid": True}
 
     def test_nonexistent_schema_path_falls_back_to_well_known(self, tmp_path):
         nonexistent = tmp_path / "does_not_exist.json"
         analyzer = MetadataAnalyzer(
-            metadata={"ci.platform": "github"},
-            meta_schema_path=nonexistent,
+            metadata={"ci": {"platform": "github"}}, meta_schema_path=nonexistent
         )
         result = analyzer.analyze()
         assert result["valid"] is True
@@ -171,13 +153,11 @@ class TestMetadataAnalyzerWithPlaybookSchema:
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "required": ["PROJECT_ID"],
-            "properties": {
-                "PROJECT_ID": {"type": "string"},
-            },
+            "properties": {"PROJECT_ID": {"type": "string"}},
         }
         schema_path = self._write_schema(tmp_path, schema)
         analyzer = MetadataAnalyzer(
-            metadata={"PROJECT_ID": "PROJ-1", "ci.platform": "gitlab"},
+            metadata={"PROJECT_ID": "PROJ-1", "ci": {"platform": "gitlab"}},
             meta_schema_path=schema_path,
         )
         result = analyzer.analyze()
@@ -189,5 +169,4 @@ class TestMetadataAnalyzerWithPlaybookSchema:
         analyzer = MetadataAnalyzer(metadata=None)
         result = analyzer.analyze()
         assert result["valid"] is True
-        # Schema-defined optional fields appear as null (no user-supplied values)
-        assert result["metadata"].get("ci.platform") is None
+        assert result["metadata"] == {}

--- a/tests/test_analyzer_metadata.py
+++ b/tests/test_analyzer_metadata.py
@@ -170,3 +170,43 @@ class TestMetadataAnalyzerWithPlaybookSchema:
         result = analyzer.analyze()
         assert result["valid"] is True
         assert result["metadata"] == {}
+
+    def test_required_field_partially_present(self, tmp_path):
+        """When some required fields are present, only the missing ones are invalid."""
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["FIELD_A", "FIELD_B"],
+            "properties": {
+                "FIELD_A": {"type": "string"},
+                "FIELD_B": {"type": "string"},
+            },
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(
+            metadata={"FIELD_A": "present"}, meta_schema_path=schema_path
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        assert result["metadata_validation"]["FIELD_A"] == {"valid": True}
+        assert result["metadata_validation"]["FIELD_B"]["valid"] is False
+
+    def test_unexpected_key_rejected_by_strict_schema(self, tmp_path):
+        """A structural (no-path) error is surfaced, keeping valid and the map consistent."""
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"KNOWN": {"type": "string"}},
+            "additionalProperties": False,
+        }
+        schema_path = self._write_schema(tmp_path, schema)
+        analyzer = MetadataAnalyzer(
+            metadata={"KNOWN": "ok", "SURPRISE": "x"}, meta_schema_path=schema_path
+        )
+        result = analyzer.analyze()
+        assert result["valid"] is False
+        # The structural error is recorded (not silently dropped).
+        invalid = [
+            k for k, v in result["metadata_validation"].items() if not v["valid"]
+        ]
+        assert invalid, "expected at least one invalid entry for the structural error"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,8 +135,8 @@ class TestCliBasics:
             assert report["metadata"]["ci"]["job_id"] == "456"
             assert report["metadata"]["ci"]["url"] == "http://ci.com"
             assert report["metadata"]["project"] == "regis"
-            # Also check request metadata
-            assert report["request"]["metadata"]["ci"]["job_id"] == "456"
+            # request.metadata was removed (canonical location is top-level metadata)
+            assert "metadata" not in report["request"]
 
 
 class TestAnalyzeParallelism:
@@ -359,7 +359,7 @@ class TestAnalyzeCacheAndFail:
             # path must backfill it before validation, and the saved report
             # carries it.
             saved = json.loads((cache_dir / "report.json").read_text(encoding="utf-8"))
-            assert saved["schemaVersion"] == 2
+            assert saved["schemaVersion"] == 3
 
     @patch("regis.commands.analyze.render_presentation_templates")
     @patch("regis.commands.analyze.render_and_save_reports")

--- a/tests/test_default_playbook_links.py
+++ b/tests/test_default_playbook_links.py
@@ -1,0 +1,37 @@
+"""The default playbook's MR link must read the canonical top-level metadata.*."""
+
+from __future__ import annotations
+
+import importlib.resources
+
+from regis.playbook.engine import load_playbook
+from regis.playbook.evaluator import _resolve_links
+
+
+def _load_default_playbook() -> dict:
+    pb_dir = importlib.resources.files("regis") / "playbooks" / "default"
+    return load_playbook(str(pb_dir))
+
+
+def test_mr_link_resolves_from_top_level_metadata():
+    playbook = _load_default_playbook()
+    mr_url = "https://gitlab.example/group/proj/-/merge_requests/7"
+    full_context = {"metadata": {"gitlab": {"mr_url": mr_url}}}
+    result: dict = {}
+
+    _resolve_links(playbook, result, full_context, full_context)
+
+    assert {"label": "Return to Merge Request", "url": mr_url} in result.get(
+        "links", []
+    )
+
+
+def test_mr_link_absent_without_metadata():
+    playbook = _load_default_playbook()
+    full_context = {"metadata": {}}
+    result: dict = {}
+
+    _resolve_links(playbook, result, full_context, full_context)
+
+    labels = [link.get("label") for link in result.get("links", [])]
+    assert "Return to Merge Request" not in labels

--- a/tests/test_gh_env.py
+++ b/tests/test_gh_env.py
@@ -81,3 +81,5 @@ class TestGithubEnvironment:
                 == "https://github.com/org/repo/actions/runs/12345"
             )
             assert report["metadata"]["ci"]["job_id"] == "999"
+            # Canonical location only: request.metadata was removed.
+            assert "metadata" not in report["request"]

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,74 @@
+"""Tests for shared rule/meta predicate helpers."""
+
+import pytest
+
+from regis.utils.predicates import is_empty, is_falsy, is_truthy, is_url, matches
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "On", " true "])
+def test_is_truthy_true(value):
+    assert is_truthy(value) is True
+
+
+def test_is_truthy_bool():
+    assert is_truthy(True) is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "maybe", "", None, 1, 0])
+def test_is_truthy_false(value):
+    assert is_truthy(value) is False
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "Off", " false "])
+def test_is_falsy_true(value):
+    assert is_falsy(value) is True
+
+
+def test_is_falsy_bool():
+    assert is_falsy(False) is True
+
+
+@pytest.mark.parametrize("value", ["true", "1", "maybe", "", None, 0])
+def test_is_falsy_false(value):
+    assert is_falsy(value) is False
+
+
+@pytest.mark.parametrize(
+    "value", ["http://x.io", "https://github.com/org/repo/actions/runs/1"]
+)
+def test_is_url_true(value):
+    assert is_url(value) is True
+
+
+@pytest.mark.parametrize(
+    "value", ["not a url", "ftp://x.io", "github.com", "", None, 123, "https://"]
+)
+def test_is_url_false(value):
+    assert is_url(value) is False
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_is_empty_true(value):
+    assert is_empty(value) is True
+
+
+@pytest.mark.parametrize("value", ["x", "0", 0, False])
+def test_is_empty_false(value):
+    assert is_empty(value) is False
+
+
+def test_matches_hit():
+    assert matches("job-42", r"^job-[0-9]+$") is True
+
+
+def test_matches_miss():
+    assert matches("job-x", r"^job-[0-9]+$") is False
+
+
+def test_matches_invalid_regex_is_false():
+    assert matches("anything", r"[unclosed") is False
+
+
+@pytest.mark.parametrize("value", [None, 123])
+def test_matches_non_string_is_false(value):
+    assert matches(value, r".*") is False

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -41,7 +41,18 @@ def test_is_url_true(value):
 
 
 @pytest.mark.parametrize(
-    "value", ["not a url", "ftp://x.io", "github.com", "", None, 123, "https://"]
+    "value",
+    [
+        "not a url",
+        "ftp://x.io",
+        "github.com",
+        "",
+        None,
+        123,
+        "https://",
+        "https://not a url",
+        "https://exa mple.com",
+    ],
 )
 def test_is_url_false(value):
     assert is_url(value) is False

--- a/tests/test_report_schema_version.py
+++ b/tests/test_report_schema_version.py
@@ -39,6 +39,17 @@ class TestReportSchemaVersion:
     def test_accepts_report_with_schema_version(self):
         jsonschema.validate(instance=_minimal_report(), schema=_report_schema())
 
+    def test_rejects_request_metadata(self):
+        """request.metadata was removed; request has additionalProperties:false."""
+        report = _minimal_report()
+        report["request"]["metadata"] = {"ci": {"platform": "github"}}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=report, schema=_report_schema())
+
+    def test_accepts_top_level_metadata(self):
+        report = _minimal_report(metadata={"ci": {"platform": "github"}})
+        jsonschema.validate(instance=report, schema=_report_schema())
+
     def test_rejects_report_missing_schema_version(self):
         report = _minimal_report()
         del report["schemaVersion"]
@@ -61,10 +72,10 @@ class TestReportSchemaVersion:
 
 
 class TestEnsureSchemaVersion:
-    def test_constant_is_two(self):
+    def test_constant_is_three(self):
         from regis.utils.report import REPORT_SCHEMA_VERSION
 
-        assert REPORT_SCHEMA_VERSION == 2
+        assert REPORT_SCHEMA_VERSION == 3
 
     def test_sets_when_missing(self):
         from regis.utils.report import REPORT_SCHEMA_VERSION, ensure_schema_version
@@ -92,10 +103,10 @@ class TestContractFixture:
 
         from regis.utils.report import validate_report
 
-        fixture = Path(__file__).parent / "fixtures" / "report.v2.json"
+        fixture = Path(__file__).parent / "fixtures" / "report.v3.json"
         report = json.loads(fixture.read_text(encoding="utf-8"))
 
-        assert report["schemaVersion"] == 2
+        assert report["schemaVersion"] == 3
         validate_report(report)  # must not raise
 
     def test_analyzer_blobs_match_their_schemas(self):
@@ -104,7 +115,7 @@ class TestContractFixture:
 
         import jsonschema
 
-        fixtures = Path(__file__).parent / "fixtures" / "report.v2.json"
+        fixtures = Path(__file__).parent / "fixtures" / "report.v3.json"
         report = json.loads(fixtures.read_text(encoding="utf-8"))
 
         schema_dir = importlib.resources.files("regis.schemas.analyzer")

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -255,8 +255,9 @@ def test_only_declared_rules_evaluated():
 
 def test_helper_operators_registered():
     """The new helper operators evaluate through json_logic."""
-    import regis.rules.evaluator  # noqa: F401  (registers operators on import)
     from json_logic import jsonLogic
+
+    import regis.rules.evaluator  # noqa: F401  (registers operators on import)
 
     assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "yes"}) is True
     assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "nope"}) is False
@@ -268,3 +269,65 @@ def test_helper_operators_registered():
     assert (
         jsonLogic({"matches": [{"var": "v"}, "^job-[0-9]+$"]}, {"v": "job-7"}) is True
     )
+
+
+def test_missing_metadata_does_not_mark_incomplete():
+    """A rule referencing an absent metadata.* key resolves to a clean fail/pass."""
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["metadata"]},
+        "results": {},
+        "metadata": {},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "gate-must-be-set",
+                "condition": {"is_set": [{"var": "metadata.gate.enabled"}]},
+                "messages": {"pass": "set", "fail": "not set"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "gate-must-be-set")
+    assert rule["status"] == "failed"  # absent -> failed, NOT incomplete
+    assert rule["passed"] is False
+
+
+def test_present_metadata_evaluates_normally():
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["metadata"]},
+        "results": {},
+        "metadata": {"ci": {"job": {"url": "https://ci.example/run/1"}}},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "job-url-valid",
+                "condition": {"is_url": [{"var": "metadata.ci.job.url"}]},
+                "messages": {"pass": "ok", "fail": "bad"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "job-url-valid")
+    assert rule["status"] == "passed"
+
+
+def test_missing_results_still_incomplete():
+    """Non-metadata missing data must still yield incomplete (no regression)."""
+    report = {
+        "request": {"registry": "docker.io", "analyzers": ["cve"]},
+        "results": {},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "needs-cve",
+                "condition": {"==": [{"var": "results.cve.critical_count"}, 0]},
+                "messages": {"pass": "ok", "fail": "bad"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "needs-cve")
+    assert rule["status"] == "incomplete"

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -251,3 +251,20 @@ def test_only_declared_rules_evaluated():
     }
     res = evaluate_rules(report, rules_def)
     assert [r["slug"] for r in res["rules"]] == ["age"]
+
+
+def test_helper_operators_registered():
+    """The new helper operators evaluate through json_logic."""
+    import regis.rules.evaluator  # noqa: F401  (registers operators on import)
+    from json_logic import jsonLogic
+
+    assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "yes"}) is True
+    assert jsonLogic({"is_true": [{"var": "v"}]}, {"v": "nope"}) is False
+    assert jsonLogic({"is_false": [{"var": "v"}]}, {"v": "off"}) is True
+    assert jsonLogic({"is_url": [{"var": "v"}]}, {"v": "https://x.io"}) is True
+    assert jsonLogic({"is_url": [{"var": "v"}]}, {"v": "x.io"}) is False
+    assert jsonLogic({"is_empty": [{"var": "v"}]}, {"v": ""}) is True
+    assert jsonLogic({"is_set": [{"var": "v"}]}, {"v": "x"}) is True
+    assert (
+        jsonLogic({"matches": [{"var": "v"}, "^job-[0-9]+$"]}, {"v": "job-7"}) is True
+    )


### PR DESCRIPTION
## Summary

- **New JSON Logic rule helpers** for the string-valued data that `--meta` produces: `is_true` / `is_false` (boolean-ish strings), `is_url`, `is_empty` / `is_set`, and `matches` (regex). They make conditions over `metadata.*` readable instead of forcing `{"==": [..., "true"]}` comparisons.
- **`metadata.*` is now a first-class, documented namespace.** User `--meta` lands at a single canonical location — top-level `metadata.*` — referenced in rules as `{"var": "metadata.ci.job.url"}`. The duplicate `request.metadata` is gone.
- **Absent meta no longer marks a rule `incomplete`.** A missing `metadata.*` key resolves to `null` without flagging the rule incomplete (that status is reserved for "an analyzer didn't run"), so `is_set` / `is_empty` work as real presence tests. `results.*` still marks incomplete.
- **Well-known metadata validation actually works now.** The schema was rewritten from inert flat-dotted keys to a nested structure matching the data, so `ci.platform` (enum) and `ci.job.url` (`format: uri`, enforced via a local checker) are genuinely validated; the per-field validation map is keyed by dotted path.
- New concepts section + upgrade guide document the namespace, helpers, and migration.

## Breaking change

Report `schemaVersion` bumped **2 → 3**: `request.metadata` is removed and the schema now rejects it (`request` is `additionalProperties: false`). Rules and downstream consumers must read top-level `metadata.*` and gate on `schemaVersion >= 3`. No automated migration (reports are generated output). See `docs/website/docs/upgrade/report-metadata-namespace.md`.

BREAKING CHANGE: report schemaVersion 2→3; user metadata now lives only at top-level `metadata.*` (`request.metadata` removed).

## Test Plan

- [x] Full suite green (637 passed, coverage 92.17%, ≥90% gate)
- [x] Predicate unit tests + operator registration via real `jsonLogic`
- [x] Incomplete-exemption: absent `metadata.*` → fail/pass (not incomplete); `results.*` absent → still incomplete
- [x] Well-known validation: `ci.platform` enum reject + `ci.job.url` uri reject genuinely fire; partial-required fields handled
- [x] Report rejects `request.metadata`; producer no longer writes it; default-playbook MR link reads `metadata.*` (regression-tested)
- [x] Trunk lint clean

## Coordination

This `schemaVersion` 2→3 bump must be the only report-schema bump landing in the "presentation generalization" queue, so downstream consumers (regis-gitlab, regis-backstage, regis-action) see a single coordinated bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)