### PR TITLE
fix(playbook): render mr-evidence from packaged template, not a git clone

### DIFF
--- a/docs/superpowers/specs/2026-06-08-ci-test-slow-git-clone-design.md
+++ b/docs/superpowers/specs/2026-06-08-ci-test-slow-git-clone-design.md
@@ -1,0 +1,102 @@
+# Spec — `ci-test.yml` ~10 min : le playbook par défaut clone le dépôt regis
+
+- **Date** : 2026-06-08
+- **Statut** : validé (design), implémenté
+- **Type** : `fix` (cœur + tests) — corrige aussi un comportement runtime user-facing
+
+## Problème
+
+Le job `pytest` de `.github/workflows/ci-test.yml` prend **~590s** par run, alors
+que la même suite tourne en **~12s en local**. L'écart n'est pas un coût
+d'exécution : c'est une anomalie spécifique au runner CI.
+
+## Cause racine (mesurée, reproduite)
+
+Le playbook par défaut (`regis/playbooks/default/playbook.yaml`) déclarait un
+template de présentation **par URL git** :
+
+```yaml
+presentation:
+  templates:
+    - url: https://github.com/trivoallan/regis
+      directory: regis/cookiecutters/mr-evidence
+```
+
+`regis analyze` appelle `render_presentation_templates()` →
+`cookiecutter(<url>)`. Comme l'URL est un dépôt git (`is_repo_url() == True`),
+**Cookiecutter fait un `git clone` du dépôt regis entier** (un sous-processus)
+— pour un template que regis **embarque déjà** dans son package
+(`regis/cookiecutters/mr-evidence`). Autrement dit, regis se clone lui-même à
+chaque analyse.
+
+Sur le runner CI (cache cookiecutter froid, egress git lent/filtré), ce clone
+**traîne ~25s par test** puis est avalé par un `except Exception` (« Warning:
+Failed to render template ») → le test passe, mais après 25s. ~24 tests CLI
+qui invoquent un `analyze` complet × ~25s ≈ ~600s.
+
+### Pourquoi invisible en local
+
+`~/.cookiecutters/regis` est **mis en cache** localement → Cookiecutter réutilise
+le clone, pas d'accès réseau. Reproduction : en vidant ce cache, un seul test
+analyze passe de **0,1s à 61s**.
+
+### Fausses pistes écartées (preuves)
+
+- **Réseau des analyzers / RegistryClient** : les tests lents mockent
+  `RegistryClient` **et** `_discover_analyzers` → aucun analyzer réel.
+- **pytest-socket** : un `git clone` est un sous-processus, **non blocable** par
+  pytest-socket ; le blocage socket n'a rien changé au runtime.
+- **Traceur de couverture** : CTracer (C) confirmé en CI ; ~2× en local, pas 50×.
+- **DNS/retries** : `getaddrinfo` instantané, pas de retry/backoff dans
+  `RegistryClient`.
+
+## Décision
+
+Référencer le template mr-evidence comme un **template packagé local** au lieu
+d'un dépôt git distant. Résout la lenteur CI **et** rend chaque `regis analyze`
+en production plus rapide et indépendant du réseau (plus d'auto-clone).
+
+## Changements
+
+1. **Schémas** (`playbook/v1alpha1/playbook.schema.json`,
+   `playbook/result.schema.json`) : les entrées `templates` acceptent désormais
+   `package` (paquet Python installé qui livre le template) **en alternative à**
+   `url` (`anyOf` : `url` **ou** `package`). Champ `directory` réinterprété
+   relativement à la racine du package quand `package` est fourni.
+2. **`regis/playbook/presentation.py`** (`_resolve_template_conditions`) :
+   propage `package` (et `url`) dans le template résolu injecté au rapport.
+3. **`regis/utils/report.py`** (`render_presentation_templates`) : si `package`
+   est présent, résout `importlib.resources.files(package) / directory` en chemin
+   local et appelle `cookiecutter(<chemin local>)` (aucun `directory` kwarg,
+   aucun clone). Le chemin `url` (templates distants tiers) reste supporté.
+4. **`regis/playbooks/default/playbook.yaml`** : le template mr-evidence passe à
+   `package: regis` + `directory: cookiecutters/mr-evidence`.
+5. **`tests/conftest.py`** (nouveau) : fixture `autouse` qui **rejette tout
+   clone distant** de Cookiecutter (`is_repo_url` → `RuntimeError`), tout en
+   laissant passer les templates packagés/locaux. Filet anti-régression : aucun
+   test ne doit plus cloner sur le réseau.
+6. **`tests/test_presentation_templates.py`** (nouveau) : rendu local d'un
+   template packagé (sans réseau) + garde anti-régression sur le playbook par
+   défaut (aucun `url`, un `package`).
+
+## Hors périmètre (non-objectifs)
+
+- Pas de `pytest-socket` ni de blocage socket : sans rapport avec la cause (le
+  clone est un sous-processus) ; la piste a été écartée.
+- Pas de refonte du mécanisme de templates au-delà de l'ajout `package`.
+
+## Vérification
+
+- **Local, cache cookiecutter vidé** (simule un runner CI neuf) : suite complète
+  **574 passed en ~12s** (vs un seul test à 61s avant le fix).
+- **CI** : run `ci-test.yml` attendu **< ~90s** (vs ~590s).
+- **Compat** : changement de schéma additif (`url` toujours accepté). Les
+  playbooks tiers utilisant `url` continuent de fonctionner.
+
+## Risques & mitigations
+
+- **Un template tiers légitimement distant** → toujours possible via `url` ; le
+  filet conftest ne s'applique qu'aux tests.
+- **Résolution `package` sur install editable vs wheel** →
+  `importlib.resources.files` gère les deux ; mr-evidence est packagé via
+  `tool.setuptools.package-data` (`cookiecutters/**/*`).

--- a/regis/playbook/presentation.py
+++ b/regis/playbook/presentation.py
@@ -112,18 +112,24 @@ def _resolve_templates(
     resolved_templates: list[dict[str, str]] = []
     for tmpl_def in template_defs:
         url = tmpl_def.get("url")
-        if not url:
+        package = tmpl_def.get("package")
+        if not url and not package:
             continue
 
+        label = url or package
         condition = tmpl_def.get("condition")
         if condition:
-            result = evaluate_condition(condition, full_context, label=url)
+            result = evaluate_condition(condition, full_context, label=label)
             if result is None:
                 pass  # no condition → include
             elif not result.passed or result.incomplete:
                 continue
 
-        resolved_tmpl: dict[str, str] = {"url": url}
+        resolved_tmpl: dict[str, str] = {}
+        if url:
+            resolved_tmpl["url"] = url
+        if package:
+            resolved_tmpl["package"] = package
         if tmpl_def.get("directory"):
             resolved_tmpl["directory"] = tmpl_def["directory"]
         resolved_templates.append(resolved_tmpl)

--- a/regis/playbooks/default/playbook.yaml
+++ b/regis/playbooks/default/playbook.yaml
@@ -185,8 +185,8 @@ spec:
       - cve-critical
       - cve-high
     templates:
-      - url: https://github.com/trivoallan/regis
-        directory: regis/cookiecutters/mr-evidence
+      - package: regis
+        directory: cookiecutters/mr-evidence
 
     checklists:
       - title: 📝 Review Checklist

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -403,9 +403,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["url"],
+        "anyOf": [{ "required": ["url"] }, { "required": ["package"] }],
         "properties": {
           "url": { "type": "string" },
+          "package": { "type": "string" },
           "directory": { "type": "string" }
         }
       },

--- a/regis/schemas/playbook/v1alpha1/playbook.schema.json
+++ b/regis/schemas/playbook/v1alpha1/playbook.schema.json
@@ -114,16 +114,20 @@
               "description": "Conditional Cookiecutter templates surfaced to integrations.",
               "items": {
                 "type": "object",
-                "required": ["url"],
+                "anyOf": [{ "required": ["url"] }, { "required": ["package"] }],
                 "additionalProperties": false,
                 "properties": {
                   "url": {
                     "type": "string",
-                    "description": "Cookiecutter template URL or path."
+                    "description": "Cookiecutter template URL or local path (a git URL is cloned)."
+                  },
+                  "package": {
+                    "type": "string",
+                    "description": "Installed Python package shipping the template (e.g. 'regis'); resolved to a local path with 'directory', so no clone is performed."
                   },
                   "directory": {
                     "type": "string",
-                    "description": "Optional subdirectory containing the template."
+                    "description": "Subdirectory containing the template (relative to the repo for 'url', or to the package root for 'package')."
                   },
                   "condition": {
                     "description": "JSON Logic expression to conditionally surface the template.",

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -431,9 +431,11 @@ def render_presentation_templates(
         else:
             for tmpl_def in valid_templates:
                 tmpl_url = tmpl_def.get("url")
+                tmpl_pkg = tmpl_def.get("package")
                 tmpl_dir = tmpl_def.get("directory")
+                label = tmpl_url or tmpl_pkg
                 click.echo(
-                    f"  Rendering presentation template: {tmpl_url}...", err=True
+                    f"  Rendering presentation template: {label}...", err=True
                 )
                 try:
                     out_dir = format_output_path(
@@ -447,12 +449,20 @@ def render_presentation_templates(
                         "output_dir": str(out_dir),
                         "overwrite_if_exists": True,
                     }
-                    if tmpl_dir:
-                        kwargs["directory"] = tmpl_dir
 
-                    cookiecutter(tmpl_url, **kwargs)
+                    if tmpl_pkg:
+                        # Packaged template: resolve to a local path so Cookiecutter
+                        # renders in-place (no git clone / network access).
+                        base = resources.files(tmpl_pkg)
+                        template_arg = str(base / tmpl_dir) if tmpl_dir else str(base)
+                    else:
+                        template_arg = tmpl_url
+                        if tmpl_dir:
+                            kwargs["directory"] = tmpl_dir
+
+                    cookiecutter(template_arg, **kwargs)
                 except Exception as exc:
                     click.echo(
-                        f"  Warning: Failed to render template '{tmpl_url}': {exc}",
+                        f"  Warning: Failed to render template '{label}': {exc}",
                         err=True,
                     )

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -434,9 +434,7 @@ def render_presentation_templates(
                 tmpl_pkg = tmpl_def.get("package")
                 tmpl_dir = tmpl_def.get("directory")
                 label = tmpl_url or tmpl_pkg
-                click.echo(
-                    f"  Rendering presentation template: {label}...", err=True
-                )
+                click.echo(f"  Rendering presentation template: {label}...", err=True)
                 try:
                     out_dir = format_output_path(
                         output_dir_template or ".", report, "json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures.
+
+Network guard for Cookiecutter:
+
+``regis analyze`` renders the playbook's presentation templates via
+Cookiecutter. The default playbook surfaces a *packaged* (local) template, so
+no test should ever clone a remote one. If a repository URL slips back into a
+playbook, Cookiecutter would ``git clone`` it — which hangs for ~25s per test
+on CI runners (cold cache, slow/blocked egress) and silently inflated the
+``pytest`` job to ~10 minutes. Fail fast and loudly instead.
+"""
+
+import cookiecutter.main as _cc_main
+import cookiecutter.repository as _cc_repo
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def block_remote_cookiecutter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject remote Cookiecutter templates; allow packaged/local ones."""
+    real = _cc_main.cookiecutter
+
+    def _guard(template, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if _cc_repo.is_repo_url(str(template)):
+            raise RuntimeError(
+                "Test attempted to clone a remote Cookiecutter template "
+                f"({template!r}). Use a packaged/local template instead "
+                "(see tests/conftest.py)."
+            )
+        return real(template, *args, **kwargs)
+
+    monkeypatch.setattr(_cc_main, "cookiecutter", _guard)

--- a/tests/test_presentation_templates.py
+++ b/tests/test_presentation_templates.py
@@ -1,0 +1,66 @@
+"""Presentation-template rendering must stay local (no remote clone).
+
+Regression coverage for the CI slowdown where the default playbook referenced
+the regis repo by git URL, so every ``regis analyze`` cloned the whole repo
+(~25s per test on CI). Templates are now resolved from the installed package.
+"""
+
+from importlib import resources
+from pathlib import Path
+
+import cookiecutter.main as _cc_main
+import cookiecutter.repository as _cc_repo
+import pytest
+import yaml
+
+from regis.utils.report import render_presentation_templates
+
+
+def test_packaged_template_resolved_to_local_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``package`` template is passed to Cookiecutter as a local path, never cloned."""
+    seen: list[str] = []
+    monkeypatch.setattr(
+        _cc_main, "cookiecutter", lambda template, **kw: seen.append(str(template))
+    )
+
+    report = {
+        "request": {
+            "registry": "registry-1.docker.io",
+            "repository": "library/nginx",
+            "tag": "latest",
+            "digest": "latest",
+        },
+        "playbooks": [
+            {
+                "templates": [
+                    {"package": "regis", "directory": "cookiecutters/mr-evidence"}
+                ]
+            }
+        ],
+    }
+
+    render_presentation_templates(report, str(tmp_path))
+
+    assert len(seen) == 1, "expected exactly one template render"
+    template_arg = seen[0]
+    assert not _cc_repo.is_repo_url(
+        template_arg
+    ), f"packaged template must resolve to a local path, got a repo URL: {template_arg!r}"
+    assert template_arg.endswith("cookiecutters/mr-evidence")
+    assert Path(template_arg).is_dir()
+
+
+def test_default_playbook_templates_are_packaged() -> None:
+    """The shipped default playbook must not clone a remote template."""
+    pb_path = resources.files("regis") / "playbooks" / "default" / "playbook.yaml"
+    playbook = yaml.safe_load(pb_path.read_text(encoding="utf-8"))
+    templates = playbook["spec"]["presentation"].get("templates", [])
+    assert templates, "default playbook should surface at least one template"
+    for tmpl in templates:
+        assert "url" not in tmpl, (
+            f"default playbook template uses a remote url ({tmpl.get('url')!r}); "
+            "use a packaged template to avoid a git clone on every analyze"
+        )
+        assert tmpl.get("package"), "expected a packaged template reference"


### PR DESCRIPTION
## Summary

`ci-test.yml` ran for **~590s** while the same suite takes **~12s locally**. Root cause: the default playbook surfaced the **mr-evidence** Cookiecutter template by **git URL** (`https://github.com/trivoallan/regis`), so every `regis analyze` ran `git clone` of the entire regis repo — to fetch a template regis **already ships** (`regis/cookiecutters/mr-evidence`). On CI runners (cold cookiecutter cache, slow/blocked git egress) that clone hung **~25s per test**, silently swallowed by an `except`, across ~24 analyze tests ≈ ~10 minutes. Invisible locally because `~/.cookiecutters/` caches the clone (reproduced by clearing the cache: one test went 0.1s → 61s).

## Changes

- Presentation templates may declare **`package`** (an installed Python package) instead of **`url`**. The renderer resolves `importlib.resources.files(package) / directory` to a local path and renders in place — **no clone, no network**. The `url` form still works for third-party remote templates.
- Default playbook uses `package: regis` + `directory: cookiecutters/mr-evidence`.
- Schemas (`playbook v1alpha1`, `result`) accept `url` **or** `package`.
- `tests/conftest.py`: autouse guard that **rejects any remote Cookiecutter clone** in tests (fail fast, not a 25s hang) — regression net.
- Tests for local packaged-template resolution + a guard that the default playbook ships no remote `url`.

This also speeds up **every `regis analyze` in production** and removes its network dependency on the regis repo.

## Test Plan

- [ ] CI `pytest` job completes in well under a minute (was ~590s)
- [ ] `pipenv run pytest` green, coverage ≥ 90% (locally: 639 passed, 92% coverage, ~19s with cookiecutter cache cleared)
- [ ] `regis analyze` with the default playbook renders mr-evidence with no network access

🤖 Generated with [Claude Code](https://claude.com/claude-code)