### PR TITLE
fix(ci): keep the release Docker build green against immutable releases

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -26,11 +26,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      # contents: write is required so anchore/sbom-action can attach the
-      # generated SBOMs to the GitHub Release on tag builds. With contents:read
-      # that attach step fails ("Resource not accessible by integration") and
-      # releases ship without SBOM assets (regressed silently since v0.30.0).
-      contents: write
+      # SBOMs are published as workflow artifacts (see the Upload SBOM step),
+      # not attached to the GitHub Release: Release Please publishes the release
+      # before this tag build runs, and published releases are immutable, so an
+      # attach fails with "Cannot upload assets to an immutable release". The
+      # sbom-action steps therefore set upload-release-assets: false and only
+      # contents: read is needed here.
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -144,6 +146,9 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
+          # Release Please already published an immutable release for this tag;
+          # keep SBOMs as workflow artifacts instead of attaching them.
+          upload-release-assets: false
 
       - name: Generate SPDX SBOM
         if: github.ref_type == 'tag'
@@ -152,6 +157,8 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          # See the CycloneDX step: avoid the immutable-release attach failure.
+          upload-release-assets: false
 
       - name: Upload SBOM release artifacts
         if: github.ref_type == 'tag'


### PR DESCRIPTION
## Summary

The `CD / Docker` tag build for **v0.35.0** ([run 27186553241](https://github.com/trivoallan/regis/actions/runs/27186553241)) failed. Both the `slim` and `full` jobs **built and pushed their images successfully**, then errored at the end with:

```
##[error]Cannot upload assets to an immutable release. - https://docs.github.com/rest
```

### Root cause

`anchore/sbom-action` defaults `upload-release-assets` to **`true`**. On a tag push it therefore tries to attach the generated SBOM to the GitHub Release matching the tag (`v0.35.0`), even though the workflow only set `output-file` and uploads SBOMs via an explicit `actions/upload-artifact` step. Release Please publishes that release *before* this tag-triggered build runs, and GitHub now treats published releases as **immutable** — so the implicit attach is rejected and the job fails after the image is already published.

This means every tagged release build is now red even though the images publish fine.

### Fix

- Set `upload-release-assets: false` on both SBOM steps (CycloneDX + SPDX). SBOMs are unchanged — still produced and kept as workflow artifacts (the action's own artifact upload plus the explicit `Upload SBOM release artifacts` step).
- Drop the job's `contents: write` permission back to `contents: read` — it existed only for the now-disabled release attach (the badge PR uses the App token; provenance attestation uses `id-token`/`attestations`/`packages`).

### Trade-off / follow-up

GitHub immutable releases make it impossible to attach assets to an already-published release. SBOMs remain available as workflow artifacts. If durable SBOM **release assets** are wanted later, the release pipeline would need to attach them while the release is still a draft (before Release Please publishes) — a larger change tracked separately.

### Verification

- YAML parses; change is limited to a documented `anchore/sbom-action` input and a permission downgrade.
- `trunk`/`actionlint` aren't installed in this environment, so the authoritative lint runs in CI.
- The fix can only be fully exercised by a tag build, but the next `main` push run of `CD / Docker` confirms the workflow is otherwise intact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FbwZ8rMLFYZCMyH3Qr9Nhj)_