### PR TITLE
test(coverage): enforce a per-file 90% coverage gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ vendor/
 coverage/
 .cache/
 tmp/
+
+coverage.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ Never modify `RULES.md` or write secrets into any memory bank file.
 
 ```bash
 pipenv install --dev          # Install all dependencies
-pipenv run pytest             # Full run with coverage (fails if < 90%)
-pipenv run pytest --no-cov    # Fast loop — no coverage check
+pipenv run pytest             # Full run with coverage (fails if total < 90% OR any file < 90%)
+pipenv run pytest --no-cov    # Fast loop — disables both the global and per-file coverage gates
 pipenv run ruff check .       # Lint
 pipenv run ruff format .      # Format
 pipenv run regis --help       # Run CLI locally
@@ -27,6 +27,11 @@ pnpm --filter @regis/dashboard build   # Build viewer SPA
 ```
 
 Required external binaries (must be on `PATH`): `grype`, `syft`, `trufflehog`, `regctl`, `hadolint`, `dockle`.
+
+Coverage is enforced at two levels by `tests/_per_file_coverage.py` (loaded via `tests/conftest.py`): a global
+`--cov-fail-under=90` gate and a per-file gate that fails if any single source file under `regis/` is below 90%.
+The threshold for both is `[tool.coverage.report].fail_under` in `pyproject.toml`. `tests/` is excluded from
+measurement; zero-statement files are skipped. `--no-cov` disables both gates.
 
 Use `--no-cov` for fast iteration; run the full suite before opening a PR.
 

--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -46,6 +46,19 @@ Backward compatibility: the legacy `rule:` entry key and `rule.*` condition name
 - **Documentation**: Docusaurus for documentation as code.
 - **Aesthetics**: High priority on visual excellence for HTML reports.
 
+### Couverture de tests — double gate (global + par fichier)
+
+La suite `pipenv run pytest` applique deux niveaux de garde :
+
+1. **Global** : `--cov-fail-under=90` (paramètre pytest standard, lu depuis `pyproject.toml`).
+2. **Par fichier** : `tests/_per_file_coverage.py` — plugin pytest maison enregistré via un
+   hookwrapper `pytest_sessionfinish` dans `tests/conftest.py`. Il parcourt le rapport de
+   couverture et fait échouer la session si un fichier sous `regis/` est en-dessous du seuil.
+
+Les deux gates lisent le même seuil : `[tool.coverage.report].fail_under` dans `pyproject.toml`.
+`tests/` est exclu de la mesure (pas de récursion). Les fichiers sans aucune instruction sont
+ignorés. `--no-cov` désactive les deux gates.
+
 ## CI/CD Gotchas
 
 - **`ci-test.yml`** includes `pip-audit` and enforces a HIGH/CRITICAL severity gate via `scripts/enforce_pip_audit_severity.py` (severity is resolved from OSV metadata).

--- a/docs/superpowers/plans/2026-06-08-per-file-coverage-gate.md
+++ b/docs/superpowers/plans/2026-06-08-per-file-coverage-gate.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `pipenv run pytest` fail when any single file under `regis/` is below 90 % coverage, after first raising the 8 currently-below-threshold files to ≥ 90 %.
 
-**Architecture:** coverage.py only enforces a *global* `fail_under`. We add a small pytest plugin (`tests/_per_file_coverage.py`, wired via `tests/conftest.py`) that, after pytest-cov writes its data, loads the coverage data, computes per-file percentages, and fails the session if any file is below the same threshold read from `[tool.coverage.report].fail_under`. Tasks 1–8 raise the 8 legacy files first so the gate (Task 9) goes green immediately. Task 10 documents it.
+**Architecture:** coverage.py only enforces a _global_ `fail_under`. We add a small pytest plugin (`tests/_per_file_coverage.py`, wired via `tests/conftest.py`) that, after pytest-cov writes its data, loads the coverage data, computes per-file percentages, and fails the session if any file is below the same threshold read from `[tool.coverage.report].fail_under`. Tasks 1–8 raise the 8 legacy files first so the gate (Task 9) goes green immediately. Task 10 documents it.
 
 **Tech Stack:** Python 3.10+, pytest, pytest-cov, coverage.py 7.x, `tomllib`. Tests mock at source module locations (project convention).
 
@@ -36,6 +36,7 @@ gate), otherwise the suite goes red. Do them worst-file-first.
 ### Task 1: Raise `regis/tools/cosign.py` (73.3 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/tools/test_cosign.py` (extend)
 - Under test: `regis/tools/cosign.py` (uncovered lines **29–46**)
 
@@ -109,6 +110,7 @@ git commit -m "test(tools): cover cosign verify-blob success and failure paths"
 ### Task 2: Raise `regis/commands/doctor.py` (73.8 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/commands/test_doctor.py` (extend)
 - Under test: `regis/commands/doctor.py` (uncovered **30–31, 33–35, 45–56**)
 
@@ -169,6 +171,7 @@ git commit -m "test(commands): cover doctor sha256 branches and version error pa
 ### Task 3: Raise `regis/utils/process.py` (75.0 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_utils_process.py` (extend)
 - Under test: `regis/utils/process.py` (uncovered **33–38, 60–62, 67–69, 73, 94–95, 98**)
 
@@ -249,6 +252,7 @@ git commit -m "test(utils): cover run_cmd errors and ensure_tool fetch paths"
 ### Task 4: Raise `regis/playbook/sections.py` (78.6 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_playbook_sections.py` (**create** — no dedicated test today)
 - Under test: `regis/playbook/sections.py` (uncovered **33–47, 159–160, 180, 187, 217, 237–265, 290, 292, 328–332, 338–342, 365, 377**)
 
@@ -344,6 +348,7 @@ git commit -m "test(playbook): cover sections scorecards, rule refs and final re
 ### Task 5: Raise `regis/analyzers/endoflife.py` (79.4 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_endoflife.py` (extend)
 - Under test: `regis/analyzers/endoflife.py` (uncovered **76, 99–108, 125, 173, 177**)
 
@@ -396,6 +401,7 @@ git commit -m "test(analyzers): cover endoflife fetch errors and eol derivation"
 ### Task 6: Raise `regis/playbook/evaluator.py` (83.2 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_playbook_evaluator.py` (**create**)
 - Under test: `regis/playbook/evaluator.py` (uncovered **40, 68–82, 150, 154–155, 237–238, 255–257, 267–269, 286**)
 
@@ -466,6 +472,7 @@ git commit -m "test(playbook): cover evaluator pages, links, tiers and badges"
 ### Task 7: Raise `regis/rules/evaluator.py` (84.7 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_rules_evaluator.py` (extend)
 - Under test: `regis/rules/evaluator.py` (uncovered **43, 56–63, 165–166, 195, 212–221, 234, 261, 266–279, 398–402**)
 
@@ -535,6 +542,7 @@ git commit -m "test(rules): cover interpolation, custom operators and merge path
 ### Task 8: Raise `regis/playbook/conditions.py` (87.8 % → ≥ 90 %)
 
 **Files:**
+
 - Test: `tests/test_playbook_conditions.py` (**create**)
 - Under test: `regis/playbook/conditions.py` (uncovered **47, 52–54, 89, 93**)
 
@@ -593,12 +601,13 @@ git commit -m "test(playbook): cover condition falsy/exception and stringify bra
 ### Task 9: Add the per-file coverage gate plugin
 
 **Files:**
+
 - Create: `tests/_per_file_coverage.py`
 - Modify: `tests/conftest.py` (register the `pytest_sessionfinish` hookwrapper)
 - Test: `tests/test_per_file_coverage.py` (create)
 
 **Design notes (validated during brainstorming):** a hookwrapper
-`pytest_sessionfinish` runs *after* pytest-cov has written `.coverage`; loading a
+`pytest_sessionfinish` runs _after_ pytest-cov has written `.coverage`; loading a
 fresh `coverage.Coverage()` then yields the same per-file percentages as the CLI
 report. The `--no-cov` no-op is detected via `option.no_cov` / `option.cov_source`.
 The gate lives under `tests/` (not measured by coverage), so it is exempt from
@@ -812,29 +821,30 @@ git commit -m "test(coverage): fail the suite on any file below the per-file thr
 ### Task 10: Document the gate
 
 **Files:**
+
 - Modify: `CLAUDE.md` (Commands section)
 - Modify: `docs/memory-bank/systemPatterns.md` and/or `docs/memory-bank/techContext.md`
 
 - [ ] **Step 1: Update `CLAUDE.md`** — in the Commands block, annotate the test
-  commands to note the per-file gate. Add a line near the pytest commands, e.g.:
+      commands to note the per-file gate. Add a line near the pytest commands, e.g.:
 
 ```markdown
-pipenv run pytest             # Full run with coverage — fails if total < 90% OR any file < 90%
+pipenv run pytest # Full run with coverage — fails if total < 90% OR any file < 90%
 ```
 
-  And add a short note under the commands: "Coverage is enforced both globally
-  and **per file** (no file < 90 %) by `tests/_per_file_coverage.py`. Use
-  `--no-cov` for fast iteration (disables both gates)."
+And add a short note under the commands: "Coverage is enforced both globally
+and **per file** (no file < 90 %) by `tests/_per_file_coverage.py`. Use
+`--no-cov` for fast iteration (disables both gates)."
 
 - [ ] **Step 2: Update the memory bank** — add an entry to
-  `docs/memory-bank/systemPatterns.md` (and/or `techContext.md`) recording the
-  rule and mechanism: a hookwrapper `pytest_sessionfinish` in `tests/conftest.py`
-  delegating to `tests/_per_file_coverage.py`, threshold sourced from
-  `[tool.coverage.report].fail_under`, exempting `tests/` and zero-statement
-  files. Follow the existing taxonomy/format of that file.
+      `docs/memory-bank/systemPatterns.md` (and/or `techContext.md`) recording the
+      rule and mechanism: a hookwrapper `pytest_sessionfinish` in `tests/conftest.py`
+      delegating to `tests/_per_file_coverage.py`, threshold sourced from
+      `[tool.coverage.report].fail_under`, exempting `tests/` and zero-statement
+      files. Follow the existing taxonomy/format of that file.
 
 - [ ] **Step 3: Verify docs render / lint** — `trunk check --fix` on the changed
-  markdown; commit any auto-formatting.
+      markdown; commit any auto-formatting.
 
 - [ ] **Step 4: Commit**
 
@@ -848,6 +858,7 @@ git commit -m "docs(tests): document the per-file coverage gate"
 ## Self-Review
 
 **Spec coverage:**
+
 - Behaviour (single command fails on any file < 90 %, `--no-cov` no-op, new files auto-blocked) → Task 9 (`enforce`, `option.no_cov` guard, `_collect_stats` scans all measured files).
 - Plugin location/hook/data-source/threshold-source → Task 9 Steps 3 & 5 exactly as specified.
 - Edge cases (`--no-cov`, `omit`, zero-statement, failure output + exitstatus) → covered by `enforce`/`evaluate_coverage` and their unit tests in Task 9.

--- a/docs/superpowers/plans/2026-06-08-per-file-coverage-gate.md
+++ b/docs/superpowers/plans/2026-06-08-per-file-coverage-gate.md
@@ -1,0 +1,868 @@
+# Per-file coverage gate (≥ 90 %) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pipenv run pytest` fail when any single file under `regis/` is below 90 % coverage, after first raising the 8 currently-below-threshold files to ≥ 90 %.
+
+**Architecture:** coverage.py only enforces a *global* `fail_under`. We add a small pytest plugin (`tests/_per_file_coverage.py`, wired via `tests/conftest.py`) that, after pytest-cov writes its data, loads the coverage data, computes per-file percentages, and fails the session if any file is below the same threshold read from `[tool.coverage.report].fail_under`. Tasks 1–8 raise the 8 legacy files first so the gate (Task 9) goes green immediately. Task 10 documents it.
+
+**Tech Stack:** Python 3.10+, pytest, pytest-cov, coverage.py 7.x, `tomllib`. Tests mock at source module locations (project convention).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-per-file-coverage-gate-design.md`
+
+---
+
+## Conventions for every task
+
+- Run a **single file's** coverage during the raise loop:
+  `pipenv run pytest --cov=regis --cov-report=term-missing <testfile> -q`
+  then read the line for the target file. (Coverage measures all imported `regis`
+  modules, so a single test file is enough to report the target's percentage.)
+- The example tests below are a **concrete starting point**. They use real symbol
+  names and real patch targets (verified against the source), but the exact
+  assertion strings / mock targets may need a one-line adjustment — the
+  term-missing loop is the source of truth. **Iterate until the target file is
+  ≥ 90 %, then commit.**
+- Patch at the **source** module location (e.g. `regis.utils.process.subprocess`),
+  never `regis.cli.*` (project convention, see `CLAUDE.md`).
+- Trunk's pre-commit hook auto-formats; re-add and commit the produced changes.
+- Commit scopes are mandatory (Conventional Commits).
+
+**Order matters:** Tasks 1–8 (raise coverage) MUST land before Task 9 (arm the
+gate), otherwise the suite goes red. Do them worst-file-first.
+
+---
+
+### Task 1: Raise `regis/tools/cosign.py` (73.3 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/tools/test_cosign.py` (extend)
+- Under test: `regis/tools/cosign.py` (uncovered lines **29–46**)
+
+**Uncovered behaviour:** `verify_blob()` builds the `cosign verify-blob` command
+(29–41), runs it via `subprocess.run` (42–44), and raises
+`CosignVerificationFailed` on non-zero return, using `stderr` or falling back to
+`stdout` (45–46). Only the "cosign not found" path is currently tested.
+
+- [ ] **Step 1: Write failing tests** — append to `tests/tools/test_cosign.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+
+def test_verify_blob_success(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "artifact.bin"
+    blob.write_bytes(b"data")
+    policy = CosignPolicy(
+        issuer="https://token.actions.githubusercontent.com",
+        identity_regex="^https://github\\.com/org/.*",
+    )
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    cmd = run.call_args[0][0]
+    assert cmd[1] == "verify-blob"
+    assert "--signature" in cmd and "https://r.example.com/bin.tar.gz.sig" in cmd
+
+
+def test_verify_blob_failure_uses_stderr(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "a.bin"
+    blob.write_bytes(b"x")
+    policy = CosignPolicy(issuer="i", identity_regex="r")
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1, stderr="bad signature", stdout="")
+        with pytest.raises(CosignVerificationFailed) as exc:
+            verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    assert "bad signature" in str(exc.value)
+
+
+def test_verify_blob_failure_falls_back_to_stdout(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "a.bin"
+    blob.write_bytes(b"x")
+    policy = CosignPolicy(issuer="i", identity_regex="r")
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1, stderr="", stdout="stdout error")
+        with pytest.raises(CosignVerificationFailed) as exc:
+            verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    assert "stdout error" in str(exc.value)
+```
+
+> First read the top of `regis/tools/cosign.py` to confirm `CosignPolicy`'s field
+> names and how `verify_blob` derives the `.sig`/`.pem` URLs and builds its error
+> message; adjust the imports and assertions to match.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/tools/test_cosign.py -q` → new tests fail (or error on a wrong symbol). Fix symbols until they run.
+- [ ] **Step 3: Make them pass** — adjust assertions to the real command/message shape until green.
+- [ ] **Step 4: Verify coverage** — `pipenv run pytest --cov=regis --cov-report=term-missing tests/tools/test_cosign.py -q` → `regis/tools/cosign.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tools/test_cosign.py
+git commit -m "test(tools): cover cosign verify-blob success and failure paths"
+```
+
+---
+
+### Task 2: Raise `regis/commands/doctor.py` (73.8 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/commands/test_doctor.py` (extend)
+- Under test: `regis/commands/doctor.py` (uncovered **30–31, 33–35, 45–56**)
+
+**Uncovered behaviour:** in `_print_tools_section()`, the cached+sha256-ok branch
+(30–31) and the cached+sha256-mismatch branch (33–35, which sets `all_ok=False`);
+and in `_get_version()`, the `except (FileNotFoundError, OSError, subprocess.TimeoutExpired): return None` path (45–56).
+
+> First read `regis/commands/doctor.py` to confirm: the `ToolStatus` dataclass
+> fields, the exact patch target for the status source (the agent suggested
+> `regis.tools.fetcher.ToolFetcher.status`), how `doctor` is invoked (Click vs
+> argparse), and `_get_version`'s real signature. Adjust below to match.
+
+- [ ] **Step 1: Write failing tests** — add to `tests/commands/test_doctor.py`:
+
+```python
+def test_get_version_returns_none_on_filenotfound(monkeypatch):
+    from regis.commands.doctor import _get_version
+    def _raise(*a, **k):
+        raise FileNotFoundError
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/no/such/tool", "--version") is None
+
+
+def test_get_version_returns_none_on_timeout(monkeypatch):
+    import subprocess
+    from regis.commands.doctor import _get_version
+    def _raise(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="tool", timeout=5)
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/usr/bin/tool", "--version") is None
+
+
+def test_get_version_returns_none_on_oserror(monkeypatch):
+    from regis.commands.doctor import _get_version
+    def _raise(*a, **k):
+        raise OSError("denied")
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/usr/bin/tool", "--version") is None
+```
+
+For the cached/sha256 branches, add a test that patches the tool-status source to
+return one cached+ok and one cached+mismatch `ToolStatus`, invokes `doctor`, and
+asserts the `✓`/`MISMATCH` markers appear (and that a mismatch yields a non-zero
+exit). Model the invocation on the existing tests already in this file.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/commands/test_doctor.py -q`.
+- [ ] **Step 3: Make them pass** — fix patch targets / invocation until green.
+- [ ] **Step 4: Verify coverage** — `pipenv run pytest --cov=regis --cov-report=term-missing tests/commands/test_doctor.py -q` → `regis/commands/doctor.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/commands/test_doctor.py
+git commit -m "test(commands): cover doctor sha256 branches and version error paths"
+```
+
+---
+
+### Task 3: Raise `regis/utils/process.py` (75.0 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_utils_process.py` (extend)
+- Under test: `regis/utils/process.py` (uncovered **33–38, 60–62, 67–69, 73, 94–95, 98**)
+
+**Uncovered behaviour:** `run_cmd()` non-zero-exit error raising (33–38) and the
+`FileNotFoundError` "not found in PATH" path; the lazy helpers `_default_fetcher`
+(60–62), `_manifest_names` (67–69), `_in_manifest` (73); and `ensure_tool()`'s
+`ToolFetchError`→`ClickException` conversion (94–95) and install-hint message (98).
+
+> First read `regis/utils/process.py` to confirm `run_cmd`'s signature (does it
+> take `check=`, `step_label=`, `cwd=`?), the exact `ClickException` message
+> strings, and where `load_manifest`/`ToolFetcher`/`ToolFetchError` are imported
+> from. Adjust the tests accordingly.
+
+- [ ] **Step 1: Write failing tests** — add to `tests/test_utils_process.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+import subprocess
+import click
+import pytest
+from regis.utils.process import run_cmd, ensure_tool
+
+
+def test_run_cmd_raises_on_nonzero_with_stderr():
+    result = subprocess.CompletedProcess(["x"], 1, stdout="", stderr="boom")
+    with patch("regis.utils.process.subprocess.run", return_value=result):
+        with pytest.raises(click.ClickException) as exc:
+            run_cmd(["x"], check=True)
+    assert "boom" in exc.value.message
+
+
+def test_run_cmd_raises_on_missing_binary():
+    with patch("regis.utils.process.subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(click.ClickException) as exc:
+            run_cmd(["nope"], check=True)
+    assert "not found in PATH" in exc.value.message
+
+
+def test_ensure_tool_fetches_from_manifest():
+    with patch("regis.utils.process.shutil.which", return_value=None), \
+         patch("regis.utils.process._manifest_names", return_value=frozenset({"grype"})), \
+         patch("regis.utils.process._default_fetcher") as fetcher:
+        fetcher.return_value = MagicMock(ensure=MagicMock(return_value="/cache/grype"))
+        assert str(ensure_tool("grype")) == "/cache/grype"
+
+
+def test_ensure_tool_wraps_fetch_error():
+    from regis.tools.fetcher import ToolFetchError
+    with patch("regis.utils.process.shutil.which", return_value=None), \
+         patch("regis.utils.process._manifest_names", return_value=frozenset({"grype"})), \
+         patch("regis.utils.process._default_fetcher") as fetcher:
+        fetcher.return_value = MagicMock(ensure=MagicMock(side_effect=ToolFetchError("dl failed")))
+        with pytest.raises(click.ClickException) as exc:
+            ensure_tool("grype")
+    assert "dl failed" in exc.value.message
+
+
+def test_ensure_tool_missing_with_install_hint():
+    with patch("regis.utils.process.shutil.which", return_value=None), \
+         patch("regis.utils.process._manifest_names", return_value=frozenset()):
+        with pytest.raises(click.ClickException) as exc:
+            ensure_tool("ghost", install_hint="brew install ghost")
+    assert "brew install ghost" in exc.value.message
+```
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_utils_process.py -q`.
+- [ ] **Step 3: Make them pass** — align messages/targets until green.
+- [ ] **Step 4: Verify coverage** — term-missing for `regis/utils/process.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_utils_process.py
+git commit -m "test(utils): cover run_cmd errors and ensure_tool fetch paths"
+```
+
+---
+
+### Task 4: Raise `regis/playbook/sections.py` (78.6 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_playbook_sections.py` (**create** — no dedicated test today)
+- Under test: `regis/playbook/sections.py` (uncovered **33–47, 159–160, 180, 187, 217, 237–265, 290, 292, 328–332, 338–342, 365, 377**)
+
+**Highest-value blocks:** `_evaluate_scorecards` pre-evaluated branch (33–47);
+`_evaluate_section` rule-reference processing (237–265); `resolve_widgets_final`
+section/widget condition filtering (328–342) and subvalue/URL re-resolution
+(365, 377). Functions are all module-level: `_evaluate_scorecards`,
+`_evaluate_widgets`, `_build_render_order`, `_evaluate_section`,
+`resolve_widgets_final`.
+
+> First read `regis/playbook/sections.py` around each uncovered block to confirm
+> the exact dict keys these functions read (e.g. `_pre_evaluated`/`_rule_result`,
+> `rules`, `hint`, `condition`, `options.subvalue`, `url`) and the call
+> signatures. Build minimal raw-context/section dicts that drive each branch.
+
+- [ ] **Step 1: Write failing tests** — create `tests/test_playbook_sections.py`. Start with the largest blocks; representative cases:
+
+```python
+"""Coverage for regis/playbook/sections.py branches."""
+from regis.playbook.sections import (
+    _evaluate_scorecards,
+    _evaluate_section,
+    resolve_widgets_final,
+)
+
+
+def test_pre_evaluated_scorecard_is_passed_through():
+    defs = [{
+        "_pre_evaluated": True,
+        "_rule_result": {
+            "slug": "r1", "description": "Rule 1", "level": "bronze",
+            "tags": ["sec"], "analyzers": ["cve"], "passed": True,
+            "status": "passed", "message": "ok",
+        },
+    }]
+    out = _evaluate_scorecards(defs, {})
+    assert out[0]["name"] == "r1" and out[0]["passed"] is True
+
+
+def test_section_rule_reference_by_slug():
+    section = {"name": "S", "rules": ["my-rule"]}
+    ctx = {"rules": {"my-rule": {
+        "slug": "my-rule", "description": "My Rule", "level": "bronze",
+        "tags": [], "analyzers": [], "passed": True, "status": "passed", "message": "",
+    }}}
+    out = _evaluate_section(section, ctx)
+    assert any(c["name"] == "my-rule" for c in out["scorecards"])
+
+
+def test_section_hint_and_condition_preserved():
+    out = _evaluate_section(
+        {"name": "S", "hint": "h", "condition": {"==": [1, 1]}, "scorecards": []}, {}
+    )
+    assert out["hint"] == "h" and out["condition"] == {"==": [1, 1]}
+
+
+def test_resolve_widgets_final_filters_false_section_condition():
+    pages = [{"sections": [
+        {"name": "keep", "condition": {"==": [1, 1]}, "widgets": []},
+        {"name": "drop", "condition": {"==": [1, 0]}, "widgets": []},
+    ]}]
+    resolve_widgets_final(pages, {})
+    assert [s["name"] for s in pages[0]["sections"]] == ["keep"]
+
+
+def test_resolve_widgets_final_filters_false_widget_condition():
+    pages = [{"sections": [{"widgets": [
+        {"label": "keep", "condition": {"==": [1, 1]}},
+        {"label": "drop", "condition": {"==": [1, 0]}},
+    ]}]}]
+    resolve_widgets_final(pages, {})
+    assert [w["label"] for w in pages[0]["sections"][0]["widgets"]] == ["keep"]
+```
+
+Add cases for: a widget whose condition raises (invalid operator) with no missing
+data (skipped); a widget with `options.subvalue` resolving to `None` (line 180)
+and with a `url` template (185–189); the tags-in-render-order branch (217); and
+the subvalue/URL re-resolution in the final pass (365, 377). Drive each from the
+term-missing output.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_playbook_sections.py -q`.
+- [ ] **Step 3: Make them pass / add cases** — iterate against term-missing.
+- [ ] **Step 4: Verify coverage** — `regis/playbook/sections.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_playbook_sections.py
+git commit -m "test(playbook): cover sections scorecards, rule refs and final resolution"
+```
+
+---
+
+### Task 5: Raise `regis/analyzers/endoflife.py` (79.4 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_endoflife.py` (extend)
+- Under test: `regis/analyzers/endoflife.py` (uncovered **76, 99–108, 125, 173, 177**)
+
+**Uncovered behaviour:** `_image_to_product` short-name fallback (76);
+`_fetch_cycles` HTTP non-200 / error handling (99–108); `_match_cycle` major-
+version fallback (125); and in `EndOfLifeAnalyzer.analyze`, `is_eol` derivation
+for `eol=False` (173) and boolean `eol=True` (177).
+
+> CRITICAL: confirm which HTTP client `_fetch_cycles` uses — read the imports at
+> the top of `regis/analyzers/endoflife.py`. `pyproject.toml` ships `httpx`; the
+> recipe assumed `requests`. Patch whatever it actually imports
+> (e.g. `regis.analyzers.endoflife.httpx.get` or `...requests.get`). Also confirm
+> how existing tests in `tests/test_endoflife.py` mock HTTP (look for `responses`
+> or an `httpx` mock) and follow that pattern.
+
+- [ ] **Step 1: Write failing tests** — add to `tests/test_endoflife.py` (pure-function cases are client-agnostic):
+
+```python
+from regis.analyzers.endoflife import _image_to_product, _match_cycle
+
+
+def test_image_to_product_short_name_fallback():
+    assert _image_to_product("myorg/nodejs") == "nodejs"
+
+
+def test_match_cycle_major_version_fallback():
+    cycles = [{"cycle": "1", "eol": False, "latest": "1.5.0"}]
+    assert _match_cycle("1.5", cycles)["cycle"] == "1"
+```
+
+For `_fetch_cycles` (99–108): add tests mocking the real client to return a 404
+(→ `None`) and to raise a transport/timeout error (→ `None`). For `analyze`
+(173, 177): patch `regis.analyzers.endoflife._fetch_cycles` to return a cycle
+list with `eol=False` (assert `report["is_eol"] is False`) and one with
+`eol=True` (assert `report["is_eol"] is True`); reuse the existing
+`MockRegistryClient` in the file.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_endoflife.py -q`.
+- [ ] **Step 3: Make them pass** — fix the HTTP patch target to the real client.
+- [ ] **Step 4: Verify coverage** — `regis/analyzers/endoflife.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_endoflife.py
+git commit -m "test(analyzers): cover endoflife fetch errors and eol derivation"
+```
+
+---
+
+### Task 6: Raise `regis/playbook/evaluator.py` (83.2 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_playbook_evaluator.py` (**create**)
+- Under test: `regis/playbook/evaluator.py` (uncovered **40, 68–82, 150, 154–155, 237–238, 255–257, 267–269, 286**)
+
+**Uncovered behaviour:** `_normalize_pages` pages-provided branch (40);
+`_evaluate_pages` section-condition handling incl. missing-data tracking and
+exception path (68–82); `_resolve_links` `.format(**report)` (150) and its
+exception handling (154–155); and inside `evaluate`, tier-condition exception
+(237–238), badge value interpolation (255–257), badge condition exception
+(267–269), and label-without-value (286). Module functions: `_normalize_pages`,
+`_evaluate_pages`, `_resolve_links`, `evaluate`.
+
+> First read `regis/playbook/evaluator.py` around these lines to confirm the
+> signatures of `_evaluate_pages` and `_resolve_links` (argument order/keys) and
+> the shape of `evaluate(playbook, report)` output (`tier`, `badges`, `links`).
+> The drafts below match the agent's reading but verify before trusting.
+
+- [ ] **Step 1: Write failing tests** — create `tests/test_playbook_evaluator.py`:
+
+```python
+"""Coverage for regis/playbook/evaluator.py branches."""
+from regis.playbook.evaluator import _normalize_pages, evaluate
+
+
+def test_normalize_pages_returns_explicit_pages():
+    pb = {"pages": [{"name": "P1", "sections": []}]}
+    assert _normalize_pages(pb) == pb["pages"]
+
+
+def test_badge_without_value_uses_scope_label():
+    out = evaluate({"name": "x", "badges": [{"slug": "s", "scope": "Status"}]}, {})
+    badge = out["badges"][0]
+    assert badge["label"] == "Status" and badge["value"] is None
+
+
+def test_badge_value_interpolation():
+    pb = {"name": "x", "badges": [{"slug": "v", "scope": "Version", "value": "${version}"}]}
+    out = evaluate(pb, {"version": "1.2.3"})
+    assert out["badges"][0]["value"] == "1.2.3"
+
+
+def test_badge_condition_exception_is_skipped():
+    pb = {"name": "x", "badges": [
+        {"slug": "bad", "scope": "T", "value": "X", "condition": {"invalid_op": [1, 2]}},
+    ]}
+    out = evaluate(pb, {})
+    assert all(b["slug"] != "bad" for b in out.get("badges", []))
+```
+
+Add cases driving `_evaluate_pages` (a section whose condition is False with no
+missing data → skipped; a condition referencing missing data → kept as
+incomplete; an invalid-operator condition → exception path) and `_resolve_links`
+(a `{repo}`-style URL formatted from `report`; a URL referencing a missing key →
+link skipped via the exception handler), plus a tier whose condition uses an
+invalid operator (237–238). Iterate against term-missing.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_playbook_evaluator.py -q`.
+- [ ] **Step 3: Make them pass / add cases** — iterate against term-missing.
+- [ ] **Step 4: Verify coverage** — `regis/playbook/evaluator.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_playbook_evaluator.py
+git commit -m "test(playbook): cover evaluator pages, links, tiers and badges"
+```
+
+---
+
+### Task 7: Raise `regis/rules/evaluator.py` (84.7 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_rules_evaluator.py` (extend)
+- Under test: `regis/rules/evaluator.py` (uncovered **43, 56–63, 165–166, 195, 212–221, 234, 261, 266–279, 398–402**)
+
+**Highest-value blocks:** `_interpolate_string` list `.length`/index access and
+its error handling (56–63) and empty-template early return (43); custom-operator
+edge branches registered in `_add_custom_operations` (non-list/non-dict inputs);
+`resolve_rules` merge-when-already-present logic (266–279); and `evaluate_rules`
+exception path (398–402).
+
+> First read `regis/rules/evaluator.py` around 40–65, 200–280 and 359–402 to
+> confirm `_interpolate_string`/`resolve_rules`/`evaluate_rules` signatures and
+> the custom operator names. The custom ops (`intersects`, `contains_all`,
+> `subset`, `keys`, `get`, `env_contains`) are registered globally via
+> `_add_custom_operations()`; verify it has been called (import side effect) or
+> call it in the test setup.
+
+- [ ] **Step 1: Write failing tests** — add to `tests/test_rules_evaluator.py`. High-confidence cases:
+
+```python
+from regis.rules.evaluator import _interpolate_string, evaluate_rules
+
+
+def test_interpolate_empty_template_returns_input():
+    assert _interpolate_string("", {}) == ""
+
+
+def test_interpolate_list_length_and_index():
+    ctx = {"items": ["a", "b", "c"]}
+    assert _interpolate_string("n=${items.length}", ctx) == "n=3"
+    assert _interpolate_string("first=${items.0}", ctx) == "first=a"
+
+
+def test_interpolate_list_index_out_of_range_keeps_placeholder():
+    assert _interpolate_string("x=${items.9}", {"items": ["a"]}) == "x=${items.9}"
+
+
+def test_evaluate_rules_condition_exception_marks_failed():
+    report = {"request": {"registry": "docker.io", "analyzers": []}, "results": {}}
+    rules_def = {"rules": [{
+        "slug": "bad", "condition": {"invalid_op": [1, 2]},
+        "messages": {"pass": "ok", "fail": "err"},
+    }]}
+    res = evaluate_rules(report, rules_def)
+    bad = next(r for r in res["rules"] if r["slug"] == "bad")
+    assert bad["passed"] is False
+```
+
+For the custom-operator edge branches, add a test exercising each operator with
+non-list/non-dict inputs (the project registers them via `json_logic`; call them
+through `evaluate_rules` with crafted conditions, or directly via the registered
+`jsonLogic` if exposed). For the `resolve_rules` merge path (266–279), declare
+the same provider+slug twice with different `messages`/`params` and assert they
+merge. Iterate against term-missing.
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_rules_evaluator.py -q`.
+- [ ] **Step 3: Make them pass / add cases** — iterate against term-missing.
+- [ ] **Step 4: Verify coverage** — `regis/rules/evaluator.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_rules_evaluator.py
+git commit -m "test(rules): cover interpolation, custom operators and merge paths"
+```
+
+---
+
+### Task 8: Raise `regis/playbook/conditions.py` (87.8 % → ≥ 90 %)
+
+**Files:**
+- Test: `tests/test_playbook_conditions.py` (**create**)
+- Under test: `regis/playbook/conditions.py` (uncovered **47, 52–54, 89, 93**)
+
+**Uncovered behaviour:** `evaluate_condition` falsy-condition early return (47)
+and its exception handler returning an incomplete `ConditionResult` (52–54); and
+`_stringify_condition`'s `in` (89) and `and` (93) operator branches.
+
+> First read `regis/playbook/conditions.py` to confirm `evaluate_condition`'s
+> signature (does it take a `label=`/tracker arg?), `ConditionResult`'s fields
+> (`passed`, `incomplete`), and `_stringify_condition`'s output format.
+
+- [ ] **Step 1: Write failing tests** — create `tests/test_playbook_conditions.py`:
+
+```python
+"""Coverage for regis/playbook/conditions.py branches."""
+from regis.playbook.conditions import (
+    ConditionResult,
+    evaluate_condition,
+    _stringify_condition,
+)
+
+
+def test_falsy_condition_returns_none():
+    assert evaluate_condition(None, {}) is None
+    assert evaluate_condition({}, {}) is None
+
+
+def test_condition_exception_returns_incomplete():
+    res = evaluate_condition({"/": [1, 0]}, {})  # division by zero
+    assert isinstance(res, ConditionResult)
+    assert res.passed is False and res.incomplete is True
+
+
+def test_stringify_in_operator():
+    out = _stringify_condition({"in": [{"var": "x"}, {"var": "xs"}]}, {"x": "a", "xs": ["a"]})
+    assert " in " in out
+
+
+def test_stringify_and_operator():
+    out = _stringify_condition({"and": [{"==": [1, 1]}, {"==": [2, 2]}]}, {})
+    assert " and " in out
+```
+
+- [ ] **Step 2: Run, expect failures** — `pipenv run pytest tests/test_playbook_conditions.py -q`.
+- [ ] **Step 3: Make them pass** — adjust to the real signatures/format.
+- [ ] **Step 4: Verify coverage** — `regis/playbook/conditions.py` ≥ 90 %.
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_playbook_conditions.py
+git commit -m "test(playbook): cover condition falsy/exception and stringify branches"
+```
+
+---
+
+### Task 9: Add the per-file coverage gate plugin
+
+**Files:**
+- Create: `tests/_per_file_coverage.py`
+- Modify: `tests/conftest.py` (register the `pytest_sessionfinish` hookwrapper)
+- Test: `tests/test_per_file_coverage.py` (create)
+
+**Design notes (validated during brainstorming):** a hookwrapper
+`pytest_sessionfinish` runs *after* pytest-cov has written `.coverage`; loading a
+fresh `coverage.Coverage()` then yields the same per-file percentages as the CLI
+report. The `--no-cov` no-op is detected via `option.no_cov` / `option.cov_source`.
+The gate lives under `tests/` (not measured by coverage), so it is exempt from
+itself; its logic is unit-tested instead.
+
+- [ ] **Step 1: Write the gate's unit tests (failing)** — create `tests/test_per_file_coverage.py`:
+
+```python
+"""Unit tests for the per-file coverage gate logic."""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests import _per_file_coverage
+
+
+def test_evaluate_coverage_flags_files_below_threshold():
+    stats = {"regis/a.py": (10, 0), "regis/b.py": (10, 2), "regis/c.py": (100, 11)}
+    assert _per_file_coverage.evaluate_coverage(stats, 90.0) == [
+        ("regis/b.py", 80.0),
+        ("regis/c.py", 89.0),
+    ]
+
+
+def test_evaluate_coverage_passes_at_exact_threshold():
+    assert _per_file_coverage.evaluate_coverage({"ok.py": (10, 1)}, 90.0) == []
+
+
+def test_evaluate_coverage_skips_zero_statement_files():
+    assert _per_file_coverage.evaluate_coverage({"x/__init__.py": (0, 0)}, 90.0) == []
+
+
+def test_read_threshold_reads_fail_under(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.coverage.report]\nfail_under = 90\n", encoding="utf-8"
+    )
+    assert _per_file_coverage.read_threshold(tmp_path) == 90.0
+
+
+def _session(no_cov, cov_source):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            option=SimpleNamespace(no_cov=no_cov, cov_source=cov_source),
+            rootpath=Path("."),
+        ),
+        exitstatus=0,
+    )
+
+
+def test_enforce_is_noop_when_coverage_disabled(monkeypatch):
+    monkeypatch.setattr(
+        _per_file_coverage, "_collect_stats",
+        lambda _r: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+    session = _session(no_cov=True, cov_source=[])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == 0
+
+
+def test_enforce_fails_session_for_low_file(monkeypatch, capsys):
+    monkeypatch.setattr(_per_file_coverage, "read_threshold", lambda _r: 90.0)
+    monkeypatch.setattr(_per_file_coverage, "_collect_stats", lambda _r: {"regis/bad.py": (10, 5)})
+    session = _session(no_cov=False, cov_source=["regis"])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+    err = capsys.readouterr().err
+    assert "regis/bad.py" in err and "below 90.0%" in err
+
+
+def test_enforce_passes_when_all_meet_threshold(monkeypatch):
+    monkeypatch.setattr(_per_file_coverage, "read_threshold", lambda _r: 90.0)
+    monkeypatch.setattr(_per_file_coverage, "_collect_stats", lambda _r: {"regis/good.py": (10, 0)})
+    session = _session(no_cov=False, cov_source=["regis"])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == 0
+```
+
+- [ ] **Step 2: Run, expect failure** — `pipenv run pytest tests/test_per_file_coverage.py -q` → fails with `ModuleNotFoundError`/`AttributeError` (module not written yet).
+
+- [ ] **Step 3: Write the plugin** — create `tests/_per_file_coverage.py`:
+
+```python
+"""Per-file coverage gate.
+
+coverage.py only enforces a *global* ``fail_under`` threshold, so a poorly
+tested file can hide behind well-covered ones. After pytest-cov writes its data,
+this gate loads it and fails the session if any measured file is below the same
+threshold (read from ``[tool.coverage.report].fail_under``). Wired in via
+``tests/conftest.py``. Spec:
+docs/superpowers/specs/2026-06-08-per-file-coverage-gate-design.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib
+
+import coverage
+import pytest
+
+
+def read_threshold(rootpath: Path) -> float:
+    """Read the shared coverage threshold from ``[tool.coverage.report]``."""
+    data = tomllib.loads((rootpath / "pyproject.toml").read_text(encoding="utf-8"))
+    return float(data["tool"]["coverage"]["report"]["fail_under"])
+
+
+def evaluate_coverage(
+    stats: dict[str, tuple[int, int]], threshold: float
+) -> list[tuple[str, float]]:
+    """Return ``[(path, percent)]`` for files below ``threshold``, worst first.
+
+    ``stats`` maps a display path to ``(n_statements, n_missing)``. Files with
+    zero statements are skipped. The percentage is rounded to two decimals before
+    comparison, mirroring coverage.py's reporting precision.
+    """
+    offenders: list[tuple[str, float]] = []
+    for path, (n_statements, n_missing) in stats.items():
+        if n_statements == 0:
+            continue
+        percent = 100.0 * (n_statements - n_missing) / n_statements
+        if round(percent, 2) < threshold:
+            offenders.append((path, percent))
+    offenders.sort(key=lambda item: (item[1], item[0]))
+    return offenders
+
+
+def _collect_stats(rootpath: Path) -> dict[str, tuple[int, int]]:
+    """Load on-disk coverage data into ``{display_path: (n_statements, n_missing)}``."""
+    cov = coverage.Coverage()  # reads [tool.coverage] config (omit, etc.)
+    cov.load()
+    data = cov.get_data()
+    stats: dict[str, tuple[int, int]] = {}
+    for filename in data.measured_files():
+        _, statements, _excluded, missing, _fmt = cov.analysis2(filename)
+        try:
+            display = str(Path(filename).relative_to(rootpath))
+        except ValueError:
+            display = filename
+        stats[display] = (len(statements), len(missing))
+    return stats
+
+
+def enforce(session: pytest.Session) -> None:
+    """Fail the pytest session if any measured file is below the threshold."""
+    option = session.config.option
+    if getattr(option, "no_cov", False) or not getattr(option, "cov_source", None):
+        return  # coverage disabled (e.g. --no-cov): nothing to check
+    rootpath = Path(session.config.rootpath)
+    threshold = read_threshold(rootpath)
+    offenders = evaluate_coverage(_collect_stats(rootpath), threshold)
+    if not offenders:
+        return
+    lines = [f"Per-file coverage gate: {len(offenders)} file(s) below {threshold:.1f}%"]
+    lines += [f"  {percent:5.1f}%  {path}" for path, percent in offenders]
+    print("\n" + "\n".join(lines), file=sys.stderr)
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+```
+
+- [ ] **Step 4: Run the gate's unit tests** — `pipenv run pytest tests/test_per_file_coverage.py -q` → PASS.
+
+- [ ] **Step 5: Register the hook in `tests/conftest.py`** — add at the top (after the module docstring/imports) and append the hook:
+
+```python
+import pytest
+
+from tests import _per_file_coverage
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_sessionfinish(session: pytest.Session):
+    """Run the per-file coverage gate after pytest-cov writes its data."""
+    yield
+    _per_file_coverage.enforce(session)
+```
+
+> `import pytest` may already be present in `tests/conftest.py` — don't duplicate it.
+
+- [ ] **Step 6: Run the FULL suite — expect green** — Tasks 1–8 brought every file ≥ 90 %, so the gate passes:
+
+```bash
+pipenv run pytest
+```
+
+Expected: `Required test coverage of 90% reached`, all tests pass, no
+"Per-file coverage gate" message, exit 0.
+
+- [ ] **Step 7: Sanity-check the gate actually bites** — temporarily append a throwaway uncovered branch to a small module to confirm the gate fails, then revert:
+
+```bash
+printf '\n\ndef _gate_probe(x):\n    if x:\n        return 1\n    return 2\n' >> regis/tools/cosign.py
+pipenv run pytest -q; echo "exit=$?"   # expect a 'Per-file coverage gate' message + non-zero exit
+git checkout -- regis/tools/cosign.py  # revert the probe
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/_per_file_coverage.py tests/test_per_file_coverage.py tests/conftest.py
+git commit -m "test(coverage): fail the suite on any file below the per-file threshold"
+```
+
+---
+
+### Task 10: Document the gate
+
+**Files:**
+- Modify: `CLAUDE.md` (Commands section)
+- Modify: `docs/memory-bank/systemPatterns.md` and/or `docs/memory-bank/techContext.md`
+
+- [ ] **Step 1: Update `CLAUDE.md`** — in the Commands block, annotate the test
+  commands to note the per-file gate. Add a line near the pytest commands, e.g.:
+
+```markdown
+pipenv run pytest             # Full run with coverage — fails if total < 90% OR any file < 90%
+```
+
+  And add a short note under the commands: "Coverage is enforced both globally
+  and **per file** (no file < 90 %) by `tests/_per_file_coverage.py`. Use
+  `--no-cov` for fast iteration (disables both gates)."
+
+- [ ] **Step 2: Update the memory bank** — add an entry to
+  `docs/memory-bank/systemPatterns.md` (and/or `techContext.md`) recording the
+  rule and mechanism: a hookwrapper `pytest_sessionfinish` in `tests/conftest.py`
+  delegating to `tests/_per_file_coverage.py`, threshold sourced from
+  `[tool.coverage.report].fail_under`, exempting `tests/` and zero-statement
+  files. Follow the existing taxonomy/format of that file.
+
+- [ ] **Step 3: Verify docs render / lint** — `trunk check --fix` on the changed
+  markdown; commit any auto-formatting.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/memory-bank/
+git commit -m "docs(tests): document the per-file coverage gate"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Behaviour (single command fails on any file < 90 %, `--no-cov` no-op, new files auto-blocked) → Task 9 (`enforce`, `option.no_cov` guard, `_collect_stats` scans all measured files).
+- Plugin location/hook/data-source/threshold-source → Task 9 Steps 3 & 5 exactly as specified.
+- Edge cases (`--no-cov`, `omit`, zero-statement, failure output + exitstatus) → covered by `enforce`/`evaluate_coverage` and their unit tests in Task 9.
+- "Raise the 8 files first" → Tasks 1–8, worst-first, each ≥ 90 % before Task 9.
+- Plugin itself tested → `tests/test_per_file_coverage.py` (Task 9).
+- Integration & docs (no new CI step; CLAUDE.md + memory-bank) → Task 10.
+
+**Placeholder scan:** none — every code step contains real code; the coverage-
+raise tasks intentionally end in a measured term-missing gate (the iterative loop
+is the spec, not a placeholder).
+
+**Type/name consistency:** gate API names are consistent across the plugin and
+its tests: `read_threshold`, `evaluate_coverage(stats, threshold)`,
+`_collect_stats(rootpath)`, `enforce(session)`. Target symbol names in Tasks 1–8
+were verified against the source. The only deliberately-flagged uncertainties
+(HTTP client in `endoflife`, exact message strings, some `_resolve_links`/
+`_evaluate_pages` signatures) carry an explicit "read the source first" note and
+self-correct via the per-file coverage loop.

--- a/docs/superpowers/specs/2026-06-08-per-file-coverage-gate-design.md
+++ b/docs/superpowers/specs/2026-06-08-per-file-coverage-gate-design.md
@@ -1,0 +1,128 @@
+# Per-file coverage gate (≥ 90 %)
+
+**Date** : 2026-06-08
+**Statut** : approuvé (design), prêt pour planification
+
+## Problème
+
+Le seuil de couverture du projet est **global** : `--cov-fail-under=90` (addopts)
+et `[tool.coverage.report].fail_under = 90`. Un fichier peu testé peut donc rester
+sous 90 % tant que d'autres fichiers très couverts maintiennent la moyenne au-dessus
+du seuil. Aujourd'hui la couverture globale est à 92 %, mais **8 fichiers sont sous
+90 %** (de 73 % à 88 %).
+
+Objectif : garantir qu'**aucun fichier individuel** de `regis/` ne descende sous 90 %.
+
+## Décisions de cadrage
+
+| Décision          | Choix retenu                                                                                                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Périmètre         | **Tous les fichiers, toujours.** Échec dur si un seul fichier < 90 %, qu'il soit touché ou non par la PR.                        |
+| Exemptions        | **Aucune liste d'exemptions.** Pas de baseline gelée.                                                                            |
+| Fichiers legacy   | **Remontés ≥ 90 % d'abord**, dans la même livraison, avant d'armer le gate.                                                      |
+| Mécanisme         | **Plugin pytest intégré** (hook `pytest_sessionfinish`). Une seule commande `pipenv run pytest` enforce tout, en local et en CI. |
+| Seuil par-fichier | **Identique au seuil global** (90), lu depuis l'unique source `[tool.coverage.report].fail_under`. Pas de second chiffre en dur. |
+
+## Comportement cible
+
+`pipenv run pytest` échoue si au moins un fichier de `regis/` est sous 90 %, en
+plus du gate global existant. Le message d'échec liste chaque fichier fautif avec
+son pourcentage, trié du pire au meilleur. Exemple :
+
+```text
+FAILED per-file coverage gate: 2 file(s) below 90.0%
+   73.3%  regis/tools/cosign.py
+   84.7%  regis/rules/evaluator.py
+```
+
+- `pytest --no-cov` reste un **no-op** : la boucle d'itération rapide est intacte.
+- Tout **nouveau** fichier sous 90 % est bloqué automatiquement, sans config à
+  maintenir.
+
+## Architecture
+
+### Le plugin
+
+- **Emplacement** : la logique de seuil vit dans un module dédié et isolé,
+  `tests/_per_file_coverage.py`, enregistré via `tests/conftest.py`. Le module
+  expose une fonction pure prenant des données de couverture (mapping
+  `fichier -> pourcentage`) + un seuil, et renvoyant la liste triée des fichiers
+  fautifs — testable sans lancer toute la suite.
+- **Hook** : `pytest_sessionfinish` en `hookwrapper`, pour s'exécuter **après**
+  pytest-cov (qui combine et écrit les données en fin de session).
+- **Source des données** : l'objet `Coverage` de coverage.py via son API
+  (`get_data()` / `analysis2` ou équivalent), pas un parse de fichier sur disque.
+  Robuste et déjà disponible en mémoire après pytest-cov.
+- **Seuil** : lu depuis `[tool.coverage.report].fail_under` dans `pyproject.toml`
+  (parse via `tomllib`). Une seule source de vérité partagée avec le gate global.
+
+### Cas limites
+
+| Cas                                          | Comportement                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `--no-cov` (couverture non collectée)        | Sortie silencieuse, aucun échec.                                                            |
+| Fichiers `omit` (`regis/cookiecutters/*`)    | Exclus automatiquement : on lit les données coverage déjà filtrées par la config existante. |
+| Fichier à 0 instruction (`__init__.py` vide) | Ignoré (considéré comme passant).                                                           |
+| Échec                                        | `session.exitstatus` forcé non nul + tableau fautif imprimé dans le résumé terminal.        |
+
+### Flux
+
+```text
+pytest run
+  ├─ pytest-cov collecte + écrit les données de couverture (sessionfinish)
+  └─ hookwrapper per-file gate (sessionfinish, après pytest-cov)
+       ├─ couverture absente ? → no-op
+       ├─ lit le seuil depuis pyproject.toml
+       ├─ calcule % par fichier depuis l'objet Coverage
+       ├─ filtre les fichiers 0-instruction
+       ├─ collecte les fichiers < seuil
+       └─ si non vide → imprime + exitstatus ≠ 0
+```
+
+## Travail préalable — remonter les 8 fichiers
+
+Avant d'armer le gate, écrire en **TDD** les tests manquants pour amener chacun
+des fichiers suivants ≥ 90 %. Chaque fichier est une étape isolée, ordonnée du
+plus bas au plus haut :
+
+| % actuel | Fichier                        |
+| -------- | ------------------------------ |
+| 73.3     | `regis/tools/cosign.py`        |
+| 73.8     | `regis/commands/doctor.py`     |
+| 75.0     | `regis/utils/process.py`       |
+| 78.6     | `regis/playbook/sections.py`   |
+| 79.4     | `regis/analyzers/endoflife.py` |
+| 83.2     | `regis/playbook/evaluator.py`  |
+| 84.7     | `regis/rules/evaluator.py`     |
+| 87.8     | `regis/playbook/conditions.py` |
+
+Le plugin lui-même (`tests/_per_file_coverage.py`) doit aussi être ≥ 90 %.
+
+> Note : `tests/` n'est pas mesuré par coverage (`source = ["regis"]`), donc le
+> module de plugin sous `tests/` n'est pas soumis au gate. Sa couverture est
+> néanmoins assurée par ses propres tests unitaires (section suivante).
+
+## Tests du plugin
+
+Tests unitaires de la fonction de seuil, indépendants d'un run complet :
+
+- fichier sous le seuil → présent dans la liste fautive, trié ;
+- tous les fichiers ≥ seuil → liste vide (succès) ;
+- `--no-cov` / couverture absente → no-op ;
+- fichier 0-instruction → ignoré ;
+- lecture correcte du seuil depuis `pyproject.toml`.
+
+## Intégration & documentation
+
+- **Aucun nouveau step CI** : le gate vit dans `pipenv run pytest`, déjà lancé en
+  CI et en pré-PR.
+- Mettre à jour `CLAUDE.md` (section Commands) pour signaler le gate par-fichier.
+- Mettre à jour le memory-bank (`systemPatterns.md` et/ou `techContext.md`) pour
+  documenter la règle « aucun fichier < 90 % » et son mécanisme.
+
+## Hors périmètre (YAGNI)
+
+- Pas de seuil par-fichier distinct du seuil global.
+- Pas de liste d'exemptions ni de baseline gelée.
+- Pas de couverture par-diff (l'absolu par fichier couvre déjà les nouveaux fichiers).
+- Pas de dépendance tierce.

--- a/tests/_per_file_coverage.py
+++ b/tests/_per_file_coverage.py
@@ -1,0 +1,80 @@
+"""Per-file coverage gate.
+
+coverage.py only enforces a *global* ``fail_under`` threshold, so a poorly
+tested file can hide behind well-covered ones. After pytest-cov writes its data,
+this gate loads it and fails the session if any measured file is below the same
+threshold (read from ``[tool.coverage.report].fail_under``). Wired in via
+``tests/conftest.py``. Spec:
+docs/superpowers/specs/2026-06-08-per-file-coverage-gate-design.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib
+
+import coverage
+import pytest
+
+
+def read_threshold(rootpath: Path) -> float:
+    """Read the shared coverage threshold from ``[tool.coverage.report]``."""
+    data = tomllib.loads((rootpath / "pyproject.toml").read_text(encoding="utf-8"))
+    return float(data["tool"]["coverage"]["report"]["fail_under"])
+
+
+def evaluate_coverage(
+    stats: dict[str, tuple[int, int]], threshold: float
+) -> list[tuple[str, float]]:
+    """Return ``[(path, percent)]`` for files below ``threshold``, worst first.
+
+    ``stats`` maps a display path to ``(n_statements, n_missing)``. Files with
+    zero statements are skipped. The percentage is rounded to two decimals before
+    comparison, mirroring coverage.py's reporting precision.
+    """
+    offenders: list[tuple[str, float]] = []
+    for path, (n_statements, n_missing) in stats.items():
+        if n_statements == 0:
+            continue
+        percent = 100.0 * (n_statements - n_missing) / n_statements
+        if round(percent, 2) < threshold:
+            offenders.append((path, percent))
+    offenders.sort(key=lambda item: (item[1], item[0]))
+    return offenders
+
+
+def _collect_stats(rootpath: Path) -> dict[str, tuple[int, int]]:
+    """Load on-disk coverage data into ``{display_path: (n_statements, n_missing)}``."""
+    cov = coverage.Coverage()  # reads [tool.coverage] config (omit, etc.)
+    cov.load()
+    data = cov.get_data()
+    stats: dict[str, tuple[int, int]] = {}
+    for filename in data.measured_files():
+        _, statements, _excluded, missing, _fmt = cov.analysis2(filename)
+        try:
+            display = str(Path(filename).relative_to(rootpath))
+        except ValueError:
+            display = filename
+        stats[display] = (len(statements), len(missing))
+    return stats
+
+
+def enforce(session: pytest.Session) -> None:
+    """Fail the pytest session if any measured file is below the threshold."""
+    option = session.config.option
+    if getattr(option, "no_cov", False) or not getattr(option, "cov_source", None):
+        return  # coverage disabled (e.g. --no-cov): nothing to check
+    rootpath = Path(session.config.rootpath)
+    threshold = read_threshold(rootpath)
+    offenders = evaluate_coverage(_collect_stats(rootpath), threshold)
+    if not offenders:
+        return
+    lines = [f"Per-file coverage gate: {len(offenders)} file(s) below {threshold:.1f}%"]
+    lines += [f"  {percent:5.1f}%  {path}" for path, percent in offenders]
+    print("\n" + "\n".join(lines), file=sys.stderr)
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -125,7 +125,9 @@ def test_get_version_returns_output_line(monkeypatch):
     mock_result = MagicMock()
     mock_result.stdout = "grype 0.78.0\nextra line\n"
     mock_result.stderr = ""
-    monkeypatch.setattr("regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result)
+    monkeypatch.setattr(
+        "regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result
+    )
     assert _get_version("/usr/bin/grype", "version") == "grype 0.78.0"
 
 
@@ -136,7 +138,9 @@ def test_get_version_returns_none_when_output_empty(monkeypatch):
     mock_result = MagicMock()
     mock_result.stdout = ""
     mock_result.stderr = ""
-    monkeypatch.setattr("regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result)
+    monkeypatch.setattr(
+        "regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result
+    )
     assert _get_version("/usr/bin/grype", "version") is None
 
 

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from regis.cli import main
-from regis.commands.doctor import doctor
+from regis.commands.doctor import _get_version, doctor
+from regis.tools.fetcher import ToolStatus
 
 
 def _which_all(name: str) -> str:
@@ -107,3 +110,117 @@ def test_doctor_lists_tools_section(monkeypatch, tmp_path):
     assert "Tools" in result.output or "grype" in result.output
     assert "grype" in result.output
     assert "not cached" in result.output  # all 6 tools are missing under tmp_path cache
+
+
+# ---------------------------------------------------------------------------
+# _get_version exception paths (lines 45-56)
+# ---------------------------------------------------------------------------
+
+
+def test_get_version_returns_output_line(monkeypatch):
+    """Normal success path: returns the first line of stdout."""
+    import subprocess as _sp
+    from unittest.mock import MagicMock
+
+    mock_result = MagicMock()
+    mock_result.stdout = "grype 0.78.0\nextra line\n"
+    mock_result.stderr = ""
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result)
+    assert _get_version("/usr/bin/grype", "version") == "grype 0.78.0"
+
+
+def test_get_version_returns_none_when_output_empty(monkeypatch):
+    """Success path with empty output → None."""
+    from unittest.mock import MagicMock
+
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_result.stderr = ""
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", lambda *a, **k: mock_result)
+    assert _get_version("/usr/bin/grype", "version") is None
+
+
+def test_get_version_returns_none_on_filenotfound(monkeypatch):
+    def _raise(*a, **k):
+        raise FileNotFoundError
+
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/no/such/tool", "--version") is None
+
+
+def test_get_version_returns_none_on_timeout(monkeypatch):
+    def _raise(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="tool", timeout=5)
+
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/usr/bin/tool", "--version") is None
+
+
+def test_get_version_returns_none_on_oserror(monkeypatch):
+    def _raise(*a, **k):
+        raise OSError("denied")
+
+    monkeypatch.setattr("regis.commands.doctor.subprocess.run", _raise)
+    assert _get_version("/usr/bin/tool", "--version") is None
+
+
+# ---------------------------------------------------------------------------
+# _print_tools_section cached+sha256_ok and cached+sha256 mismatch (lines 29-35)
+# ---------------------------------------------------------------------------
+
+
+def _make_statuses(*, mismatch: bool) -> list[ToolStatus]:
+    """Return one cached-ok and optionally one cached-mismatch ToolStatus."""
+    statuses = [
+        ToolStatus(
+            name="grype",
+            version="0.1.0",
+            cached=True,
+            path=Path("/cache/grype"),
+            sha256_ok=True,
+        ),
+    ]
+    if mismatch:
+        statuses.append(
+            ToolStatus(
+                name="syft",
+                version="0.2.0",
+                cached=True,
+                path=Path("/cache/syft"),
+                sha256_ok=False,
+            )
+        )
+    return statuses
+
+
+def test_tools_section_cached_ok_shows_checkmark(monkeypatch):
+    """cached + sha256_ok=True → ✓ marker and exit 0 (PATH tools all present)."""
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_all),
+        patch("regis.commands.doctor._get_version", return_value="1.0.0"),
+        patch(
+            "regis.commands.doctor.ToolFetcher.status",
+            return_value=_make_statuses(mismatch=False),
+        ),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code == 0
+    assert "✓" in result.output
+    assert "cached @" in result.output
+
+
+def test_tools_section_sha256_mismatch_exits_nonzero(monkeypatch):
+    """cached + sha256_ok=False → ✗ MISMATCH marker and non-zero exit."""
+    runner = CliRunner()
+    with (
+        patch("regis.commands.doctor.shutil.which", side_effect=_which_all),
+        patch("regis.commands.doctor._get_version", return_value="1.0.0"),
+        patch(
+            "regis.commands.doctor.ToolFetcher.status",
+            return_value=_make_statuses(mismatch=True),
+        ),
+    ):
+        result = runner.invoke(doctor)
+    assert result.exit_code == 1
+    assert "MISMATCH" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ import cookiecutter.main as _cc_main
 import cookiecutter.repository as _cc_repo
 import pytest
 
+from tests import _per_file_coverage
+
 
 @pytest.fixture(autouse=True)
 def block_remote_cookiecutter(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,3 +32,10 @@ def block_remote_cookiecutter(monkeypatch: pytest.MonkeyPatch) -> None:
         return real(template, *args, **kwargs)
 
     monkeypatch.setattr(_cc_main, "cookiecutter", _guard)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_sessionfinish(session: pytest.Session):
+    """Run the per-file coverage gate after pytest-cov writes its data."""
+    yield
+    _per_file_coverage.enforce(session)

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -1,10 +1,13 @@
 """Tests for the end-of-life analyzer."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import requests
 
 from regis.analyzers.endoflife import (
     EndOfLifeAnalyzer,
     _extract_version,
+    _fetch_cycles,
     _image_to_product,
     _match_cycle,
 )
@@ -34,6 +37,11 @@ class TestImageToProduct:
 
     def test_golang(self):
         assert _image_to_product("library/golang") == "go"
+
+    def test_short_name_fallback_via_org_prefix(self):
+        """Short name (last path segment) resolves to a known product slug."""
+        # "myorg/node" → full name not in map, short name "node" IS in map → "nodejs"
+        assert _image_to_product("myorg/node") == "nodejs"
 
 
 class TestExtractVersion:
@@ -83,6 +91,13 @@ class TestMatchCycle:
     def test_no_match(self):
         result = _match_cycle("2.0", self.CYCLES)
         assert result is None
+
+    def test_major_version_fallback_matches(self):
+        """When exact version misses, major component matches a cycle with that id."""
+        cycles = [{"cycle": "1", "eol": False, "latest": "1.5.0"}]
+        result = _match_cycle("1.5", cycles)
+        assert result is not None
+        assert result["cycle"] == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -166,3 +181,75 @@ class TestEndOfLifeAnalyzer:
         assert report["product_found"] is True
         assert report["matched_cycle"] is None
         assert report["is_eol"] is None
+
+    @patch("regis.analyzers.endoflife._fetch_cycles")
+    def test_eol_false_is_not_eol(self, mock_fetch):
+        """Cycle with eol=False → is_eol is False (not None)."""
+        mock_fetch.return_value = [
+            {"cycle": "1.27", "releaseDate": "2024-01-01", "eol": False, "latest": "1.27.5"}
+        ]
+        client = MockRegistryClient()
+        analyzer = EndOfLifeAnalyzer()
+        report = analyzer.analyze(client, "library/nginx", "1.27")
+        analyzer.validate(report)
+
+        assert report["product_found"] is True
+        assert report["matched_cycle"] is not None
+        assert report["is_eol"] is False
+
+    @patch("regis.analyzers.endoflife._fetch_cycles")
+    def test_eol_bool_true_is_eol(self, mock_fetch):
+        """Cycle with eol=True (boolean) → is_eol is True."""
+        mock_fetch.return_value = [
+            {"cycle": "1.25", "releaseDate": "2023-01-01", "eol": True, "latest": "1.25.5"}
+        ]
+        client = MockRegistryClient()
+        analyzer = EndOfLifeAnalyzer()
+        report = analyzer.analyze(client, "library/nginx", "1.25")
+        analyzer.validate(report)
+
+        assert report["product_found"] is True
+        assert report["matched_cycle"] is not None
+        assert report["is_eol"] is True
+
+
+# ---------------------------------------------------------------------------
+# _fetch_cycles HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCycles:
+    """Test _fetch_cycles HTTP error handling (patches requests.get directly)."""
+
+    @patch("regis.analyzers.endoflife.requests.get")
+    def test_200_returns_cycle_list(self, mock_get):
+        """A 200 response should return the parsed JSON list."""
+        cycles = [{"cycle": "1.27", "eol": False}]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = cycles
+        mock_get.return_value = mock_resp
+
+        result = _fetch_cycles("nginx")
+
+        assert result == cycles
+
+    @patch("regis.analyzers.endoflife.requests.get")
+    def test_non_200_returns_none(self, mock_get):
+        """A 404 response should return None."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = _fetch_cycles("nonexistent-product")
+
+        assert result is None
+
+    @patch("regis.analyzers.endoflife.requests.get")
+    def test_request_exception_returns_none(self, mock_get):
+        """A network/timeout error should return None."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("network error")
+
+        result = _fetch_cycles("someproduct")
+
+        assert result is None

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -186,7 +186,12 @@ class TestEndOfLifeAnalyzer:
     def test_eol_false_is_not_eol(self, mock_fetch):
         """Cycle with eol=False → is_eol is False (not None)."""
         mock_fetch.return_value = [
-            {"cycle": "1.27", "releaseDate": "2024-01-01", "eol": False, "latest": "1.27.5"}
+            {
+                "cycle": "1.27",
+                "releaseDate": "2024-01-01",
+                "eol": False,
+                "latest": "1.27.5",
+            }
         ]
         client = MockRegistryClient()
         analyzer = EndOfLifeAnalyzer()
@@ -201,7 +206,12 @@ class TestEndOfLifeAnalyzer:
     def test_eol_bool_true_is_eol(self, mock_fetch):
         """Cycle with eol=True (boolean) → is_eol is True."""
         mock_fetch.return_value = [
-            {"cycle": "1.25", "releaseDate": "2023-01-01", "eol": True, "latest": "1.25.5"}
+            {
+                "cycle": "1.25",
+                "releaseDate": "2023-01-01",
+                "eol": True,
+                "latest": "1.25.5",
+            }
         ]
         client = MockRegistryClient()
         analyzer = EndOfLifeAnalyzer()

--- a/tests/test_per_file_coverage.py
+++ b/tests/test_per_file_coverage.py
@@ -1,0 +1,92 @@
+"""Unit tests for the per-file coverage gate logic."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests import _per_file_coverage
+
+
+def test_evaluate_coverage_flags_files_below_threshold():
+    stats = {"regis/a.py": (10, 0), "regis/b.py": (10, 2), "regis/c.py": (100, 11)}
+    assert _per_file_coverage.evaluate_coverage(stats, 90.0) == [
+        ("regis/b.py", 80.0),
+        ("regis/c.py", 89.0),
+    ]
+
+
+def test_evaluate_coverage_passes_at_exact_threshold():
+    assert _per_file_coverage.evaluate_coverage({"ok.py": (10, 1)}, 90.0) == []
+
+
+def test_evaluate_coverage_skips_zero_statement_files():
+    assert _per_file_coverage.evaluate_coverage({"x/__init__.py": (0, 0)}, 90.0) == []
+
+
+def test_read_threshold_reads_fail_under(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.coverage.report]\nfail_under = 90\n", encoding="utf-8"
+    )
+    assert _per_file_coverage.read_threshold(tmp_path) == 90.0
+
+
+def _session(no_cov, cov_source):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            option=SimpleNamespace(no_cov=no_cov, cov_source=cov_source),
+            rootpath=Path("."),
+        ),
+        exitstatus=0,
+    )
+
+
+def test_enforce_is_noop_when_coverage_disabled(monkeypatch):
+    monkeypatch.setattr(
+        _per_file_coverage,
+        "_collect_stats",
+        lambda _r: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+    session = _session(no_cov=True, cov_source=[])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == 0
+
+
+def test_enforce_fails_session_for_low_file(monkeypatch, capsys):
+    monkeypatch.setattr(_per_file_coverage, "read_threshold", lambda _r: 90.0)
+    monkeypatch.setattr(
+        _per_file_coverage, "_collect_stats", lambda _r: {"regis/bad.py": (10, 5)}
+    )
+    session = _session(no_cov=False, cov_source=["regis"])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+    err = capsys.readouterr().err
+    assert "regis/bad.py" in err and "below 90.0%" in err
+
+
+def test_enforce_passes_when_all_meet_threshold(monkeypatch):
+    monkeypatch.setattr(_per_file_coverage, "read_threshold", lambda _r: 90.0)
+    monkeypatch.setattr(
+        _per_file_coverage, "_collect_stats", lambda _r: {"regis/good.py": (10, 0)}
+    )
+    session = _session(no_cov=False, cov_source=["regis"])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == 0
+
+
+def test_enforce_is_noop_when_cov_source_empty(monkeypatch):
+    """Gate no-ops when coverage is disabled by absence of --cov (cov_source=[])."""
+    monkeypatch.setattr(
+        _per_file_coverage,
+        "_collect_stats",
+        lambda _r: (_ for _ in ()).throw(AssertionError("should not run")),
+    )
+    session = _session(no_cov=False, cov_source=[])
+    _per_file_coverage.enforce(session)
+    assert session.exitstatus == 0
+
+
+def test_read_threshold_reads_real_pyproject():
+    """read_threshold returns 90.0 reading the actual project pyproject.toml."""
+    repo_root = Path(__file__).resolve().parents[1]
+    assert _per_file_coverage.read_threshold(repo_root) == 90.0

--- a/tests/test_playbook_conditions.py
+++ b/tests/test_playbook_conditions.py
@@ -1,0 +1,78 @@
+"""Coverage for regis/playbook/conditions.py branches."""
+from regis.playbook.conditions import (
+    ConditionResult,
+    _stringify_condition,
+    evaluate_condition,
+)
+
+
+def test_falsy_condition_returns_none():
+    assert evaluate_condition(None, {}) is None
+    assert evaluate_condition({}, {}) is None
+
+
+def test_condition_passes_with_complete_data():
+    """Normal path: condition evaluates to True, no missing data (line 51)."""
+    res = evaluate_condition({"==": [{"var": "x"}, 1]}, {"x": 1})
+    assert isinstance(res, ConditionResult)
+    assert res.passed is True
+    assert res.incomplete is False
+
+
+def test_condition_exception_returns_incomplete():
+    res = evaluate_condition({"/": [1, 0]}, {})  # division by zero
+    assert isinstance(res, ConditionResult)
+    assert res.passed is False and res.incomplete is True
+
+
+def test_stringify_none_returns_missing():
+    """Line 64: None condition → 'MISSING'."""
+    out = _stringify_condition(None, {})
+    assert out == "MISSING"
+
+
+def test_stringify_var_missing_value():
+    """Line 74: var not in context → 'key (MISSING)'."""
+    out = _stringify_condition({"var": "x"}, {})
+    assert out == "x (MISSING)"
+
+
+def test_stringify_args_not_list():
+    """Line 78: non-list args are wrapped in a list."""
+    # "!" with a scalar arg (not a list) exercises the `args = [args]` branch
+    out = _stringify_condition({"!": True}, {})
+    assert "True" in out
+
+
+def test_stringify_comparison_fewer_than_two_parts():
+    """Line 87: comparison operator with single arg falls back to func notation."""
+    out = _stringify_condition({"==": [1]}, {})
+    assert out == "==(1)"
+
+
+def test_stringify_not_operator():
+    """Line 91: '!' operator → '!(…)'."""
+    out = _stringify_condition({"!": [{"==": [1, 1]}]}, {})
+    assert out.startswith("!(")
+
+
+def test_stringify_or_operator():
+    """Lines 94-95: 'or' operator joins with ' or '."""
+    out = _stringify_condition({"or": [{"==": [1, 1]}, {"==": [2, 2]}]}, {})
+    assert " or " in out
+
+
+def test_stringify_unknown_operator_fallback():
+    """Lines 96-97: unknown operator falls back to 'op(…)' notation."""
+    out = _stringify_condition({"cat": ["hello", " ", "world"]}, {})
+    assert out.startswith("cat(")
+
+
+def test_stringify_in_operator():
+    out = _stringify_condition({"in": [{"var": "x"}, {"var": "xs"}]}, {"x": "a", "xs": ["a"]})
+    assert " in " in out
+
+
+def test_stringify_and_operator():
+    out = _stringify_condition({"and": [{"==": [1, 1]}, {"==": [2, 2]}]}, {})
+    assert " and " in out

--- a/tests/test_playbook_conditions.py
+++ b/tests/test_playbook_conditions.py
@@ -1,4 +1,5 @@
 """Coverage for regis/playbook/conditions.py branches."""
+
 from regis.playbook.conditions import (
     ConditionResult,
     _stringify_condition,
@@ -69,7 +70,9 @@ def test_stringify_unknown_operator_fallback():
 
 
 def test_stringify_in_operator():
-    out = _stringify_condition({"in": [{"var": "x"}, {"var": "xs"}]}, {"x": "a", "xs": ["a"]})
+    out = _stringify_condition(
+        {"in": [{"var": "x"}, {"var": "xs"}]}, {"x": "a", "xs": ["a"]}
+    )
     assert " in " in out
 
 

--- a/tests/test_playbook_evaluator.py
+++ b/tests/test_playbook_evaluator.py
@@ -1,0 +1,300 @@
+"""Coverage for regis/playbook/evaluator.py branches."""
+
+from __future__ import annotations
+
+import pytest
+
+from regis.playbook.evaluator import _evaluate_pages, _normalize_pages, _resolve_links, evaluate
+
+
+# ---------------------------------------------------------------------------
+# _normalize_pages
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_pages_returns_explicit_pages():
+    pb = {"pages": [{"name": "P1", "sections": []}]}
+    assert _normalize_pages(pb) == pb["pages"]
+
+
+def test_normalize_pages_wraps_bare_sections():
+    pb = {"sections": [{"name": "S1"}]}
+    result = _normalize_pages(pb)
+    assert result == [{"name": "Default", "sections": [{"name": "S1"}]}]
+
+
+def test_normalize_pages_empty_when_neither():
+    assert _normalize_pages({}) == []
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_pages — section condition branches
+# ---------------------------------------------------------------------------
+
+
+def _make_raw_ctx(data: dict) -> dict:
+    """Minimal raw_context helper (flat copy)."""
+    from regis.playbook.context import _flatten
+
+    ctx = _flatten(data)
+    ctx.update(data)
+    return ctx
+
+
+def test_evaluate_pages_section_false_condition_skipped():
+    """A section whose condition is False with no missing data is skipped."""
+    pages = [
+        {
+            "sections": [
+                {
+                    "name": "Skipped",
+                    # {"==": [1, 0]} is always False, no missing keys
+                    "condition": {"==": [1, 0]},
+                    "scorecards": [],
+                }
+            ]
+        }
+    ]
+    raw_ctx = _make_raw_ctx({})
+    pages_results, total, passed = _evaluate_pages(pages, raw_ctx, {})
+    assert total == 0
+    assert pages_results[0]["sections"] == []
+
+
+def test_evaluate_pages_section_condition_missing_data_kept():
+    """A condition referencing a None value marks section as incomplete (kept).
+
+    json_logic uses dict.get() so absent keys return None (not raising KeyError).
+    A None value accessed via __getitem__ triggers missing_accessed=True.
+    We need the condition to evaluate to False while missing_accessed is True,
+    which happens when a key is explicitly None in context.
+    """
+    pages = [
+        {
+            "sections": [
+                {
+                    "name": "MaybeActive",
+                    # score is None → missing_accessed=True; None == True → False
+                    "condition": {"==": [{"var": "score"}, True]},
+                    "scorecards": [],
+                }
+            ]
+        }
+    ]
+    # Include 'score' as None so tracker sees a None value → missing_accessed=True
+    raw_ctx = _make_raw_ctx({"score": None})
+    pages_results, total, passed = _evaluate_pages(pages, raw_ctx, {})
+    # Section must be kept because the None value triggered missing_accessed=True
+    section_names = [s["name"] for s in pages_results[0]["sections"]]
+    assert "MaybeActive" in section_names
+
+
+def test_evaluate_pages_section_condition_invalid_op_no_missing_skipped():
+    """Invalid json-logic operator with no missing keys → exception path → section skipped."""
+    pages = [
+        {
+            "sections": [
+                {
+                    "name": "Invalid",
+                    "condition": {"__bad_op__": [1, 2]},
+                    "scorecards": [],
+                }
+            ]
+        }
+    ]
+    raw_ctx = _make_raw_ctx({"some_key": "value"})
+    pages_results, total, passed = _evaluate_pages(pages, raw_ctx, {})
+    section_names = [s["name"] for s in pages_results[0]["sections"]]
+    assert "Invalid" not in section_names
+
+
+def test_evaluate_pages_section_condition_exception_missing_data_kept():
+    """Invalid op + None value accessed → exception path → section kept (incomplete).
+
+    json_logic evaluates var operands before the op check, so accessing a None
+    value via __getitem__ sets missing_accessed=True even when the op raises.
+    """
+    pages = [
+        {
+            "sections": [
+                {
+                    "name": "ExcButMissing",
+                    # 'score' is None → missing_accessed=True, then __bad_op__ raises
+                    "condition": {"__bad_op__": [{"var": "score"}, 1]},
+                    "scorecards": [],
+                }
+            ]
+        }
+    ]
+    raw_ctx = _make_raw_ctx({"score": None})
+    pages_results, total, passed = _evaluate_pages(pages, raw_ctx, {})
+    # Because 'score' is None, tracker.missing_accessed is True → section kept
+    section_names = [s["name"] for s in pages_results[0]["sections"]]
+    assert "ExcButMissing" in section_names
+
+
+# ---------------------------------------------------------------------------
+# _resolve_links
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_links_format_from_report():
+    """URL with {key} placeholders is formatted from the report dict."""
+    playbook = {"links": [{"label": "Repo", "url": "https://github.com/{repo}"}]}
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {"repo": "acme/regis"})
+    assert result["links"] == [{"label": "Repo", "url": "https://github.com/acme/regis"}]
+
+
+def test_resolve_links_missing_key_skipped():
+    """URL referencing a missing key triggers exception → link is skipped."""
+    playbook = {"links": [{"label": "Missing", "url": "https://example.com/{no_such_key}"}]}
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {})
+    assert "links" not in result
+
+
+def test_resolve_links_condition_false_skipped():
+    """Link with a False condition is not included."""
+    playbook = {
+        "links": [
+            {"label": "Nope", "url": "https://x.com", "condition": {"==": [1, 0]}}
+        ]
+    }
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {})
+    assert "links" not in result
+
+
+def test_resolve_links_condition_exception_skipped():
+    """Link whose condition raises is skipped."""
+    playbook = {
+        "links": [
+            {"label": "Bad", "url": "https://x.com", "condition": {"__bad_op__": [1, 2]}}
+        ]
+    }
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {})
+    assert "links" not in result
+
+
+# ---------------------------------------------------------------------------
+# evaluate — tier / badge / label branches
+# ---------------------------------------------------------------------------
+
+
+def test_badge_without_value_uses_scope_as_label():
+    """Badge with no value gets label == scope."""
+    out = evaluate({"name": "x", "badges": [{"slug": "s", "scope": "Status"}]}, {})
+    badge = out["badges"][0]
+    assert badge["label"] == "Status"
+    assert badge["value"] is None
+
+
+def test_badge_value_interpolation():
+    """${var} in badge value is interpolated from the full context."""
+    pb = {
+        "name": "x",
+        "badges": [{"slug": "v", "scope": "Version", "value": "${version}"}],
+    }
+    out = evaluate(pb, {"version": "1.2.3"})
+    assert out["badges"][0]["value"] == "1.2.3"
+    assert out["badges"][0]["label"] == "Version: 1.2.3"
+
+
+def test_badge_condition_exception_is_skipped():
+    """Badge whose condition raises is omitted from results."""
+    pb = {
+        "name": "x",
+        "badges": [
+            {"slug": "bad", "scope": "T", "value": "X", "condition": {"__bad_op__": [1, 2]}},
+        ],
+    }
+    out = evaluate(pb, {})
+    assert all(b["slug"] != "bad" for b in out.get("badges", []))
+
+
+def test_badge_condition_false_is_skipped():
+    """Badge whose condition is False is omitted."""
+    pb = {
+        "name": "x",
+        "badges": [
+            {"slug": "hidden", "scope": "T", "value": "X", "condition": {"==": [1, 0]}},
+        ],
+    }
+    out = evaluate(pb, {})
+    assert all(b["slug"] != "hidden" for b in out.get("badges", []))
+
+
+def test_tier_condition_exception_does_not_crash():
+    """A tier whose condition raises should be silently skipped without crashing."""
+    pb = {
+        "name": "x",
+        "tiers": [
+            {"name": "Gold", "condition": {"__bad_op__": [1, 2]}},
+        ],
+    }
+    out = evaluate(pb, {})
+    assert "tier" not in out
+
+
+def test_tier_condition_matched():
+    """A tier whose condition is True is set in the result."""
+    pb = {
+        "name": "x",
+        "tiers": [
+            {"name": "Gold", "icon": "star", "condition": {"==": [1, 1]}},
+        ],
+    }
+    out = evaluate(pb, {})
+    assert out["tier"] == "Gold"
+    assert out["tier_icon"] == "star"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_links — edge cases (lines 123, 142, 146)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_links_non_dict_link_skipped():
+    """Non-dict items in links list are silently skipped (line 123)."""
+    playbook = {"links": ["not-a-dict", {"label": "OK", "url": "https://x.com"}]}
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {})
+    assert result["links"] == [{"label": "OK", "url": "https://x.com"}]
+
+
+def test_resolve_links_non_string_url_skipped():
+    """Link with a non-string url is skipped (line 142)."""
+    playbook = {"links": [{"label": "No URL"}, {"label": "OK", "url": "https://y.com"}]}
+    result: dict = {}
+    _resolve_links(playbook, result, {}, {})
+    assert result["links"] == [{"label": "OK", "url": "https://y.com"}]
+
+
+def test_resolve_links_jinja2_template_url():
+    """URL containing {{ }} is resolved via _resolve_template (line 146)."""
+    playbook = {"links": [{"label": "Tmpl", "url": "https://x.com/{{ repo }}"}]}
+    result: dict = {}
+    full_context = {"repo": "acme/regis"}
+    _resolve_links(playbook, result, full_context, {})
+    assert "links" in result
+    assert "acme/regis" in result["links"][0]["url"]
+
+
+# ---------------------------------------------------------------------------
+# evaluate — sidebar and source_name (lines 294, 300)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_sidebar_passed_through():
+    """Playbook with a sidebar dict attaches it to the result (line 294)."""
+    pb = {"name": "x", "sidebar": {"items": ["Foo", "Bar"]}}
+    out = evaluate(pb, {})
+    assert out["sidebar"] == {"items": ["Foo", "Bar"]}
+
+
+def test_evaluate_source_name_set():
+    """source_name parameter populates _meta in the result (line 300)."""
+    out = evaluate({"name": "x"}, {}, source_name="my-playbook.yaml")
+    assert out["_meta"] == {"source_name": "my-playbook.yaml"}

--- a/tests/test_playbook_evaluator.py
+++ b/tests/test_playbook_evaluator.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from regis.playbook.evaluator import _evaluate_pages, _normalize_pages, _resolve_links, evaluate
-
+from regis.playbook.evaluator import (
+    _evaluate_pages,
+    _normalize_pages,
+    _resolve_links,
+    evaluate,
+)
 
 # ---------------------------------------------------------------------------
 # _normalize_pages
@@ -143,12 +147,16 @@ def test_resolve_links_format_from_report():
     playbook = {"links": [{"label": "Repo", "url": "https://github.com/{repo}"}]}
     result: dict = {}
     _resolve_links(playbook, result, {}, {"repo": "acme/regis"})
-    assert result["links"] == [{"label": "Repo", "url": "https://github.com/acme/regis"}]
+    assert result["links"] == [
+        {"label": "Repo", "url": "https://github.com/acme/regis"}
+    ]
 
 
 def test_resolve_links_missing_key_skipped():
     """URL referencing a missing key triggers exception → link is skipped."""
-    playbook = {"links": [{"label": "Missing", "url": "https://example.com/{no_such_key}"}]}
+    playbook = {
+        "links": [{"label": "Missing", "url": "https://example.com/{no_such_key}"}]
+    }
     result: dict = {}
     _resolve_links(playbook, result, {}, {})
     assert "links" not in result
@@ -170,7 +178,11 @@ def test_resolve_links_condition_exception_skipped():
     """Link whose condition raises is skipped."""
     playbook = {
         "links": [
-            {"label": "Bad", "url": "https://x.com", "condition": {"__bad_op__": [1, 2]}}
+            {
+                "label": "Bad",
+                "url": "https://x.com",
+                "condition": {"__bad_op__": [1, 2]},
+            }
         ]
     }
     result: dict = {}
@@ -207,7 +219,12 @@ def test_badge_condition_exception_is_skipped():
     pb = {
         "name": "x",
         "badges": [
-            {"slug": "bad", "scope": "T", "value": "X", "condition": {"__bad_op__": [1, 2]}},
+            {
+                "slug": "bad",
+                "scope": "T",
+                "value": "X",
+                "condition": {"__bad_op__": [1, 2]},
+            },
         ],
     }
     out = evaluate(pb, {})

--- a/tests/test_playbook_sections.py
+++ b/tests/test_playbook_sections.py
@@ -1,0 +1,417 @@
+"""Coverage for regis/playbook/sections.py branches.
+
+Targets the following uncovered lines (as of initial measurement):
+  33-47   _evaluate_scorecards: _pre_evaluated fast-path
+  57-64   _evaluate_scorecards: exception branch (bad condition)
+  154-168 _evaluate_widgets: condition evaluation error
+  180     _evaluate_widgets: options.subvalue resolution
+  187     _evaluate_widgets: url template resolution
+  217     _build_render_order: tags_summary exists but scorecards not in render_order
+  237-265 _evaluate_section: rules list slug resolution (found & not found)
+  290     _evaluate_section: hint preserved
+  292     _evaluate_section: condition preserved
+  328-332 resolve_widgets_final: section condition False → section dropped
+  338-342 resolve_widgets_final: widget condition False → widget dropped
+  365     resolve_widgets_final: subvalue re-resolution
+  377     resolve_widgets_final: url re-resolution
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from regis.playbook.sections import (
+    _build_render_order,
+    _evaluate_scorecards,
+    _evaluate_section,
+    _evaluate_widgets,
+    resolve_widgets_final,
+)
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_scorecards
+# ---------------------------------------------------------------------------
+
+
+def test_pre_evaluated_scorecard_is_passed_through():
+    """Lines 33-47: _pre_evaluated branch copies _rule_result fields."""
+    defs = [
+        {
+            "_pre_evaluated": True,
+            "_rule_result": {
+                "slug": "r1",
+                "description": "Rule one",
+                "level": "bronze",
+                "tags": ["security"],
+                "analyzers": ["cve"],
+                "passed": True,
+                "status": "passed",
+                "message": "all good",
+            },
+        }
+    ]
+    out = _evaluate_scorecards(defs, {})
+    assert len(out) == 1
+    sc = out[0]
+    assert sc["name"] == "r1"
+    assert sc["description"] == "Rule one"
+    assert sc["title"] == "Rule one"
+    assert sc["level"] == "bronze"
+    assert sc["tags"] == ["security"]
+    assert sc["analyzers"] == ["cve"]
+    assert sc["passed"] is True
+    assert sc["status"] == "passed"
+    assert sc["message"] == "all good"
+
+
+def test_pre_evaluated_scorecard_uses_slug_as_description_fallback():
+    """Lines 33-47: when description absent, slug is used as description/title."""
+    defs = [
+        {
+            "_pre_evaluated": True,
+            "_rule_result": {
+                "slug": "no-desc",
+                "description": None,
+                "level": "silver",
+                "tags": [],
+                "analyzers": [],
+                "passed": False,
+                "status": "failed",
+                "message": "fail",
+            },
+        }
+    ]
+    out = _evaluate_scorecards(defs, {})
+    assert out[0]["description"] == "no-desc"
+    assert out[0]["title"] == "no-desc"
+
+
+def test_scorecard_condition_exception_marks_incomplete():
+    """Lines 57-64: an invalid condition raises → passed=False, status=incomplete."""
+    # Use a badly-typed condition that json_logic cannot evaluate without error.
+    # Passing a non-iterable as an operator key works reliably.
+    defs = [
+        {
+            "name": "bad-rule",
+            "level": "bronze",
+            "tags": [],
+            # "==" expects a list; passing an int triggers an error inside jsonLogic
+            "condition": {"==": 42},
+        }
+    ]
+    out = _evaluate_scorecards(defs, {})
+    assert len(out) == 1
+    assert out[0]["passed"] is False
+    assert out[0]["status"] == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_widgets
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_widgets_subvalue_resolved():
+    """Line 180: options.subvalue path is resolved into resolved_subvalue."""
+    raw_context = {"score": 80}
+    widgets = [{"label": "w", "options": {"subvalue": "score"}}]
+    out = _evaluate_widgets(widgets, raw_context, None)
+    assert len(out) == 1
+    assert out[0]["resolved_subvalue"] == 80
+
+
+def test_evaluate_widgets_url_template_resolved():
+    """Line 187: url template is resolved into resolved_url."""
+    raw_context = {"image": "nginx:1.25"}
+    widgets = [{"label": "w", "url": "https://example.com/{{ image }}"}]
+    out = _evaluate_widgets(widgets, raw_context, {"image": "nginx:1.25"})
+    assert len(out) == 1
+    assert out[0]["resolved_url"] == "https://example.com/nginx:1.25"
+
+
+def test_evaluate_widgets_condition_error_with_missing_data_keeps_widget():
+    """Lines 154-168: condition raises AND missing data → widget is kept (not dropped).
+
+    We mock MissingDataTracker to force missing_accessed=True so that the except branch
+    (line 166-168) takes the "keep" path rather than ``continue``.
+    """
+    from unittest.mock import patch, MagicMock
+
+    mock_tracker = MagicMock()
+    mock_tracker.missing_accessed = True  # simulate prior missing access
+    mock_tracker.accessed_keys = set()
+
+    with patch(
+        "regis.playbook.sections.MissingDataTracker", return_value=mock_tracker
+    ):
+        # Use an invalid operator so jsonLogic raises
+        widgets = [{"label": "w", "condition": {"$INVALID$": []}}]
+        out = _evaluate_widgets(widgets, {"x": 1}, None)
+
+    # Widget must be kept because missing_accessed was True when exception occurred
+    assert len(out) == 1
+    assert out[0]["label"] == "w"
+
+
+def test_evaluate_widgets_condition_false_no_missing_drops_widget():
+    """Lines 155-160: condition evaluates to False with no missing data → widget dropped."""
+    raw_context = {"x": 0}
+    widgets = [
+        {"label": "drop", "condition": {"==": [{"var": "x"}, 1]}},
+        {"label": "keep", "condition": {"==": [{"var": "x"}, 0]}},
+    ]
+    out = _evaluate_widgets(widgets, raw_context, None)
+    assert len(out) == 1
+    assert out[0]["label"] == "keep"
+
+
+def test_evaluate_widgets_condition_error_no_missing_drops_widget():
+    """Lines 161-168: condition raises AND missing_accessed is False → widget dropped."""
+    # An invalid operator that raises without triggering key access.
+    # We pre-populate all keys the condition might touch; the bad op raises before any lookup.
+    raw_context = {"x": 1}
+    # {"bad_op": [1, 2]} will raise "Unrecognised operation" immediately, before any
+    # key lookup, so missing_accessed stays False → widget is dropped.
+    widgets = [{"label": "w", "condition": {"$INVALID_OP$": [1, 2]}}]
+    out = _evaluate_widgets(widgets, raw_context, None)
+    assert len(out) == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_render_order
+# ---------------------------------------------------------------------------
+
+
+def test_build_render_order_tags_appended_when_no_scorecards_key():
+    """Line 217: tags_summary present but 'scorecards' not in render_order → tags appended."""
+    # A section with widgets only → 'scorecards' is not in render_order
+    section = {"widgets": []}
+    tags_summary = {"security": {"total": 1, "passed": 1, "percentage": 100}}
+    order = _build_render_order(section, tags_summary)
+    assert "tags" in order
+    assert "scorecards" not in order
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_section — rules list, hint, condition
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(slug: str, passed: bool = True) -> dict:
+    return {
+        "slug": slug,
+        "description": f"Rule {slug}",
+        "level": "bronze",
+        "tags": ["sec"],
+        "analyzers": [],
+        "passed": passed,
+        "status": "passed" if passed else "failed",
+        "message": "",
+    }
+
+
+def test_section_rule_reference_found_by_exact_slug():
+    """Lines 237-263: rule slug found in rules registry → appended as pre-evaluated scorecard."""
+    rule = _make_rule("my-rule")
+    ctx = {"rules": {"my-rule": rule}}
+    section = {"name": "S", "rules": ["my-rule"]}
+    out = _evaluate_section(section, ctx)
+    assert any(sc["name"] == "my-rule" for sc in out["scorecards"])
+
+
+def test_section_rule_reference_found_by_dotted_slug():
+    """Lines 237-263: 'provider.slug' format — slug part used for lookup."""
+    rule = _make_rule("my-rule")
+    ctx = {"rules": {"my-rule": rule}}
+    section = {"name": "S", "rules": ["provider.my-rule"]}
+    out = _evaluate_section(section, ctx)
+    assert any(sc["name"] == "my-rule" for sc in out["scorecards"])
+
+
+def test_section_rule_reference_not_found_logs_warning(caplog):
+    """Lines 264-269: rule not found → warning logged, no scorecard added."""
+    import logging
+
+    ctx = {"rules": {}}
+    section = {"name": "S", "rules": ["missing-rule"]}
+    with caplog.at_level(logging.WARNING, logger="regis.playbook.sections"):
+        out = _evaluate_section(section, ctx)
+    assert out["scorecards"] == []
+    assert "missing-rule" in caplog.text
+
+
+def test_section_rule_reference_non_string_skipped():
+    """Lines 239-241: non-string entries in rules list are silently skipped."""
+    ctx = {"rules": {}}
+    section = {"name": "S", "rules": [42, None]}
+    out = _evaluate_section(section, ctx)
+    assert out["scorecards"] == []
+
+
+def test_section_hint_preserved():
+    """Line 290: hint key from section dict is propagated to result."""
+    out = _evaluate_section({"name": "S", "hint": "read the docs", "scorecards": []}, {})
+    assert out["hint"] == "read the docs"
+
+
+def test_section_condition_preserved():
+    """Line 292: condition key from section dict is propagated to result."""
+    cond = {"==": [1, 1]}
+    out = _evaluate_section({"name": "S", "condition": cond, "scorecards": []}, {})
+    assert out["condition"] == cond
+
+
+def test_section_without_hint_has_no_hint_key():
+    """Negative: when no hint provided, result must not contain the hint key."""
+    out = _evaluate_section({"name": "S", "scorecards": []}, {})
+    assert "hint" not in out
+
+
+# ---------------------------------------------------------------------------
+# resolve_widgets_final
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_widgets_final_drops_section_with_false_condition():
+    """Lines 328-332: section whose condition evaluates to False is removed."""
+    pages = [
+        {
+            "sections": [
+                {
+                    "name": "keep",
+                    "condition": {"==": [1, 1]},
+                    "widgets": [],
+                },
+                {
+                    "name": "drop",
+                    "condition": {"==": [1, 0]},
+                    "widgets": [],
+                },
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, {})
+    names = [s["name"] for s in pages[0]["sections"]]
+    assert names == ["keep"]
+
+
+def test_resolve_widgets_final_drops_section_with_exception_condition():
+    """Lines 328-332: section whose condition raises is also removed."""
+    pages = [
+        {
+            "sections": [
+                {"name": "bad", "condition": {"$INVALID$": []}, "widgets": []},
+                {"name": "good", "widgets": []},
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, {})
+    names = [s["name"] for s in pages[0]["sections"]]
+    assert names == ["good"]
+
+
+def test_resolve_widgets_final_drops_widget_with_false_condition():
+    """Lines 338-342: widget whose condition evaluates to False is removed."""
+    pages = [
+        {
+            "sections": [
+                {
+                    "widgets": [
+                        {"label": "keep", "condition": {"==": [1, 1]}},
+                        {"label": "drop", "condition": {"==": [1, 0]}},
+                    ]
+                }
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, {})
+    labels = [w["label"] for w in pages[0]["sections"][0]["widgets"]]
+    assert labels == ["keep"]
+
+
+def test_resolve_widgets_final_drops_widget_with_exception_condition():
+    """Lines 338-342: widget whose condition raises is also removed."""
+    pages = [
+        {
+            "sections": [
+                {
+                    "widgets": [
+                        {"label": "bad", "condition": {"$INVALID$": []}},
+                        {"label": "good"},
+                    ]
+                }
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, {})
+    labels = [w["label"] for w in pages[0]["sections"][0]["widgets"]]
+    assert labels == ["good"]
+
+
+def test_resolve_widgets_final_re_resolves_subvalue_when_none():
+    """Line 365: resolved_subvalue is None → re-resolved from full_context."""
+    full_ctx = {"score": 42}
+    pages = [
+        {
+            "sections": [
+                {
+                    "widgets": [
+                        {
+                            "label": "w",
+                            "options": {"subvalue": "score"},
+                            "resolved_subvalue": None,
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, full_ctx)
+    widget = pages[0]["sections"][0]["widgets"][0]
+    assert widget["resolved_subvalue"] == 42
+
+
+def test_resolve_widgets_final_re_resolves_url_when_none():
+    """Line 377: resolved_url is None → re-resolved from full_context."""
+    full_ctx = {"image": "redis:7"}
+    pages = [
+        {
+            "sections": [
+                {
+                    "widgets": [
+                        {
+                            "label": "w",
+                            "url": "https://hub.docker.com/r/{{ image }}",
+                            "resolved_url": None,
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, full_ctx)
+    widget = pages[0]["sections"][0]["widgets"][0]
+    assert widget["resolved_url"] == "https://hub.docker.com/r/redis:7"
+
+
+def test_resolve_widgets_final_re_resolves_value_with_playbook_prefix():
+    """Lines 346-355: value starting with 'playbook' prefix → re-resolved even if not None."""
+    full_ctx = {"playbook": {"name": "default"}, "score": 0}
+    pages = [
+        {
+            "sections": [
+                {
+                    "widgets": [
+                        {
+                            "label": "w",
+                            "value": "playbook.name",
+                            "resolved_value": "stale",
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+    resolve_widgets_final(pages, full_ctx)
+    widget = pages[0]["sections"][0]["widgets"][0]
+    assert widget["resolved_value"] == "default"

--- a/tests/test_playbook_sections.py
+++ b/tests/test_playbook_sections.py
@@ -28,7 +28,6 @@ from regis.playbook.sections import (
     resolve_widgets_final,
 )
 
-
 # ---------------------------------------------------------------------------
 # _evaluate_scorecards
 # ---------------------------------------------------------------------------
@@ -135,15 +134,13 @@ def test_evaluate_widgets_condition_error_with_missing_data_keeps_widget():
     We mock MissingDataTracker to force missing_accessed=True so that the except branch
     (line 166-168) takes the "keep" path rather than ``continue``.
     """
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import MagicMock, patch
 
     mock_tracker = MagicMock()
     mock_tracker.missing_accessed = True  # simulate prior missing access
     mock_tracker.accessed_keys = set()
 
-    with patch(
-        "regis.playbook.sections.MissingDataTracker", return_value=mock_tracker
-    ):
+    with patch("regis.playbook.sections.MissingDataTracker", return_value=mock_tracker):
         # Use an invalid operator so jsonLogic raises
         widgets = [{"label": "w", "condition": {"$INVALID$": []}}]
         out = _evaluate_widgets(widgets, {"x": 1}, None)
@@ -250,7 +247,9 @@ def test_section_rule_reference_non_string_skipped():
 
 def test_section_hint_preserved():
     """Line 290: hint key from section dict is propagated to result."""
-    out = _evaluate_section({"name": "S", "hint": "read the docs", "scorecards": []}, {})
+    out = _evaluate_section(
+        {"name": "S", "hint": "read the docs", "scorecards": []}, {}
+    )
     assert out["hint"] == "read the docs"
 
 

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -1,8 +1,11 @@
 """Tests for rules evaluator."""
 
+import warnings
+
 import pytest
 
 from regis.rules.evaluator import (
+    _interpolate_string,
     evaluate_rules,
     get_criterion_templates,
     resolve_rules,
@@ -214,8 +217,6 @@ def test_criterion_key_does_not_warn():
         ]
     }
 
-    import warnings
-
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         evaluate_rules(report, new_def)
@@ -331,3 +332,295 @@ def test_missing_results_still_incomplete():
     res = evaluate_rules(report, rules_def)
     rule = next(r for r in res["rules"] if r["slug"] == "needs-cve")
     assert rule["status"] == "incomplete"
+
+
+# ---------------------------------------------------------------------------
+# _interpolate_string edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_empty_template_returns_input():
+    assert _interpolate_string("", {}) == ""
+
+
+def test_interpolate_list_length():
+    ctx = {"items": ["a", "b", "c"]}
+    assert _interpolate_string("n=${items.length}", ctx) == "n=3"
+
+
+def test_interpolate_list_index():
+    ctx = {"items": ["a", "b", "c"]}
+    assert _interpolate_string("first=${items.0}", ctx) == "first=a"
+    assert _interpolate_string("last=${items.2}", ctx) == "last=c"
+
+
+def test_interpolate_list_index_out_of_range_keeps_placeholder():
+    assert _interpolate_string("x=${items.9}", {"items": ["a"]}) == "x=${items.9}"
+
+
+def test_interpolate_list_invalid_part_keeps_placeholder():
+    """A non-integer, non-'length' part on a list keeps the placeholder."""
+    assert (
+        _interpolate_string("x=${items.foo}", {"items": ["a", "b"]}) == "x=${items.foo}"
+    )
+
+
+def test_interpolate_missing_nested_key_returns_missing():
+    """A path that reaches a dict but the key is absent returns MISSING."""
+    ctx = {"data": {"a": 1}}
+    assert _interpolate_string("v=${data.b}", ctx) == "v=MISSING"
+
+
+# ---------------------------------------------------------------------------
+# Custom JSON Logic operators — non-list / non-dict inputs return False / []
+# ---------------------------------------------------------------------------
+
+
+def test_custom_operators_with_non_list_inputs():
+    """intersects, contains_all, subset, env_contains return False for non-list inputs."""
+    from json_logic import jsonLogic
+
+    import regis.rules.evaluator  # noqa: F401 — ensures operators are registered
+
+    # intersects: non-list inputs
+    assert jsonLogic({"intersects": ["not-a-list", ["a"]]}, {}) is False
+    assert jsonLogic({"intersects": [["a"], "not-a-list"]}, {}) is False
+
+    # contains_all: non-list inputs
+    assert jsonLogic({"contains_all": ["x", ["a"]]}, {}) is False
+
+    # subset: non-list inputs
+    assert jsonLogic({"subset": ["x", ["a"]]}, {}) is False
+
+    # env_contains: non-list inputs
+    assert jsonLogic({"env_contains": ["not-list", ["sub"]]}, {}) is False
+
+
+def test_keys_operator_with_non_dict_returns_empty():
+    """keys() returns [] for non-dict input."""
+    from json_logic import jsonLogic
+
+    import regis.rules.evaluator  # noqa: F401
+
+    assert jsonLogic({"keys": [{"var": "v"}]}, {"v": "not-a-dict"}) == []
+    assert jsonLogic({"keys": [{"var": "v"}]}, {"v": ["a", "b"]}) == []
+
+
+def test_get_operator_with_non_dict_returns_none():
+    """get() returns None for non-dict data."""
+    from json_logic import jsonLogic
+
+    import regis.rules.evaluator  # noqa: F401
+
+    assert jsonLogic({"get": [{"var": "v"}, "key"]}, {"v": "not-a-dict"}) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — merge when same (provider, slug) appears twice
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_merges_duplicate_slug():
+    """Two declared rules with the same (provider, slug) merge messages and params."""
+    templates = []
+    declared = [
+        {
+            "provider": "custom",
+            "slug": "my-rule",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "v1-pass", "fail": "v1-fail"},
+            "params": {"threshold": 10},
+        },
+        {
+            "provider": "custom",
+            "slug": "my-rule",
+            "messages": {"fail": "v2-fail"},
+            "params": {"extra": True},
+        },
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    rule = resolved[0]
+    # Messages merged: v2-fail overrides v1-fail, v1-pass preserved
+    assert rule["messages"]["pass"] == "v1-pass"
+    assert rule["messages"]["fail"] == "v2-fail"
+    # Params merged
+    assert rule["params"]["threshold"] == 10
+    assert rule["params"]["extra"] is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — Case A: slug auto-generation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_autogenerate_slug_with_level():
+    """When no slug is given and options contains 'level', slug becomes <template>.<level>."""
+    templates = [
+        {
+            "provider": "cve",
+            "slug": "cve-count",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "err"},
+        }
+    ]
+    declared = [
+        {
+            "provider": "cve",
+            "criterion": "cve-count",
+            "options": {"level": "critical"},
+            # No slug provided
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    assert resolved[0]["slug"] == "cve-count.critical"
+
+
+def test_resolve_rules_autogenerate_slug_without_level():
+    """When no slug and no 'level' in options, slug becomes <template>.<index>."""
+    templates = [
+        {
+            "provider": "cve",
+            "slug": "cve-count",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "err"},
+        }
+    ]
+    declared = [
+        {
+            "provider": "cve",
+            "criterion": "cve-count",
+            # No slug, no level in options
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    assert resolved[0]["slug"] == "cve-count.0"
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — Case A: template not found but slug provided
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_template_not_found_with_slug_appends_raw():
+    """When template is not found but a slug is given, the raw rule_def is kept."""
+    templates = []
+    declared = [
+        {
+            "provider": "nonexistent",
+            "criterion": "ghost-template",
+            "slug": "fallback-rule",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "err"},
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    assert resolved[0]["slug"] == "fallback-rule"
+    assert resolved[0]["provider"] == "nonexistent"
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — Case B: explicit provider on a standalone rule
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_case_b_explicit_provider():
+    """Case B with an explicit provider: provider and slug stay as given."""
+    templates = []
+    declared = [
+        {
+            "provider": "myteam",
+            "slug": "custom-check",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "err"},
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    assert resolved[0]["provider"] == "myteam"
+    assert resolved[0]["slug"] == "custom-check"
+
+
+def test_resolve_rules_case_b_no_rule_id_skipped():
+    """A declared rule with no criterion, rule, or slug is silently skipped."""
+    templates = []
+    declared = [{"condition": {"==": [1, 1]}}]
+    resolved = resolve_rules(templates, declared)
+    assert resolved == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — Case A fallback: template found via regis.analyzers.<provider>
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_fallback_prefixed_provider():
+    """A template registered under 'regis.analyzers.myprov' is found via plain 'myprov'."""
+    templates = [
+        {
+            "provider": "regis.analyzers.myprov",
+            "slug": "some-check",
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "err"},
+        }
+    ]
+    declared = [
+        {
+            "provider": "myprov",
+            "criterion": "some-check",
+            "slug": "my-check",
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert len(resolved) == 1
+    assert resolved[0]["slug"] == "my-check"
+
+
+# ---------------------------------------------------------------------------
+# resolve_rules — last-resort: template loaded directly from the analyzer class
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rules_last_resort_loads_from_analyzer():
+    """When template is absent from catalogue, it is loaded directly from the analyzer."""
+    # The 'freshness' analyzer is present; its 'age' template should be found
+    # even when we pass an empty templates list.
+    resolved = resolve_rules(
+        [],
+        [
+            {
+                "provider": "freshness",
+                "criterion": "age",
+                "slug": "age-direct",
+            }
+        ],
+    )
+    assert len(resolved) == 1
+    assert resolved[0]["slug"] == "age-direct"
+    assert "condition" in resolved[0]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_rules — exception in jsonLogic marks rule as failed
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_rules_condition_exception_marks_failed():
+    """A rule whose condition raises an exception is marked failed, not crashed."""
+    report = {"request": {"registry": "docker.io", "analyzers": []}, "results": {}}
+    rules_def = {
+        "rules": [
+            {
+                "slug": "bad-op",
+                "condition": {"__nonexistent_op__": [1, 2]},
+                "messages": {"pass": "ok", "fail": "err"},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    bad = next(r for r in res["rules"] if r["slug"] == "bad-op")
+    assert bad["passed"] is False
+    assert bad["status"] == "failed"

--- a/tests/test_utils_process.py
+++ b/tests/test_utils_process.py
@@ -1,11 +1,73 @@
 """Tests for regis.utils.process helpers."""
 
-from unittest.mock import patch
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 
-from regis.utils.process import require_tool
+from regis.utils.process import (
+    _default_fetcher,
+    _manifest_names,
+    ensure_tool,
+    require_tool,
+    run_cmd,
+)
+
+
+class TestRunCmd:
+    def test_returns_completed_process_on_success(self):
+        result = subprocess.CompletedProcess(
+            ["echo", "hi"], 0, stdout="hi\n", stderr=""
+        )
+        with patch("regis.utils.process.subprocess.run", return_value=result):
+            out = run_cmd(["echo", "hi"])
+        assert out.returncode == 0
+
+    def test_raises_on_nonzero_with_stderr(self):
+        result = subprocess.CompletedProcess(["x"], 1, stdout="", stderr="boom")
+        with patch("regis.utils.process.subprocess.run", return_value=result):
+            with pytest.raises(click.ClickException) as exc:
+                run_cmd(["x"], check=True)
+        assert "boom" in exc.value.message
+
+    def test_raises_on_nonzero_falls_back_to_stdout_when_no_stderr(self):
+        result = subprocess.CompletedProcess(["x"], 1, stdout="out msg", stderr="")
+        with patch("regis.utils.process.subprocess.run", return_value=result):
+            with pytest.raises(click.ClickException) as exc:
+                run_cmd(["x"], check=True)
+        assert "out msg" in exc.value.message
+
+    def test_no_raise_when_check_false(self):
+        result = subprocess.CompletedProcess(["x"], 1, stdout="", stderr="boom")
+        with patch("regis.utils.process.subprocess.run", return_value=result):
+            out = run_cmd(["x"], check=False)
+        assert out.returncode == 1
+
+    def test_raises_on_missing_binary(self):
+        with patch("regis.utils.process.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(click.ClickException) as exc:
+                run_cmd(["nope"], check=True)
+        assert "not found in PATH" in exc.value.message
+
+    def test_step_label_appears_in_error_message(self):
+        result = subprocess.CompletedProcess(["x"], 2, stdout="", stderr="err")
+        with patch("regis.utils.process.subprocess.run", return_value=result):
+            with pytest.raises(click.ClickException) as exc:
+                run_cmd(["x"], check=True, step_label="my-step")
+        assert "my-step" in exc.value.message
+
+    def test_cwd_is_forwarded(self):
+        result = subprocess.CompletedProcess(["x"], 0, stdout="", stderr="")
+        with patch(
+            "regis.utils.process.subprocess.run", return_value=result
+        ) as mock_run:
+            run_cmd(["x"], cwd="/tmp")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["cwd"] == "/tmp"
 
 
 class TestRequireTool:
@@ -26,3 +88,87 @@ class TestRequireTool:
             require_tool("foo", install_hint=hint)
         assert "'foo' not found in PATH" in exc_info.value.message
         assert hint in exc_info.value.message
+
+
+class TestLazyHelpers:
+    def setup_method(self):
+        # lru_cache must be cleared so patching takes effect each test
+        _default_fetcher.cache_clear()
+        _manifest_names.cache_clear()
+
+    def test_default_fetcher_returns_tool_fetcher_instance(self):
+        mock_fetcher_cls = MagicMock()
+        mock_instance = MagicMock()
+        mock_fetcher_cls.return_value = mock_instance
+        with patch("regis.tools.fetcher.ToolFetcher", mock_fetcher_cls):
+            fetcher = _default_fetcher()
+        assert fetcher is mock_instance
+
+    def test_manifest_names_returns_frozenset(self):
+        with patch(
+            "regis.tools.manifest.load_manifest", return_value={"grype": {}, "syft": {}}
+        ):
+            names = _manifest_names()
+        assert isinstance(names, frozenset)
+        assert "grype" in names
+        assert "syft" in names
+
+
+class TestEnsureTool:
+    def setup_method(self):
+        _default_fetcher.cache_clear()
+        _manifest_names.cache_clear()
+
+    def test_returns_path_when_found_in_host(self):
+        with patch(
+            "regis.utils.process.shutil.which", return_value="/usr/local/bin/grype"
+        ):
+            result = ensure_tool("grype")
+        assert result == "/usr/local/bin/grype"
+
+    def test_fetches_from_manifest_when_not_in_path(self):
+        mock_fetcher = MagicMock()
+        mock_fetcher.ensure.return_value = "/cache/grype"
+        with (
+            patch("regis.utils.process.shutil.which", return_value=None),
+            patch(
+                "regis.utils.process._manifest_names", return_value=frozenset({"grype"})
+            ),
+            patch("regis.utils.process._default_fetcher", return_value=mock_fetcher),
+        ):
+            result = ensure_tool("grype")
+        assert result == "/cache/grype"
+
+    def test_wraps_fetch_error_as_click_exception(self):
+        from regis.tools.fetcher import ToolFetchError
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.ensure.side_effect = ToolFetchError("dl failed")
+        with (
+            patch("regis.utils.process.shutil.which", return_value=None),
+            patch(
+                "regis.utils.process._manifest_names", return_value=frozenset({"grype"})
+            ),
+            patch("regis.utils.process._default_fetcher", return_value=mock_fetcher),
+        ):
+            with pytest.raises(click.ClickException) as exc:
+                ensure_tool("grype")
+        assert "dl failed" in exc.value.message
+
+    def test_raises_when_not_in_path_and_not_in_manifest(self):
+        with (
+            patch("regis.utils.process.shutil.which", return_value=None),
+            patch("regis.utils.process._manifest_names", return_value=frozenset()),
+        ):
+            with pytest.raises(click.ClickException) as exc:
+                ensure_tool("ghost")
+        assert "not found in PATH" in exc.value.message
+
+    def test_raises_with_install_hint_when_not_in_manifest(self):
+        with (
+            patch("regis.utils.process.shutil.which", return_value=None),
+            patch("regis.utils.process._manifest_names", return_value=frozenset()),
+        ):
+            with pytest.raises(click.ClickException) as exc:
+                ensure_tool("ghost", install_hint="brew install ghost")
+        assert "brew install ghost" in exc.value.message

--- a/tests/tools/test_cosign.py
+++ b/tests/tools/test_cosign.py
@@ -31,14 +31,15 @@ def test_verify_blob_success(monkeypatch, tmp_path):
         verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
     cmd = run.call_args[0][0]
     assert cmd[1] == "verify-blob"
-    assert "--signature" in cmd
-    assert "https://r.example.com/bin.tar.gz.sig" in cmd
-    assert "--certificate" in cmd
-    assert "https://r.example.com/bin.tar.gz.pem" in cmd
-    assert "--certificate-oidc-issuer" in cmd
-    assert "https://token.actions.githubusercontent.com" in cmd
-    assert "--certificate-identity-regexp" in cmd
-    assert "^https://github\\.com/org/.*" in cmd
+
+    def _flag_value(flag: str) -> str:
+        """Return the argument immediately following *flag* in the command."""
+        return cmd[cmd.index(flag) + 1]
+
+    assert _flag_value("--certificate-oidc-issuer") == policy.issuer
+    assert _flag_value("--certificate-identity-regexp") == policy.identity_regex
+    assert _flag_value("--signature") == "https://r.example.com/bin.tar.gz.sig"
+    assert _flag_value("--certificate") == "https://r.example.com/bin.tar.gz.pem"
     assert str(blob) in cmd
 
 

--- a/tests/tools/test_cosign.py
+++ b/tests/tools/test_cosign.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import shutil
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from regis.tools.cosign import CosignUnavailable, verify_blob
+from regis.tools.cosign import CosignUnavailable, CosignVerificationFailed, verify_blob
 from regis.tools.manifest import CosignPolicy
 
 
@@ -15,3 +16,51 @@ def test_verify_blob_returns_unavailable_when_cosign_not_in_path(monkeypatch, tm
     blob.write_bytes(b"hi")
     with pytest.raises(CosignUnavailable):
         verify_blob(blob, "https://example.com/x.bin", policy)
+
+
+def test_verify_blob_success(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "artifact.bin"
+    blob.write_bytes(b"data")
+    policy = CosignPolicy(
+        issuer="https://token.actions.githubusercontent.com",
+        identity_regex="^https://github\\.com/org/.*",
+    )
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    cmd = run.call_args[0][0]
+    assert cmd[1] == "verify-blob"
+    assert "--signature" in cmd
+    assert "https://r.example.com/bin.tar.gz.sig" in cmd
+    assert "--certificate" in cmd
+    assert "https://r.example.com/bin.tar.gz.pem" in cmd
+    assert "--certificate-oidc-issuer" in cmd
+    assert "https://token.actions.githubusercontent.com" in cmd
+    assert "--certificate-identity-regexp" in cmd
+    assert "^https://github\\.com/org/.*" in cmd
+    assert str(blob) in cmd
+
+
+def test_verify_blob_failure_uses_stderr(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "a.bin"
+    blob.write_bytes(b"x")
+    policy = CosignPolicy(issuer="i", identity_regex="r")
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1, stderr="bad signature", stdout="")
+        with pytest.raises(CosignVerificationFailed) as exc:
+            verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    assert "bad signature" in str(exc.value)
+
+
+def test_verify_blob_failure_falls_back_to_stdout(monkeypatch, tmp_path):
+    monkeypatch.setattr("regis.tools.cosign.shutil.which", lambda _n: "/usr/bin/cosign")
+    blob = tmp_path / "a.bin"
+    blob.write_bytes(b"x")
+    policy = CosignPolicy(issuer="i", identity_regex="r")
+    with patch("regis.tools.cosign.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1, stderr="", stdout="stdout error")
+        with pytest.raises(CosignVerificationFailed) as exc:
+            verify_blob(blob, "https://r.example.com/bin.tar.gz", policy)
+    assert "stdout error" in str(exc.value)


### PR DESCRIPTION
## Summary

- Add a per-file coverage gate: `pipenv run pytest` now fails if **any** file under `regis/` is below 90%, on top of the existing global threshold. coverage.py only enforces a *global* `fail_under`, so a poorly tested file could previously hide behind well-covered ones.
- The gate is a small pytest plugin (`tests/_per_file_coverage.py`) wired via a `pytest_sessionfinish` hookwrapper in `tests/conftest.py`. It runs after pytest-cov writes its data, reads the threshold from the single source `[tool.coverage.report].fail_under`, lists offending files worst-first, and fails the session. It is a no-op under `--no-cov`; `tests/` and zero-statement files are exempt.
- Raise the 8 files that were previously below 90% to ≥ 90% first (cosign, doctor, process, sections, endoflife, playbook/evaluator, rules/evaluator, conditions), so the gate goes green immediately. Global coverage rose 92% → 95.69%; **0 files below 90%**.

## Test Plan

- [x] Full suite green with the gate active: `pipenv run pytest` → 754 passed, exit 0, no gate message.
- [x] Gate bites: a throwaway uncovered branch triggers `Per-file coverage gate: 1 file(s) below 90.0%` + non-zero exit (reverted).
- [x] Gate logic unit-tested (`tests/test_per_file_coverage.py`): threshold read, worst-first ordering, exact-threshold pass, zero-statement skip, `--no-cov`/absent-`--cov` no-op, failure sets exit status.
- [x] No production code under `regis/` modified — tests, conftest, gate module, and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)