### PR TITLE
ci(docs): serve Pages from a build artifact, stop gh-pages branch growth

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -33,7 +33,6 @@ jobs:
     environment: docs-production
     permissions:
       contents: write
-      pages: write
       pull-requests: write
     steps:
       - name: Generate GitHub App token
@@ -270,24 +269,29 @@ jobs:
             docs/website/docs/reference/schemas/**
             docs/website/static/schemas/**
 
-      - name: Deploy docs to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        with:
-          personal_token: ${{ steps.generate-token.outputs.token }}
-          publish_dir: docs/website/build
-          destination_dir: docs
-          keep_files: true
-          user_name: regis-ci[bot]
-          user_email: regis-ci[bot]@users.noreply.github.com
-          commit_message: "ci(docs): deploy documentation"
+      - name: Assemble Pages site
+        run: |
+          set -euo pipefail
+          rm -rf _site
+          mkdir -p _site/docs
+          cp -r docs/website/build/. _site/docs/
+          cp -r .github/pages-root/. _site/
 
-      - name: Deploy root redirect to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          personal_token: ${{ steps.generate-token.outputs.token }}
-          publish_dir: .github/pages-root
-          destination_dir: .
-          keep_files: true
-          user_name: regis-ci[bot]
-          user_email: regis-ci[bot]@users.noreply.github.com
-          commit_message: "ci(docs): deploy root redirect"
+          path: _site
+
+  deploy-pages:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -120,3 +120,24 @@ jobs:
           fi
 
           echo "All top-level workflow actions are pinned by SHA."
+
+  generated-artifacts-guard:
+    name: No Generated Artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reject committed build artifacts
+        run: |
+          set -euo pipefail
+
+          matches="$(git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**')"
+          if [ -n "$matches" ]; then
+            echo "::error::Generated documentation artifacts must not be committed. GitHub Pages is served from a CI build artifact, not from tracked files."
+            echo "$matches"
+            exit 1
+          fi
+          echo "No generated documentation artifacts committed."

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ thoughts/
 
 # Docusaurus
 .docusaurus
+# GitHub Pages assembly (built in CI, never committed)
+_site/
 regis-archive-ui/
 
 # Dashboard

--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -66,10 +66,13 @@ artifact** (`actions/upload-pages-artifact` + `actions/deploy-pages` in
 `gh-pages` branch: it previously accumulated every deploy commit under
 `keep_files: true` and grew the default clone to ~326 MB. The Docusaurus build
 output is **never committed** — `ci-lint.yml`'s `generated-artifacts-guard` job
-fails any PR that tracks `**/search-index.json`, `docs/v*/**`, `_site/**`, or
+fails any PR that tracks `**/search-index.json`, `docs/v<N>*/`, `_site/**`, or
 `docs/website/build/**`. Only the latest 3 doc versions + `next` are served
 (matching `release-snapshot.yml`'s 3-version source pruning). GitHub Pages
 **Source** must be set to _GitHub Actions_ in repo Settings → Pages.
+`actions/upload-pages-artifact` strips dotfiles (e.g. `.nojekyll`) by default,
+which is harmless here because a GitHub Actions Pages source does not invoke
+Jekyll.
 
 ## Mémoire & artefacts de planification — taxonomie
 

--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -59,6 +59,19 @@ Backward compatibility: the legacy `rule:` entry key and `rule.*` condition name
 - **Auto-rebase + squash merge no-op**: if a fix branch is auto-rebased after `main` already contains the same change, the squash merge becomes a no-op. Always branch from the latest `main` immediately before committing.
 - **mypy** is excluded for `tests/**` (crashes on Linux CI with stale cache on `http.server`).
 
+### Docs hosting — Pages served from an artifact (no `gh-pages` branch)
+
+The published documentation site is deployed from a **GitHub Actions build
+artifact** (`actions/upload-pages-artifact` + `actions/deploy-pages` in
+`cd-docs.yml`), **not** from a `gh-pages` branch. There is intentionally no
+`gh-pages` branch: it previously accumulated every deploy commit under
+`keep_files: true` and grew the default clone to ~326 MB. The Docusaurus build
+output is **never committed** — `ci-lint.yml`'s `generated-artifacts-guard` job
+fails any PR that tracks `**/search-index.json`, `docs/v*/**`, `_site/**`, or
+`docs/website/build/**`. Only the latest 3 doc versions + `next` are served
+(matching `release-snapshot.yml`'s 3-version source pruning). GitHub Pages
+**Source** must be set to *GitHub Actions* in repo Settings → Pages.
+
 ## Mémoire & artefacts de planification — taxonomie
 
 Tout artefact de mémoire se range selon deux axes : **portée** (local à un repo /

--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -51,7 +51,6 @@ Backward compatibility: the legacy `rule:` entry key and `rule.*` condition name
 - **`ci-test.yml`** includes `pip-audit` and enforces a HIGH/CRITICAL severity gate via `scripts/enforce_pip_audit_severity.py` (severity is resolved from OSV metadata).
 - **`cd-docker.yml`** emits CycloneDX/SPDX SBOM artifacts and provenance attestations via `actions/attest-build-provenance`.
 - **GitHub App authentication**: All workflows use `actions/create-github-app-token@v1` with `REGIS_CI_APP_ID` + `REGIS_CI_APP_PRIVATE_KEY`. Never use `GITHUB_TOKEN` for checkouts that need to trigger downstream CI runs — it won't.
-- **`peaceiris/actions-gh-pages`** with the App token requires `personal_token:`, not `github_token:`.
 - **Trunk auto-fmt in CI**: the trunk workflow commits formatting fixes via `stefanzweifel/git-auto-commit-action`. The checkout must use the App token so the commit triggers a new workflow run.
 - **Trunk pre-commit**: locally, `trunk-check-fix-pre-commit` runs `trunk check --fix` on `git commit`. Commit the auto-fixed files it produces.
 - **Dependabot PRs + secrets**: workflows triggered by Dependabot via `pull_request` run with read-only `GITHUB_TOKEN` and no secrets. Use `pull_request_target` for any workflow that must act on Dependabot PRs (safe when no PR code is checked out).
@@ -70,7 +69,7 @@ output is **never committed** — `ci-lint.yml`'s `generated-artifacts-guard` jo
 fails any PR that tracks `**/search-index.json`, `docs/v*/**`, `_site/**`, or
 `docs/website/build/**`. Only the latest 3 doc versions + `next` are served
 (matching `release-snapshot.yml`'s 3-version source pruning). GitHub Pages
-**Source** must be set to *GitHub Actions* in repo Settings → Pages.
+**Source** must be set to _GitHub Actions_ in repo Settings → Pages.
 
 ## Mémoire & artefacts de planification — taxonomie
 

--- a/docs/superpowers/plans/2026-06-08-repo-slimming-gh-pages.md
+++ b/docs/superpowers/plans/2026-06-08-repo-slimming-gh-pages.md
@@ -1,0 +1,355 @@
+# Repo Slimming (gh-pages → artifact) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink the default clone of `regis` from ~326 MB to ~35 MB by serving GitHub Pages from a build artifact instead of a `gh-pages` branch, deleting that branch, and guarding against future build-artifact commits.
+
+**Architecture:** Three workstreams. WS3 (guardrails) + WS1 (CI rework to artifact-based Pages) land together in one PR — these are reversible and protect `main`. After that PR is merged and the live site is verified, WS2 (destructive branch deletion) runs from the CLI. `main` history is never rewritten.
+
+**Tech Stack:** GitHub Actions (`actions/upload-pages-artifact`, `actions/deploy-pages`), Docusaurus, Git, Bash. No application code (`regis/`) changes.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md`
+
+---
+
+## File Structure
+
+- `.github/workflows/cd-docs.yml` — **modify.** Replace the two `peaceiris/actions-gh-pages` deploy steps with an artifact upload in the build job + a new `deploy-pages` job. (WS1)
+- `.github/workflows/ci-lint.yml` — **modify.** Add a `generated-artifacts-guard` job that fails if build artifacts are committed. (WS3)
+- `.gitignore` — **modify.** Add `_site/`. (WS3)
+- `docs/memory-bank/systemPatterns.md` — **modify.** Document the new Pages model. (WS3)
+- Operational (no repo file): mirror backup, GitHub Pages settings flip, branch deletions. (Task 0, Task 4)
+
+---
+
+## Task 0: Safety backup (operational, do first)
+
+**Files:** none (creates a local mirror outside the repo).
+
+- [ ] **Step 1: Create a full mirror backup of origin**
+
+This preserves every branch (including `gh-pages` and all old published doc versions) before any destructive operation.
+
+Run:
+```bash
+git clone --mirror https://github.com/trivoallan/regis.git ~/regis-mirror-backup-2026-06-08.git
+```
+Expected: a bare mirror repo is created; `Cloning into bare repository ...` finishes without error.
+
+- [ ] **Step 2: Verify the backup is a complete bare mirror**
+
+Run:
+```bash
+git -C ~/regis-mirror-backup-2026-06-08.git rev-parse --is-bare-repository \
+  && git -C ~/regis-mirror-backup-2026-06-08.git show-ref --verify refs/heads/gh-pages
+```
+Expected: prints `true` then a SHA line for `refs/heads/gh-pages` (proves `gh-pages` is captured).
+
+---
+
+## Task 1: WS3 — `.gitignore` + generated-artifacts CI guard
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `.github/workflows/ci-lint.yml`
+
+- [ ] **Step 1: Add `_site/` to `.gitignore`**
+
+`build/` (line 6) already ignores `docs/website/build/`, and `.docusaurus` (line 42) covers the Docusaurus cache. Only the new Pages assembly dir needs adding. Under the `# Docusaurus` section, change:
+
+```gitignore
+# Docusaurus
+.docusaurus
+```
+to:
+```gitignore
+# Docusaurus
+.docusaurus
+
+# GitHub Pages assembly (built in CI, never committed)
+_site/
+```
+
+- [ ] **Step 2: Verify the guard logic passes on the current (clean) tree**
+
+This is the exact command the new CI job will run. It must currently find nothing.
+
+Run:
+```bash
+git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**'
+```
+Expected: **no output** (empty). If anything prints, stop — there is already a committed artifact to remove first.
+
+- [ ] **Step 3: Verify the guard logic fails on a planted artifact**
+
+Run:
+```bash
+mkdir -p docs/website/build && echo x > docs/website/build/index.html && git add -f docs/website/build/index.html
+git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**'
+git rm --cached docs/website/build/index.html && rm -rf docs/website/build
+```
+Expected: the middle command prints `docs/website/build/index.html` (guard would fail), then cleanup restores a clean tree.
+
+- [ ] **Step 4: Add the `generated-artifacts-guard` job to `ci-lint.yml`**
+
+Append this job at the end of the `jobs:` block (sibling of `workflow-action-pinning`). The `checkout` SHA matches the one already used elsewhere in this file.
+
+```yaml
+  generated-artifacts-guard:
+    name: No Generated Artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reject committed build artifacts
+        run: |
+          set -euo pipefail
+
+          matches="$(git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**')"
+          if [ -n "$matches" ]; then
+            echo "::error::Generated documentation artifacts must not be committed. GitHub Pages is served from a CI build artifact, not from tracked files."
+            echo "$matches"
+            exit 1
+          fi
+          echo "No generated documentation artifacts committed."
+```
+
+- [ ] **Step 5: Verify the workflow still parses and actions stay pinned**
+
+Run:
+```bash
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci-lint.yml')); print('yaml ok')"
+grep -REn 'uses:\s*[^[:space:]]+@(v[0-9]+|main|master|latest)\b' .github/workflows/ci-lint.yml || echo "all actions pinned by SHA"
+```
+Expected: `yaml ok` then `all actions pinned by SHA`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .gitignore .github/workflows/ci-lint.yml
+git commit -m "ci(docs): guard against committed build artifacts"
+```
+
+---
+
+## Task 2: WS1 — Serve Pages from an artifact in `cd-docs.yml`
+
+**Files:**
+- Modify: `.github/workflows/cd-docs.yml`
+
+Context: today the single `build-and-deploy` job (environment `docs-production`, which gates the `REGIS_CI_*` secrets) builds the site and pushes it to `gh-pages` via two `peaceiris` steps using `keep_files: true`. We keep the build job for the secrets, have it **upload** the assembled site as a Pages artifact, and add a second job that **deploys** it under the `github-pages` environment (required by `actions/deploy-pages`, which authenticates via OIDC). The job id `build-and-deploy` is kept unchanged so branch-protection required checks keep matching.
+
+- [ ] **Step 1: Drop the now-unused `pages: write` from the build job permissions**
+
+The build job no longer pushes to Pages directly (the new `deploy-pages` job does). In the `build-and-deploy` job, change:
+
+```yaml
+    permissions:
+      contents: write
+      pages: write
+      pull-requests: write
+```
+to:
+```yaml
+    permissions:
+      contents: write
+      pull-requests: write
+```
+
+- [ ] **Step 2: Replace the two `peaceiris` deploy steps with site assembly + artifact upload**
+
+Delete both steps (`- name: Deploy docs to GitHub Pages` and `- name: Deploy root redirect to GitHub Pages`, including their `peaceiris/actions-gh-pages@...` blocks). Replace them with the two steps below. The assembly reproduces today's published layout exactly: the Docusaurus build under `/docs`, the root redirect at `/`.
+
+```yaml
+      - name: Assemble Pages site
+        run: |
+          set -euo pipefail
+          rm -rf _site
+          mkdir -p _site/docs
+          cp -r docs/website/build/. _site/docs/
+          cp -r .github/pages-root/. _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+```
+
+- [ ] **Step 3: Add the `deploy-pages` job**
+
+Append this job after `build-and-deploy` (sibling under `jobs:`). It is the only place that needs `id-token: write` (OIDC) and the `github-pages` environment.
+
+```yaml
+  deploy-pages:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+```
+
+- [ ] **Step 4: Verify YAML parses, actions are pinned, and no `peaceiris`/`keep_files` remain**
+
+Run:
+```bash
+python -c "import yaml; d=yaml.safe_load(open('.github/workflows/cd-docs.yml')); print('jobs:', list(d['jobs'].keys()))"
+grep -REn 'uses:\s*[^[:space:]]+@(v[0-9]+|main|master|latest)\b' .github/workflows/cd-docs.yml || echo "all actions pinned by SHA"
+grep -nE 'peaceiris|keep_files|destination_dir|gh-pages' .github/workflows/cd-docs.yml || echo "no branch-push deploy remnants"
+```
+Expected: `jobs: ['build-and-deploy', 'deploy-pages']`, then `all actions pinned by SHA`, then `no branch-push deploy remnants`.
+
+- [ ] **Step 5: Confirm `release-snapshot.yml` does not write to `gh-pages`**
+
+Run:
+```bash
+grep -nE 'peaceiris|gh-pages|publish_dir|force_orphan' .github/workflows/release-snapshot.yml || echo "release-snapshot does not deploy to Pages — no change needed"
+```
+Expected: `release-snapshot does not deploy to Pages — no change needed`. If it does print a match, stop and adapt that workflow the same way before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/cd-docs.yml
+git commit -m "ci(docs)!: deploy GitHub Pages from a build artifact instead of the gh-pages branch"
+```
+
+---
+
+## Task 3: WS3 — Document the new model
+
+**Files:**
+- Modify: `docs/memory-bank/systemPatterns.md`
+
+- [ ] **Step 1: Locate the CI/CD gotchas section**
+
+Run:
+```bash
+grep -nE 'gh-pages|Pages|CI/CD|Trunk auto-fmt|Workflow gotchas' docs/memory-bank/systemPatterns.md | head
+```
+Expected: one or more line numbers near the CI/CD notes. Add the new note immediately after that section's heading.
+
+- [ ] **Step 2: Add the Pages-model note**
+
+Insert this paragraph in the CI/CD area:
+
+```markdown
+### Docs hosting — Pages served from an artifact (no `gh-pages` branch)
+
+The published documentation site is deployed from a **GitHub Actions build
+artifact** (`actions/upload-pages-artifact` + `actions/deploy-pages` in
+`cd-docs.yml`), **not** from a `gh-pages` branch. There is intentionally no
+`gh-pages` branch: it previously accumulated every deploy commit under
+`keep_files: true` and grew the default clone to ~326 MB. The Docusaurus build
+output is **never committed** — `ci-lint.yml`'s `generated-artifacts-guard` job
+fails any PR that tracks `**/search-index.json`, `docs/v*/**`, `_site/**`, or
+`docs/website/build/**`. Only the latest 3 doc versions + `next` are served
+(matching `release-snapshot.yml`'s 3-version source pruning). GitHub Pages
+**Source** must be set to *GitHub Actions* in repo Settings → Pages.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/memory-bank/systemPatterns.md
+git commit -m "docs(memory-bank): record artifact-based Pages model"
+```
+
+---
+
+## Task 4: Land WS1+WS3 and flip the Pages source (operational)
+
+**Files:** none (PR + GitHub settings + live verification).
+
+- [ ] **Step 1: Set GitHub Pages source to GitHub Actions**
+
+In the browser: repo **Settings → Pages → Build and deployment → Source → "GitHub Actions"**. This can be done before merge; the new `deploy-pages` job fails until it is set.
+
+- [ ] **Step 2: Open the PR for the WS1+WS3 commits**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "ci(docs): serve Pages from artifact, drop gh-pages branch growth" \
+  --body "Implements docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md (WS1 + WS3). WS2 branch deletion follows after the live site is verified."
+```
+Expected: a PR URL is printed.
+
+- [ ] **Step 3: Merge after CI is green, then verify the live site**
+
+After merge, the `CD / Docs` workflow runs. Verify in the browser at the published URL:
+- the documentation site loads under `…/regis/docs/`;
+- the root `…/regis/` redirect works;
+- the version dropdown shows the 3 current versions + `next`.
+
+Also confirm the deploy no longer touches the branch:
+```bash
+git ls-remote origin 'refs/heads/gh-pages'
+```
+Expected after a post-merge docs run: `gh-pages` still exists (old branch, now stale) but received **no new commit** from this run — confirm via the Actions log that the `deploy-pages` job ran instead of a branch push. (The branch itself is removed in Task 5.)
+
+---
+
+## Task 5: WS2 — Delete `gh-pages` and dead branches (operational, destructive)
+
+**Files:** none (remote/local ref deletions). **Pre-condition:** Task 4 complete, live site verified, Task 0 backup confirmed.
+
+- [ ] **Step 1: Delete the `gh-pages` branch on origin**
+
+```bash
+git push origin --delete gh-pages
+```
+Expected: `- [deleted]   gh-pages`. This is the ~8.5 GB win — new clones stop fetching it immediately.
+
+- [ ] **Step 2: Delete dead experiment / merged branches on origin**
+
+Delete only after eyeballing each. The first two are already merged into `main`; the others are dead experiments.
+```bash
+git push origin --delete claude/pip-audit-error-resolution-EMrSz
+git push origin --delete copilot/fix-failing-checks
+git push origin --delete caca       || echo "caca not on origin (local-only) — skip"
+git push origin --delete nodogfood  || echo "nodogfood not on origin (local-only) — skip"
+```
+Expected: `[deleted]` lines (or the skip message for local-only branches).
+
+> Note: leave `origin/docs/latest-generated` alone — it is auto-recreated by `cd-docs.yml`'s `create-pull-request` step and its unique objects are negligible (it is `main` + a few generated files). Deleting it yields no lasting size benefit.
+
+- [ ] **Step 3: Prune merged local branches**
+
+```bash
+git branch -D caca nodogfood 2>/dev/null || true
+git branch --merged main | grep -E 'tritri/' | xargs -r -n1 git branch -d
+```
+Expected: merged `tritri/*` branches are deleted; any still-unmerged or checked-out-in-a-worktree ones are skipped by `git branch -d` (safe — it refuses non-merged).
+
+- [ ] **Step 4: Verify a fresh clone is small**
+
+A clone only transfers **reachable** objects, so deleting `gh-pages` shrinks new clones immediately — even before GitHub's server-side `gc`.
+
+```bash
+tmp="$(mktemp -d)"
+git clone --bare https://github.com/trivoallan/regis.git "$tmp/regis.git"
+du -sh "$tmp/regis.git"
+rm -rf "$tmp"
+```
+Expected: `.git` size around **~35–50 MB** (down from ~326 MB). If it is still large, re-check that `gh-pages` was actually deleted on origin (`git ls-remote origin 'refs/heads/gh-pages'` should print nothing).
+
+- [ ] **Step 5: Record completion**
+
+No commit needed (operational task). Note in the PR / tracking that server-side disk reclamation completes after GitHub's automatic `gc` (typically a few days); client clone size is already reduced.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** WS1 → Task 2; WS2 → Task 5; WS3 → Tasks 1 (gitignore+guard) & 3 (doc); backup → Task 0; manual Pages setting → Task 4 Step 1; verification → Task 4 Step 3 + Task 5 Step 4; rollback → backup (Task 0) + revertable workflow PR (Task 4). All spec sections mapped.
+- **Old-version risk** (spec "Risques"): accepted; old versions preserved in the Task 0 mirror.
+- **Naming consistency:** job ids `build-and-deploy` (kept) and `deploy-pages` (new) used identically across Task 2 steps; guard patterns identical in Task 1 Step 2/4 and the systemPatterns note.

--- a/docs/superpowers/plans/2026-06-08-repo-slimming-gh-pages.md
+++ b/docs/superpowers/plans/2026-06-08-repo-slimming-gh-pages.md
@@ -31,18 +31,22 @@
 This preserves every branch (including `gh-pages` and all old published doc versions) before any destructive operation.
 
 Run:
+
 ```bash
 git clone --mirror https://github.com/trivoallan/regis.git ~/regis-mirror-backup-2026-06-08.git
 ```
+
 Expected: a bare mirror repo is created; `Cloning into bare repository ...` finishes without error.
 
 - [ ] **Step 2: Verify the backup is a complete bare mirror**
 
 Run:
+
 ```bash
 git -C ~/regis-mirror-backup-2026-06-08.git rev-parse --is-bare-repository \
   && git -C ~/regis-mirror-backup-2026-06-08.git show-ref --verify refs/heads/gh-pages
 ```
+
 Expected: prints `true` then a SHA line for `refs/heads/gh-pages` (proves `gh-pages` is captured).
 
 ---
@@ -50,6 +54,7 @@ Expected: prints `true` then a SHA line for `refs/heads/gh-pages` (proves `gh-pa
 ## Task 1: WS3 — `.gitignore` + generated-artifacts CI guard
 
 **Files:**
+
 - Modify: `.gitignore`
 - Modify: `.github/workflows/ci-lint.yml`
 
@@ -61,7 +66,9 @@ Expected: prints `true` then a SHA line for `refs/heads/gh-pages` (proves `gh-pa
 # Docusaurus
 .docusaurus
 ```
+
 to:
+
 ```gitignore
 # Docusaurus
 .docusaurus
@@ -75,19 +82,23 @@ _site/
 This is the exact command the new CI job will run. It must currently find nothing.
 
 Run:
+
 ```bash
 git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**'
 ```
+
 Expected: **no output** (empty). If anything prints, stop — there is already a committed artifact to remove first.
 
 - [ ] **Step 3: Verify the guard logic fails on a planted artifact**
 
 Run:
+
 ```bash
 mkdir -p docs/website/build && echo x > docs/website/build/index.html && git add -f docs/website/build/index.html
 git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**'
 git rm --cached docs/website/build/index.html && rm -rf docs/website/build
 ```
+
 Expected: the middle command prints `docs/website/build/index.html` (guard would fail), then cleanup restores a clean tree.
 
 - [ ] **Step 4: Add the `generated-artifacts-guard` job to `ci-lint.yml`**
@@ -95,35 +106,37 @@ Expected: the middle command prints `docs/website/build/index.html` (guard would
 Append this job at the end of the `jobs:` block (sibling of `workflow-action-pinning`). The `checkout` SHA matches the one already used elsewhere in this file.
 
 ```yaml
-  generated-artifacts-guard:
-    name: No Generated Artifacts
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+generated-artifacts-guard:
+  name: No Generated Artifacts
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Reject committed build artifacts
-        run: |
-          set -euo pipefail
+    - name: Reject committed build artifacts
+      run: |
+        set -euo pipefail
 
-          matches="$(git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**')"
-          if [ -n "$matches" ]; then
-            echo "::error::Generated documentation artifacts must not be committed. GitHub Pages is served from a CI build artifact, not from tracked files."
-            echo "$matches"
-            exit 1
-          fi
-          echo "No generated documentation artifacts committed."
+        matches="$(git ls-files -- '**/search-index.json' 'docs/v[0-9]*/**' '_site/**' 'docs/website/build/**')"
+        if [ -n "$matches" ]; then
+          echo "::error::Generated documentation artifacts must not be committed. GitHub Pages is served from a CI build artifact, not from tracked files."
+          echo "$matches"
+          exit 1
+        fi
+        echo "No generated documentation artifacts committed."
 ```
 
 - [ ] **Step 5: Verify the workflow still parses and actions stay pinned**
 
 Run:
+
 ```bash
 python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci-lint.yml')); print('yaml ok')"
 grep -REn 'uses:\s*[^[:space:]]+@(v[0-9]+|main|master|latest)\b' .github/workflows/ci-lint.yml || echo "all actions pinned by SHA"
 ```
+
 Expected: `yaml ok` then `all actions pinned by SHA`.
 
 - [ ] **Step 6: Commit**
@@ -138,6 +151,7 @@ git commit -m "ci(docs): guard against committed build artifacts"
 ## Task 2: WS1 — Serve Pages from an artifact in `cd-docs.yml`
 
 **Files:**
+
 - Modify: `.github/workflows/cd-docs.yml`
 
 Context: today the single `build-and-deploy` job (environment `docs-production`, which gates the `REGIS_CI_*` secrets) builds the site and pushes it to `gh-pages` via two `peaceiris` steps using `keep_files: true`. We keep the build job for the secrets, have it **upload** the assembled site as a Pages artifact, and add a second job that **deploys** it under the `github-pages` environment (required by `actions/deploy-pages`, which authenticates via OIDC). The job id `build-and-deploy` is kept unchanged so branch-protection required checks keep matching.
@@ -147,16 +161,18 @@ Context: today the single `build-and-deploy` job (environment `docs-production`,
 The build job no longer pushes to Pages directly (the new `deploy-pages` job does). In the `build-and-deploy` job, change:
 
 ```yaml
-    permissions:
-      contents: write
-      pages: write
-      pull-requests: write
+permissions:
+  contents: write
+  pages: write
+  pull-requests: write
 ```
+
 to:
+
 ```yaml
-    permissions:
-      contents: write
-      pull-requests: write
+permissions:
+  contents: write
+  pull-requests: write
 ```
 
 - [ ] **Step 2: Replace the two `peaceiris` deploy steps with site assembly + artifact upload**
@@ -164,18 +180,18 @@ to:
 Delete both steps (`- name: Deploy docs to GitHub Pages` and `- name: Deploy root redirect to GitHub Pages`, including their `peaceiris/actions-gh-pages@...` blocks). Replace them with the two steps below. The assembly reproduces today's published layout exactly: the Docusaurus build under `/docs`, the root redirect at `/`.
 
 ```yaml
-      - name: Assemble Pages site
-        run: |
-          set -euo pipefail
-          rm -rf _site
-          mkdir -p _site/docs
-          cp -r docs/website/build/. _site/docs/
-          cp -r .github/pages-root/. _site/
+- name: Assemble Pages site
+  run: |
+    set -euo pipefail
+    rm -rf _site
+    mkdir -p _site/docs
+    cp -r docs/website/build/. _site/docs/
+    cp -r .github/pages-root/. _site/
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: _site
+- name: Upload Pages artifact
+  uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+  with:
+    path: _site
 ```
 
 - [ ] **Step 3: Add the `deploy-pages` job**
@@ -183,37 +199,41 @@ Delete both steps (`- name: Deploy docs to GitHub Pages` and `- name: Deploy roo
 Append this job after `build-and-deploy` (sibling under `jobs:`). It is the only place that needs `id-token: write` (OIDC) and the `github-pages` environment.
 
 ```yaml
-  deploy-pages:
-    needs: build-and-deploy
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+deploy-pages:
+  needs: build-and-deploy
+  runs-on: ubuntu-latest
+  environment:
+    name: github-pages
+    url: ${{ steps.deployment.outputs.page_url }}
+  permissions:
+    pages: write
+    id-token: write
+  steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 ```
 
 - [ ] **Step 4: Verify YAML parses, actions are pinned, and no `peaceiris`/`keep_files` remain**
 
 Run:
+
 ```bash
 python -c "import yaml; d=yaml.safe_load(open('.github/workflows/cd-docs.yml')); print('jobs:', list(d['jobs'].keys()))"
 grep -REn 'uses:\s*[^[:space:]]+@(v[0-9]+|main|master|latest)\b' .github/workflows/cd-docs.yml || echo "all actions pinned by SHA"
 grep -nE 'peaceiris|keep_files|destination_dir|gh-pages' .github/workflows/cd-docs.yml || echo "no branch-push deploy remnants"
 ```
+
 Expected: `jobs: ['build-and-deploy', 'deploy-pages']`, then `all actions pinned by SHA`, then `no branch-push deploy remnants`.
 
 - [ ] **Step 5: Confirm `release-snapshot.yml` does not write to `gh-pages`**
 
 Run:
+
 ```bash
 grep -nE 'peaceiris|gh-pages|publish_dir|force_orphan' .github/workflows/release-snapshot.yml || echo "release-snapshot does not deploy to Pages — no change needed"
 ```
+
 Expected: `release-snapshot does not deploy to Pages — no change needed`. If it does print a match, stop and adapt that workflow the same way before continuing.
 
 - [ ] **Step 6: Commit**
@@ -228,14 +248,17 @@ git commit -m "ci(docs)!: deploy GitHub Pages from a build artifact instead of t
 ## Task 3: WS3 — Document the new model
 
 **Files:**
+
 - Modify: `docs/memory-bank/systemPatterns.md`
 
 - [ ] **Step 1: Locate the CI/CD gotchas section**
 
 Run:
+
 ```bash
 grep -nE 'gh-pages|Pages|CI/CD|Trunk auto-fmt|Workflow gotchas' docs/memory-bank/systemPatterns.md | head
 ```
+
 Expected: one or more line numbers near the CI/CD notes. Add the new note immediately after that section's heading.
 
 - [ ] **Step 2: Add the Pages-model note**
@@ -254,7 +277,7 @@ output is **never committed** — `ci-lint.yml`'s `generated-artifacts-guard` jo
 fails any PR that tracks `**/search-index.json`, `docs/v*/**`, `_site/**`, or
 `docs/website/build/**`. Only the latest 3 doc versions + `next` are served
 (matching `release-snapshot.yml`'s 3-version source pruning). GitHub Pages
-**Source** must be set to *GitHub Actions* in repo Settings → Pages.
+**Source** must be set to _GitHub Actions_ in repo Settings → Pages.
 ```
 
 - [ ] **Step 3: Commit**
@@ -281,19 +304,23 @@ git push -u origin HEAD
 gh pr create --base main --title "ci(docs): serve Pages from artifact, drop gh-pages branch growth" \
   --body "Implements docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md (WS1 + WS3). WS2 branch deletion follows after the live site is verified."
 ```
+
 Expected: a PR URL is printed.
 
 - [ ] **Step 3: Merge after CI is green, then verify the live site**
 
 After merge, the `CD / Docs` workflow runs. Verify in the browser at the published URL:
+
 - the documentation site loads under `…/regis/docs/`;
 - the root `…/regis/` redirect works;
 - the version dropdown shows the 3 current versions + `next`.
 
 Also confirm the deploy no longer touches the branch:
+
 ```bash
 git ls-remote origin 'refs/heads/gh-pages'
 ```
+
 Expected after a post-merge docs run: `gh-pages` still exists (old branch, now stale) but received **no new commit** from this run — confirm via the Actions log that the `deploy-pages` job ran instead of a branch push. (The branch itself is removed in Task 5.)
 
 ---
@@ -307,17 +334,20 @@ Expected after a post-merge docs run: `gh-pages` still exists (old branch, now s
 ```bash
 git push origin --delete gh-pages
 ```
+
 Expected: `- [deleted]   gh-pages`. This is the ~8.5 GB win — new clones stop fetching it immediately.
 
 - [ ] **Step 2: Delete dead experiment / merged branches on origin**
 
 Delete only after eyeballing each. The first two are already merged into `main`; the others are dead experiments.
+
 ```bash
 git push origin --delete claude/pip-audit-error-resolution-EMrSz
 git push origin --delete copilot/fix-failing-checks
 git push origin --delete caca       || echo "caca not on origin (local-only) — skip"
 git push origin --delete nodogfood  || echo "nodogfood not on origin (local-only) — skip"
 ```
+
 Expected: `[deleted]` lines (or the skip message for local-only branches).
 
 > Note: leave `origin/docs/latest-generated` alone — it is auto-recreated by `cd-docs.yml`'s `create-pull-request` step and its unique objects are negligible (it is `main` + a few generated files). Deleting it yields no lasting size benefit.
@@ -328,6 +358,7 @@ Expected: `[deleted]` lines (or the skip message for local-only branches).
 git branch -D caca nodogfood 2>/dev/null || true
 git branch --merged main | grep -E 'tritri/' | xargs -r -n1 git branch -d
 ```
+
 Expected: merged `tritri/*` branches are deleted; any still-unmerged or checked-out-in-a-worktree ones are skipped by `git branch -d` (safe — it refuses non-merged).
 
 - [ ] **Step 4: Verify a fresh clone is small**
@@ -340,6 +371,7 @@ git clone --bare https://github.com/trivoallan/regis.git "$tmp/regis.git"
 du -sh "$tmp/regis.git"
 rm -rf "$tmp"
 ```
+
 Expected: `.git` size around **~35–50 MB** (down from ~326 MB). If it is still large, re-check that `gh-pages` was actually deleted on origin (`git ls-remote origin 'refs/heads/gh-pages'` should print nothing).
 
 - [ ] **Step 5: Record completion**

--- a/docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md
+++ b/docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md
@@ -1,0 +1,144 @@
+# Spec — Alléger le dépôt `regis`
+
+- **Date** : 2026-06-08
+- **Statut** : validé (design approuvé), prêt pour planification
+- **Scope** : infrastructure dépôt / CI docs. Aucun changement au code applicatif `regis/`.
+
+## Problème
+
+Le clone par défaut du dépôt pèse **326 MB** (taille du `.git` packé), ce qui rend
+le clonage lourd. Diagnostic mesuré :
+
+| Périmètre | Poids objets (décompressé) |
+|---|---|
+| `main` seul | 138 MB |
+| Toutes refs **sauf** `gh-pages` | 143 MB |
+| `gh-pages` | **~8,5 GB** ← tout le poids est là |
+| `origin/docs/latest-generated` (branche générée) | 138 MB |
+
+**Cause racine n°1 — historique `gh-pages`.** La branche `gh-pages` accumule
+**284 commits de déploiement** (~8,5 GB d'objets, packés à ~290 MB). Un `git clone`
+récupère toutes les branches, dont `gh-pages` → c'est l'essentiel du poids du clone.
+
+**Cause racine n°2 — le robinet est ouvert.** `.github/workflows/cd-docs.yml` déploie
+avec `peaceiris/actions-gh-pages` en **`keep_files: true` et sans `force_orphan`** :
+chaque build **empile** un nouveau commit *et* conserve tous les anciens fichiers.
+La branche grossit sans borne (ex. 226 versions de `search-index.json` empilées).
+
+**Cause racine n°2 bis — versions périmées.** L'arbre actuel de `gh-pages` (dernier
+commit, hors historique) pèse déjà **826 MB / 20 236 fichiers** et contient **21 versions
+de docs** (`v0.19.0` → `v0.33.0` + `next`). Or `release-snapshot.yml` élague déjà la
+**source** à 3 versions (`while len(versions) > 3`). À cause de `keep_files: true`, les
+18 anciennes versions ne sont jamais supprimées de `gh-pages`.
+
+## Objectif
+
+- Clone par défaut : **326 MB → ~35 MB (~90 %)**.
+- Réduction **permanente** : aucune branche ne peut réaccumuler du build généré.
+- `main` et toutes les branches de travail **intouchés** (pas de réécriture
+  d'historique sur la ligne principale → aucun re-clone forcé, aucun rebase des PR
+  ouvertes nécessaire). La seule réécriture concerne `gh-pages`, qui est jetable et
+  régénérée par le CI.
+
+## Décisions actées
+
+1. **Réécriture d'historique** : acceptée, mais limitée à `gh-pages` (branche CI
+   jetable). `main` n'est pas réécrit.
+2. **Mécanisme de service Pages** : migration vers un déploiement **basé artefact**
+   (`actions/upload-pages-artifact` + `actions/deploy-pages`), **suppression de la
+   branche `gh-pages`**. C'est la prévention définitive : sans branche, rien ne peut
+   regonfler le clone. Le site ne sert plus que les 3 versions courantes + `next`,
+   ce qui est cohérent avec la politique d'élagage de la source.
+
+## Conception
+
+### WS1 — Refonte CI (prévention ; doit atterrir en premier)
+
+Cible : `.github/workflows/cd-docs.yml`.
+
+- Remplacer les **deux** étapes `peaceiris/actions-gh-pages` (`Deploy docs to GitHub
+  Pages` et `Deploy root redirect to GitHub Pages`) par un déploiement basé artefact :
+  1. Assembler un dossier unique `_site/` :
+     - `docs/website/build/` → `_site/docs/`
+     - `.github/pages-root/*` → `_site/` (préserver `CNAME`/redirect racine si présents)
+  2. `actions/upload-pages-artifact` avec `path: _site`.
+  3. `actions/deploy-pages` (job ou étape avec l'environment `github-pages`).
+- Permissions du job : ajouter `id-token: write` et conserver `pages: write` ;
+  `deploy-pages` s'authentifie via OIDC → retirer l'usage du token applicatif
+  (`personal_token`) pour le déploiement Pages.
+- Conserver l'étape `peter-evans/create-pull-request` (branche `docs/latest-generated`)
+  inchangée : elle synchronise les assets générés dans la source, ne touche pas Pages.
+- Vérifier que `release-snapshot.yml` n'écrit **pas** sur `gh-pages` (il ne fait que
+  versionner la source via `docusaurus docs:version`) → aucun changement attendu, à
+  confirmer pendant l'implémentation.
+- **Étape manuelle (utilisateur, hors git)** : GitHub → Settings → Pages → Source =
+  *GitHub Actions*. À coordonner avant le premier déploiement artefact.
+
+### WS2 — Nettoyage curatif (l'allègement effectif)
+
+Pré-condition : WS1 mergé **et** site vérifié live depuis l'artefact.
+
+- **Supprimer `gh-pages`** (origin + local) → ses ~8,5 GB d'objets deviennent
+  inatteignables.
+- Supprimer les branches mortes / générées, après confirmation au cas par cas pour les
+  non-évidentes :
+  - `origin/docs/latest-generated` (138 MB ; regénérée à chaque run du CI docs)
+  - `caca`, `nodogfood` (branches d'expérimentation)
+  - branches déjà mergées dans `main` : `origin/claude/pip-audit-error-resolution-*`,
+    `origin/copilot/fix-failing-checks`
+- Élaguer les branches locales `tritri/*` (39) mergées/abandonnées — **local only**,
+  risque nul.
+- **Nuance à documenter** : le clone *vécu par les utilisateurs* maigrit **dès** la
+  suppression de `gh-pages` (un client ne fetch pas une branche supprimée). Le **pack
+  côté serveur** ne rétrécit qu'après le `gc` automatique de GitHub (quelques jours ;
+  pas de `gc` manuel exposé). Optionnel : ouvrir un ticket GitHub Support pour forcer
+  un repack si le délai pose problème.
+
+### WS3 — Garde-fous (empêcher tout regonflement futur)
+
+- `.gitignore` : verrouiller les sorties de build :
+  `docs/website/build/`, `docs/website/.docusaurus/`, `_site/`.
+- Garde CI dans `ci-lint.yml` (ou check dédié) : **échoue si un commit sur `main`
+  ajoute** des fichiers aux signatures de généré : `**/search-index.json`,
+  `docs/v[0-9]*/**`, sorties de build Docusaurus. Empêche tout re-commit d'artefacts.
+- Documenter le modèle dans `docs/memory-bank/systemPatterns.md` : « Pages servi depuis
+  un artefact GitHub Actions, pas de branche `gh-pages` ; le build n'est jamais
+  committé ».
+
+## Séquencement & sécurité
+
+1. **Backup** : `git clone --mirror` de origin vers une archive locale, **avant** toute
+   opération destructive (filet de sécurité, conserve les vieilles versions publiées).
+2. **WS1** : PR → merge → réglage manuel Pages → vérifier le site live.
+3. **WS3** : peut atterrir avec WS1 (même PR ou PR jumelle).
+4. **WS2** : suppressions de branches → mesurer la taille de clone.
+
+## Vérification
+
+- **Après WS1** : le site charge à l'URL publiée ; le sélecteur de versions montre les
+  3 versions + `next` ; le redirect racine fonctionne ; `gh-pages` n'est plus écrite par
+  le CI.
+- **Après WS2** : `git clone --no-local` du dépôt dans un dossier temporaire → mesurer
+  la taille du `.git` (cible ~35 MB).
+
+## Rollback
+
+- **WS1** réversible : revert du workflow + rebascule de Pages Source sur « Deploy from
+  a branch ».
+- **WS2** récupérable depuis le mirror de backup (`git push` des refs supprimées).
+
+## Risques
+
+- Les URL des anciennes versions (`v0.19.0`…`v0.30.0`) cessent d'être servies — cohérent
+  avec la politique 3-versions de la source, mais 404 si un lien externe pointe dessus.
+  Mitigation : le mirror de backup les conserve ; republication possible si besoin.
+- Le réglage GitHub Pages (Source → GitHub Actions) est manuel, hors git → à coordonner
+  avec le merge de WS1.
+- Le rétrécissement du pack côté serveur dépend du timing du `gc` GitHub (non instantané).
+
+## Hors scope
+
+- Réécriture de l'historique de `main` (gain marginal : 138 MB, presque tout légitime ;
+  coût élevé : re-clone + rebase des PR). Explicitement écarté.
+- Réduction du working tree local (`node_modules/`, `htmlcov/`, etc.) : déjà `.gitignore`,
+  sans effet sur le clone.

--- a/docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md
+++ b/docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md
@@ -9,12 +9,12 @@
 Le clone par défaut du dépôt pèse **326 MB** (taille du `.git` packé), ce qui rend
 le clonage lourd. Diagnostic mesuré :
 
-| Périmètre | Poids objets (décompressé) |
-|---|---|
-| `main` seul | 138 MB |
-| Toutes refs **sauf** `gh-pages` | 143 MB |
-| `gh-pages` | **~8,5 GB** ← tout le poids est là |
-| `origin/docs/latest-generated` (branche générée) | 138 MB |
+| Périmètre                                        | Poids objets (décompressé)         |
+| ------------------------------------------------ | ---------------------------------- |
+| `main` seul                                      | 138 MB                             |
+| Toutes refs **sauf** `gh-pages`                  | 143 MB                             |
+| `gh-pages`                                       | **~8,5 GB** ← tout le poids est là |
+| `origin/docs/latest-generated` (branche générée) | 138 MB                             |
 
 **Cause racine n°1 — historique `gh-pages`.** La branche `gh-pages` accumule
 **284 commits de déploiement** (~8,5 GB d'objets, packés à ~290 MB). Un `git clone`
@@ -22,7 +22,7 @@ récupère toutes les branches, dont `gh-pages` → c'est l'essentiel du poids d
 
 **Cause racine n°2 — le robinet est ouvert.** `.github/workflows/cd-docs.yml` déploie
 avec `peaceiris/actions-gh-pages` en **`keep_files: true` et sans `force_orphan`** :
-chaque build **empile** un nouveau commit *et* conserve tous les anciens fichiers.
+chaque build **empile** un nouveau commit _et_ conserve tous les anciens fichiers.
 La branche grossit sans borne (ex. 226 versions de `search-index.json` empilées).
 
 **Cause racine n°2 bis — versions périmées.** L'arbre actuel de `gh-pages` (dernier
@@ -57,7 +57,7 @@ de docs** (`v0.19.0` → `v0.33.0` + `next`). Or `release-snapshot.yml` élague 
 Cible : `.github/workflows/cd-docs.yml`.
 
 - Remplacer les **deux** étapes `peaceiris/actions-gh-pages` (`Deploy docs to GitHub
-  Pages` et `Deploy root redirect to GitHub Pages`) par un déploiement basé artefact :
+Pages` et `Deploy root redirect to GitHub Pages`) par un déploiement basé artefact :
   1. Assembler un dossier unique `_site/` :
      - `docs/website/build/` → `_site/docs/`
      - `.github/pages-root/*` → `_site/` (préserver `CNAME`/redirect racine si présents)
@@ -72,7 +72,7 @@ Cible : `.github/workflows/cd-docs.yml`.
   versionner la source via `docusaurus docs:version`) → aucun changement attendu, à
   confirmer pendant l'implémentation.
 - **Étape manuelle (utilisateur, hors git)** : GitHub → Settings → Pages → Source =
-  *GitHub Actions*. À coordonner avant le premier déploiement artefact.
+  _GitHub Actions_. À coordonner avant le premier déploiement artefact.
 
 ### WS2 — Nettoyage curatif (l'allègement effectif)
 
@@ -88,7 +88,7 @@ Pré-condition : WS1 mergé **et** site vérifié live depuis l'artefact.
     `origin/copilot/fix-failing-checks`
 - Élaguer les branches locales `tritri/*` (39) mergées/abandonnées — **local only**,
   risque nul.
-- **Nuance à documenter** : le clone *vécu par les utilisateurs* maigrit **dès** la
+- **Nuance à documenter** : le clone _vécu par les utilisateurs_ maigrit **dès** la
   suppression de `gh-pages` (un client ne fetch pas une branche supprimée). Le **pack
   côté serveur** ne rétrécit qu'après le `gc` automatique de GitHub (quelques jours ;
   pas de `gc` manuel exposé). Optionnel : ouvrir un ticket GitHub Support pour forcer


### PR DESCRIPTION
## Summary

The default clone of `regis` weighs ~326 MB. Diagnosis: the `gh-pages` branch
accumulated **284 deploy commits (~8.5 GB of objects)** because `cd-docs.yml`
deployed with `peaceiris/actions-gh-pages` using `keep_files: true` and no
orphaning — every build stacked a new commit and kept every old file. `main` and
all work branches together are only ~143 MB; the weight is entirely `gh-pages`.

This PR fixes the **cause** so the branch can be retired (WS1 + WS3 of the spec).
The branch deletion itself (WS2) is a follow-up operational step, gated on this
merging and the live site being verified.

- **WS1** — `cd-docs.yml` now serves Pages from a **build artifact**
  (`actions/upload-pages-artifact` + `actions/deploy-pages`, OIDC) instead of
  pushing to a `gh-pages` branch. The `build-and-deploy` job assembles `_site/`
  (Docusaurus build → `/docs`, root redirect → `/`) and uploads it; a new
  `deploy-pages` job deploys it under the `github-pages` environment. No branch is
  written, so nothing can re-accumulate.
- **WS3** — a `generated-artifacts-guard` job in `ci-lint.yml` fails any PR that
  commits build output (`**/search-index.json`, `docs/v[0-9]*/**`, `_site/**`,
  `docs/website/build/**`); `.gitignore` gains `_site/`; the model is documented in
  `systemPatterns.md`.

Only the 3 current doc versions + `next` are served, matching
`release-snapshot.yml`'s existing 3-version source pruning.

Spec & plan: `docs/superpowers/specs/2026-06-08-repo-slimming-gh-pages-design.md`.

## ⚠️ Required before merge (manual, one-time)

Set **Settings → Pages → Build and deployment → Source = "GitHub Actions"**.
If merged before this, the first post-merge `deploy-pages` job will fail (Pages not
yet configured for the Actions source).

## Follow-up after merge (WS2, operational)

Once the live site is verified from the artifact: take a `git clone --mirror`
backup, then delete `gh-pages` and dead branches on origin. New clones drop to
~35 MB immediately; server-side disk reclaims after GitHub's gc.

## Test Plan

- [ ] CI green (incl. `generated-artifacts-guard` + `workflow-action-pinning`)
- [ ] Pages Source set to "GitHub Actions"
- [ ] After merge: docs site loads under `…/regis/docs/`, root redirect works, version dropdown shows 3 versions + `next`
- [ ] `cd-docs` run uses the `deploy-pages` job (no branch push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)