### PR TITLE
test(popularity): mock Docker Hub to de-flake the live analyzer test

### DIFF
--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1,5 +1,10 @@
 """Tests for the popularity analyzer."""
 
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from regis.analyzers.popularity import PopularityAnalyzer
 
 
@@ -16,10 +21,19 @@ class MockRegistryClient:
 
 class TestPopularityAnalyzer:
     def test_official_image(self):
-        """Live test — Docker Hub should respond for library/nginx."""
+        """Docker Hub stats are parsed for an official image (mocked response)."""
         client = MockRegistryClient()
         analyzer = PopularityAnalyzer()
-        report = analyzer.analyze(client, "library/nginx", "latest")
+        with patch("requests.get") as m:
+            m.return_value = MagicMock(status_code=200)
+            m.return_value.json.return_value = {
+                "pull_count": 1_000_000_000,
+                "star_count": 19000,
+                "description": "Official build of Nginx.",
+                "last_updated": "2026-01-01T00:00:00Z",
+                "date_registered": "2014-06-05T00:00:00Z",
+            }
+            report = analyzer.analyze(client, "library/nginx", "latest")
         analyzer.validate(report)
 
         assert report["available"] is True
@@ -28,9 +42,39 @@ class TestPopularityAnalyzer:
         assert report["star_count"] > 0
 
     def test_nonexistent_image(self):
+        """A 404 from Docker Hub yields an unavailable report (mocked response)."""
         client = MockRegistryClient()
         analyzer = PopularityAnalyzer()
-        report = analyzer.analyze(client, "fakens/nonexistent-xyz", "latest")
+        with patch("requests.get") as m:
+            m.return_value = MagicMock(status_code=404)
+            report = analyzer.analyze(client, "fakens/nonexistent-xyz", "latest")
         analyzer.validate(report)
 
         assert report["available"] is False
+        assert report["is_official"] is False
+
+    def test_request_failure_is_handled(self):
+        """A network exception yields an unavailable report, never raising."""
+        client = MockRegistryClient()
+        analyzer = PopularityAnalyzer()
+        with patch("requests.get", side_effect=Exception("network down")):
+            report = analyzer.analyze(client, "library/nginx", "latest")
+        analyzer.validate(report)
+
+        assert report["available"] is False
+        assert report["is_official"] is True
+
+    @pytest.mark.skipif(
+        os.environ.get("REGIS_LIVE_TESTS") != "1",
+        reason="Live Docker Hub test; set REGIS_LIVE_TESTS=1 to run.",
+    )
+    def test_official_image_live(self):
+        """Opt-in live test — hits Docker Hub for library/nginx."""
+        client = MockRegistryClient()
+        analyzer = PopularityAnalyzer()
+        report = analyzer.analyze(client, "library/nginx", "latest")
+        analyzer.validate(report)
+
+        assert report["available"] is True
+        assert report["pull_count"] > 0
+        assert report["star_count"] > 0


### PR DESCRIPTION
## Summary

`tests/test_popularity.py` made **live network calls to Docker Hub** and asserted `available is True` / `pull_count > 0`. A transient API blip or rate-limit flips `available` to `False`, failing CI for unrelated PRs — it just failed the **0.35.0 release PR** ([job](https://github.com/trivoallan/regis/actions/runs/27158523686/job/80167545723)).

This makes the unit tests deterministic:
- `test_official_image` / `test_nonexistent_image` now mock `requests.get` (200 with fixed stats / 404), following the existing `test_analyzer_scorecard.py` pattern.
- Adds `test_request_failure_is_handled` covering the `except` branch (network error → unavailable, never raises).
- Keeps a real Docker Hub call as an **opt-in** live test, gated on `REGIS_LIVE_TESTS=1` (skipped by default).

No analyzer code changes. Same or better line coverage (the exception branch is now exercised).

## Test Plan

- [x] `pytest tests/test_popularity.py --no-cov -v` → 3 passed, 1 skipped, 0.07s, no network
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)