### PR TITLE
docs(readme): slim README into a doc front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,9 @@
 
 Regis provides unified container analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD.
 
-## Documentation
+[![Dashboard Overview](.github/assets/report-overview.png)](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)
 
-Comprehensive documentation, including installation and usage guides, is available at:
-**[https://trivoallan.github.io/regis/](https://trivoallan.github.io/regis/)**
-
-## Image variants
-
-| Tag                             | Base               | Size     | Use case                                                       |
-| ------------------------------- | ------------------ | -------- | -------------------------------------------------------------- |
-| `:latest`, `:VERSION`           | python:3.11-alpine | ≈ 156 MB | Default — slim image, scanner binaries downloaded on first use |
-| `:latest-full`, `:VERSION-full` | python:3.11-alpine | ≈ 484 MB | Air-gapped or rate-limited — all scanners baked in             |
-
-The slim image lazy-loads scanner binaries (`grype`, `syft`, `trufflehog`, `hadolint`, `dockle`) to `~/.cache/regis/tools/` on first use, verified against pinned sha256s. See [Managing analyzer tools](https://trivoallan.github.io/regis/docs/usage/tools-management) for the cache pattern and air-gapped guidance.
+**[Explore the interactive example report →](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)**
 
 ## Key Features
 
@@ -30,169 +20,18 @@ The slim image lazy-loads scanner binaries (`grype`, `syft`, `trufflehog`, `hado
 - **CI/CD Native** — Designed to integrate seamlessly into GitHub Actions or GitLab CI pipelines with first-class support for MR/PR reporting.
 - **Efficient Caching** — Reuse existing analysis results to speed up repeated evaluations and report regeneration.
 
-## Built-in Analyzers
+## Documentation
 
-| Analyzer     | Description                                                                            |
-| ------------ | -------------------------------------------------------------------------------------- |
-| `oci`        | Extracts multi-arch metadata, OS/Architecture labels, layers, and root user detection. |
-| `trivy`      | Performs vulnerability scanning and generates Software Bill of Materials (SBOM).       |
-| `provenance` | Verifies image build provenance and SLSA metadata.                                     |
-| `endoflife`  | Checks for End-Of-Life (EOL) status of base images using `endoflife.date`.             |
-| `freshness`  | Calculates image age and identifies potential maintenance risks.                       |
-| `hadolint`   | Lints Dockerfiles for security and best practice violations.                           |
-| `size`       | Analyzes image size and layer distribution for optimization.                           |
-| `versioning` | Ensures semantic versioning consistency and tag validation.                            |
+Full documentation lives at **[trivoallan.github.io/regis](https://trivoallan.github.io/regis/)**:
 
----
-
-## Report Preview
-
-`regis` generates high-quality, interactive HTML dashboards.
-Below is a preview of the different sections available in a standard report.
-
-**[Explore the interactive Alpine example report here](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)**
-
-<details>
-<summary>📈 Dashboard Overview</summary>
-<br>
-<img src=".github/assets/report-overview.png" alt="Dashboard Overview" width="100%">
-</details>
-
-<details>
-<summary>✅ Compliance Analysis</summary>
-<br>
-<img src=".github/assets/report-compliance.png" alt="Compliance Analysis" width="100%">
-</details>
-
-<details>
-<summary>🛡️ Vulnerability & Security</summary>
-<br>
-<img src=".github/assets/report-security.png" alt="Vulnerability Security" width="100%">
-</details>
-
-<details>
-<summary>🔗 Supply Chain & Quality</summary>
-<br>
-<img src=".github/assets/report-supply-chain.png" alt="Supply Chain & Quality" width="100%">
-</details>
-
-<details>
-<summary>✨ Best Practices</summary>
-<br>
-<img src=".github/assets/report-best-practices.png" alt="Best Practices" width="100%">
-</details>
-
-<details>
-<summary>💡 Insights & Lifecycle</summary>
-<br>
-<img src=".github/assets/report-insights.png" alt="Insights & Lifecycle" width="100%">
-</details>
-
-<details>
-<summary>⚙️ Technical Details</summary>
-<br>
-<img src=".github/assets/report-technical-details.png" alt="Technical Details" width="100%">
-</details>
-
----
-
-## CI/CD Security & Supply Chain Integrity
-
-The GitHub Actions pipelines enforce layered security controls:
-
-- **Dependency auditing gate (`pip-audit`)** in CI with a fail threshold at **HIGH/CRITICAL** severity.
-- **Release SBOM generation** in both **CycloneDX JSON** and **SPDX JSON** formats (via `syft`/Anchore action).
-- **Provenance attestation** for published container images using GitHub Artifact Attestations (`actions/attest-build-provenance`).
-
-These artifacts are uploaded by the release/CD workflow as GitHub Actions workflow artifacts so consumers can inspect composition and verify origin before deployment.
-
----
-
-> **Breaking change in v0.33.0** — The interactive dashboard, the multi-report
-> archive browser, and archive-site scaffolding were removed from the core and
-> now live in the standalone
-> [regis-dashboard](https://github.com/trivoallan/regis-dashboard) project
-> (`regis-dashboard render|serve|archive add|archive configure|bootstrap archive`).
-> The `regis dashboard` command, the `regis archive add|configure` commands, the
-> `bootstrap archive` subcommand, and `analyze --site` (with `--base-url`/`--open`
-> and the `html-site` format) were removed. Use `regis analyze --json` (the
-> `report.json` contract), `regis analyze --html` (self-contained `report.html`),
-> and `regis analyze --archive <dir>` (archive data the standalone dashboard
-> consumes) instead.
+- 🚀 [Getting Started](https://trivoallan.github.io/regis/docs/usage/getting-started) — install Regis and run your first analysis.
+- 📚 [Concepts](https://trivoallan.github.io/regis/docs/concepts/introduction) — analyzers, playbooks, rules, and scoring.
+- 🛠️ [Usage Guides](https://trivoallan.github.io/regis/docs/usage/analyze-image) — analyze images, manage scanner tools, configure registries.
+- 📖 [CLI Reference](https://trivoallan.github.io/regis/docs/reference/cli) — every command and flag.
 
 ## GitHub Action
 
-The [**regis-security-analysis**](https://github.com/marketplace/actions/regis-security-analysis) GitHub Action runs a full Regis security analysis on any OCI image, uploads the HTML report as a workflow artifact, and optionally posts a summary comment on pull requests.
-
-The action lives in its own repository, [**trivoallan/regis-action**](https://github.com/trivoallan/regis-action), and is versioned independently from this core project. Reference it as `trivoallan/regis-action@v1`.
-
-> **Migrating from `trivoallan/regis@vX`?** The action used to be hosted in this
-> repository. It has moved to [`trivoallan/regis-action`](https://github.com/trivoallan/regis-action).
-> Replace `uses: trivoallan/regis@vX` with `uses: trivoallan/regis-action@v1`.
-> The `version:` input (the `regis` Docker image tag) is unchanged.
-
-### Inputs
-
-| Input             | Required | Default                 | Description                                                        |
-| ----------------- | -------- | ----------------------- | ------------------------------------------------------------------ |
-| `image-url`       | Yes      | —                       | Container image URL to analyze                                     |
-| `auth`            | No       | `""`                    | Registry credentials as `registry=user:pass`                       |
-| `playbook`        | No       | `""`                    | URL or path to a custom playbook YAML                              |
-| `report-url`      | No       | `""`                    | URL to the hosted report (used in the PR comment link)             |
-| `github-token`    | No       | `${{ github.token }}`   | Token for posting PR comments; requires `pull-requests: write`     |
-| `pr-url`          | No       | `""`                    | PR URL to comment on; auto-detected in `pull_request` context      |
-| `upload-artifact` | No       | `true`                  | Whether to upload the HTML report as a workflow artifact           |
-| `artifact-name`   | No       | `regis-security-report` | Name for the uploaded artifact                                     |
-| `version`         | No       | `latest`                | Regis Docker image tag to run (pin to a release tag in production) |
-
-### Outputs
-
-| Output        | Description                                         |
-| ------------- | --------------------------------------------------- |
-| `report-path` | Absolute path to the report directory on the runner |
-
-### Basic usage
-
-```yaml
-- uses: trivoallan/regis-action@v1
-  with:
-    image-url: ghcr.io/your-org/your-image:latest
-```
-
-### PR comment usage
-
-To post a comment with the analysis summary on a pull request, add `pull-requests: write` to your job permissions and supply `pr-url`:
-
-```yaml
-jobs:
-  security-scan:
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: trivoallan/regis-action@v1
-        with:
-          image-url: ghcr.io/your-org/your-image:latest
-          pr-url: ${{ github.event.pull_request.html_url }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-The PR comment fires only when `pr-url` is set. The `github-token` always defaults to `GITHUB_TOKEN`; supplying it explicitly is optional.
-
-### Version pinning
-
-`@v1` tracks the latest stable v1.x of the action. For fully reproducible runs, pin an exact release and the Docker image tag:
-
-```yaml
-- uses: trivoallan/regis-action@v1.0.0
-  with:
-    image-url: ghcr.io/your-org/your-image:latest
-    version: "v0.34.0" # Docker image tag — independent from the action ref above
-```
-
-The `uses:` ref (action code, versioned in `trivoallan/regis-action`) and the `version:` input (the `regis` Docker image tag, released from this repository) are independent; pin both for a fully reproducible run.
-
----
+Run Regis in CI with the [**regis-security-analysis**](https://github.com/marketplace/actions/regis-security-analysis) GitHub Action. It is maintained in its own repository — [**trivoallan/regis-action**](https://github.com/trivoallan/regis-action) (`uses: trivoallan/regis-action@v1`) — where you will find its inputs, outputs, and usage examples.
 
 ## License
 

--- a/docs/superpowers/plans/2026-06-09-readme-slimming.md
+++ b/docs/superpowers/plans/2026-06-09-readme-slimming.md
@@ -1,0 +1,115 @@
+# README Slimming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 199-line `README.md` with a ~50-line front door that pitches Regis and redirects to the canonical documentation site, removing stale and duplicated content.
+
+**Architecture:** Single-file documentation change. The README becomes an orientation page; the published doc site (<https://trivoallan.github.io/regis/>) remains the source of truth. No code, no tests — verification is done with `wc`, `grep`, and `trunk`.
+
+**Tech Stack:** Markdown, GitHub-flavored. Trunk markdownlint (`MD034` forbids bare URLs) runs on commit via the pre-commit hook.
+
+**Spec:** [docs/superpowers/specs/2026-06-09-readme-slimming-design.md](../specs/2026-06-09-readme-slimming-design.md)
+
+---
+
+## Task 1: Rewrite README.md as a front door
+
+**Files:**
+
+- Modify (full replace): `README.md`
+
+**Context the executor needs:**
+
+- The repo root contains `coverage-badge.svg` and `image-size-badge.svg`, referenced relatively by the badges. Keep both badge lines verbatim — they are refreshed automatically by CI.
+- The hero image asset exists at `.github/assets/report-overview.png`.
+- The interactive example link is pinned to `0.14.0` in the current README; reuse it verbatim (updating the example version is out of scope — see follow-up note at the end of this plan).
+- All five documentation URLs below resolve to existing pages under `docs/website/docs/` (verified: `usage/getting-started.md`, `concepts/introduction.md`, `usage/analyze-image.md`, `reference/cli.md`).
+- Trunk's pre-commit hook will reject bare URLs (`MD034`). Every URL in prose must be either a Markdown link `[text](url)` or wrapped in angle brackets `<url>`. The content below already complies.
+
+- [ ] **Step 1: Replace the entire contents of `README.md` with this exact text**
+
+```markdown
+# Regis
+
+> **Registry Scores** — Container Security & Policy-as-Code Orchestration
+
+![Coverage](./coverage-badge.svg)
+[![Docker Image Size](./image-size-badge.svg)](https://github.com/trivoallan/regis/pkgs/container/regis)
+
+Regis provides unified container analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD.
+
+[![Dashboard Overview](.github/assets/report-overview.png)](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)
+
+**[Explore the interactive example report →](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)**
+
+## Key Features
+
+- **Unified Registry Inspection** — Fast, multi-arch metadata extraction from any OCI-compliant registry using `regctl`.
+- **Pluggable Analyzer Ecosystem** — Orchestrates industry-standard tools like `Trivy`, `regctl`, `Hadolint`, and `Dockle` to gather comprehensive security insights.
+- **Policy-as-Code Playbooks** — Define compliance and security rules (e.g., "no critical vulnerabilities", "maximum image age") using flexible `jsonLogic` evaluations.
+- **Hybrid Reporting** — Simultaneously generates machine-readable JSON for automation and rich, interactive HTML dashboards for human review.
+- **CI/CD Native** — Designed to integrate seamlessly into GitHub Actions or GitLab CI pipelines with first-class support for MR/PR reporting.
+- **Efficient Caching** — Reuse existing analysis results to speed up repeated evaluations and report regeneration.
+
+## Documentation
+
+Full documentation lives at **[trivoallan.github.io/regis](https://trivoallan.github.io/regis/)**:
+
+- 🚀 [Getting Started](https://trivoallan.github.io/regis/docs/usage/getting-started) — install Regis and run your first analysis.
+- 📚 [Concepts](https://trivoallan.github.io/regis/docs/concepts/introduction) — analyzers, playbooks, rules, and scoring.
+- 🛠️ [Usage Guides](https://trivoallan.github.io/regis/docs/usage/analyze-image) — analyze images, manage scanner tools, configure registries.
+- 📖 [CLI Reference](https://trivoallan.github.io/regis/docs/reference/cli) — every command and flag.
+
+## GitHub Action
+
+Run Regis in CI with the [**regis-security-analysis**](https://github.com/marketplace/actions/regis-security-analysis) GitHub Action. It is maintained in its own repository — [**trivoallan/regis-action**](https://github.com/trivoallan/regis-action) (`uses: trivoallan/regis-action@v1`) — where you will find its inputs, outputs, and usage examples.
+
+## License
+
+MIT
+```
+
+- [ ] **Step 2: Verify the README is short enough**
+
+Run: `wc -l README.md`
+Expected: a number ≤ 60 (the content above is ~40 lines).
+
+- [ ] **Step 3: Verify all stale and duplicated content is gone**
+
+Run:
+
+```bash
+grep -niE "regis-dashboard|breaking change|image variants|built-in analyzers|## inputs|## outputs|version pinning|cycloneddx|pip-audit|supply chain integrity" README.md || echo "CLEAN: no forbidden strings"
+```
+
+Expected: `CLEAN: no forbidden strings` (no matches).
+
+- [ ] **Step 4: Verify the documentation links are well-formed and resolve to existing source pages**
+
+Run:
+
+```bash
+grep -oE "https://trivoallan.github.io/regis/docs/[a-z/-]+" README.md
+for p in usage/getting-started concepts/introduction usage/analyze-image reference/cli; do
+  test -f "docs/website/docs/$p.md" && echo "OK  $p" || echo "MISSING  $p"
+done
+```
+
+Expected: the four doc URLs printed, then four `OK` lines (no `MISSING`).
+
+- [ ] **Step 5: Commit (the Trunk pre-commit hook auto-formats and runs markdownlint)**
+
+```bash
+git add README.md
+git commit -m "docs(readme): slim README into a front door that redirects to the docs site
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Expected: commit succeeds. If the hook reports an `MD034` bare-URL issue, wrap the offending URL in angle brackets `<...>` or as a Markdown link, then re-stage and re-commit. If the hook auto-formats the file, the commit may need to be re-run after `git add README.md`.
+
+---
+
+## Follow-up (out of scope for this plan)
+
+The interactive example link is pinned to `regis/0.14.0/...`, an old version. Updating it to the current release (or a `latest` alias) is a separate concern — flag it as a background task rather than fixing it here.

--- a/docs/superpowers/specs/2026-06-09-readme-slimming-design.md
+++ b/docs/superpowers/specs/2026-06-09-readme-slimming-design.md
@@ -1,0 +1,71 @@
+# Spec — README allégé (porte d'entrée minimale)
+
+- **Date** : 2026-06-09
+- **Statut** : approuvé (design)
+- **Périmètre** : `README.md` à la racine du dépôt uniquement.
+
+## Problème
+
+Le `README.md` actuel fait 199 lignes. Il duplique du contenu maintenu dans le
+site de documentation publié (<https://trivoallan.github.io/regis/>), contient une
+note de breaking change **périmée** (elle pointe vers `regis-dashboard`, projet
+abandonné au profit de regis-backstage), et embarque la documentation détaillée
+d'une GitHub Action qui vit dans son **propre dépôt** (`trivoallan/regis-action`).
+Le README doit redevenir une porte d'entrée concise qui oriente vers la doc
+canonique, sans duplication ni information obsolète.
+
+## Objectif
+
+Réduire le README à ~50-60 lignes : présenter Regis en quelques secondes et
+rediriger vers le site de doc. Source unique de vérité = site de doc ;
+le README ne fait qu'orienter.
+
+## Structure cible
+
+1. `# Regis` + tagline blockquote + 2 badges (coverage, image size) — inchangé.
+2. **Pitch** : le paragraphe d'introduction actuel (1 phrase).
+3. **Image héro** : un seul screenshot `report-overview.png` sous le pitch, suivi
+   du lien « Explore the interactive example report » (lien existant ligne 53).
+4. **Key Features** : les 6 bullets actuels conservés (pitch produit).
+5. **Documentation** : mini-index curé de liens pointés vers le site, plus le
+   lien racine. Pages cibles (toutes existantes sous `docs/website/docs/`) :
+   - Getting Started → `https://trivoallan.github.io/regis/docs/usage/getting-started`
+   - Concepts → `https://trivoallan.github.io/regis/docs/concepts/introduction`
+   - Usage guides → `https://trivoallan.github.io/regis/docs/usage/analyze-image`
+   - CLI Reference → `https://trivoallan.github.io/regis/docs/reference/cli`
+   - Lien racine → `https://trivoallan.github.io/regis/`
+6. **GitHub Action** : 2 phrases + lien vers `trivoallan/regis-action` et la
+   marketplace. Aucune table d'inputs/outputs, aucun exemple YAML, aucune note de
+   migration (tout cela vit dans le dépôt de l'action et sa doc).
+7. **License** : MIT — inchangé.
+
+## Contenu supprimé et destination
+
+| Section retirée du README                                            | Destination canonique         |
+| -------------------------------------------------------------------- | ----------------------------- |
+| Note « Breaking change in v0.33.0 » (regis-dashboard, **périmée**)   | CHANGELOG / pages `upgrade/`  |
+| Table « Image variants »                                             | `docs/usage/tools-management` |
+| Paragraphe « slim image lazy-loads… »                                | `docs/usage/tools-management` |
+| Table « Built-in Analyzers »                                         | `docs/concepts/analyzers`     |
+| 6 des 7 screenshots `<details>` (on garde la vue d'ensemble en héro) | exemple interactif + doc      |
+| Section « CI/CD Security & Supply Chain Integrity »                  | doc (détail interne)          |
+| Tables Inputs / Outputs de l'Action                                  | `trivoallan/regis-action`     |
+| Exemples YAML (basic / PR comment / version pinning)                 | `trivoallan/regis-action`     |
+| Note de migration `regis@vX` → `regis-action@v1`                     | `trivoallan/regis-action`     |
+
+## Hors périmètre
+
+- Aucune modification du site de doc, des badges, ou des assets `.github/assets/`.
+- Pas de réécriture de contenu marketing au-delà du nécessaire (on réutilise le
+  pitch et les bullets existants tels quels).
+
+## Critères d'acceptation
+
+- `README.md` ≤ ~60 lignes.
+- Aucune mention de `regis-dashboard` ni de la breaking change v0.33.0.
+- Les 5 liens de la section Documentation résolvent vers des pages existantes
+  (vérification : les fichiers source correspondants existent sous
+  `docs/website/docs/`).
+- Un seul screenshot de rapport (vue d'ensemble) subsiste.
+- La section GitHub Action tient en ≤ 3 lignes + liens, sans table ni YAML.
+- Les badges coverage et image-size restent intacts (maintenus automatiquement).


### PR DESCRIPTION
## Summary

- Reduces `README.md` from 199 → 38 lines: title, badges, pitch, a single hero screenshot, key features, a curated doc index, and a one-paragraph GitHub Action pointer.
- Removes the **stale** `regis-dashboard` "Breaking change in v0.33.0" note (the dashboard was abandoned in favor of regis-backstage).
- Drops content duplicated in the published doc site — image-variants table, built-in analyzers table, CI/CD security section, and the full GitHub Action inputs/outputs/YAML examples (the action lives in `trivoallan/regis-action`).
- Adds a curated Documentation index linking Getting Started, Concepts, Usage, and CLI Reference; the doc site stays the single source of truth.
- Includes the brainstorming spec and execution plan under `docs/superpowers/` (the plan is removed at squash-merge per project convention).

## Test Plan

- [ ] `README.md` ≤ 60 lines (currently 38)
- [ ] No references to `regis-dashboard` or the v0.33.0 breaking change
- [ ] The four doc-index links resolve to existing pages on the published site
- [ ] Badges (coverage, image size) and the hero image render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)