### PR TITLE
fix(ci): re-arm auto-merge after PR head force-push

### DIFF
--- a/.github/workflows/repo-automerge.yml
+++ b/.github/workflows/repo-automerge.yml
@@ -2,13 +2,23 @@ name: Repo / Auto-merge
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    # `synchronize` re-arms auto-merge after the PR head is updated. When `main`
+    # advances, repo-autorebase force-pushes open PR branches; a force-push that
+    # lands after auto-merge was first enabled can leave it armed but never
+    # re-evaluated, so the PR sits MERGEABLE/CLEAN without merging. Re-running on
+    # every head update keeps auto-merge bound to the current head.
+    types: [opened, ready_for_review, synchronize]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read
+
+# Coalesce the bursts of `synchronize` events an autorebase force-push produces.
+concurrency:
+  group: automerge-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   automerge:


### PR DESCRIPTION
## Summary

Versioned-docs snapshot PRs (and other auto-merge PRs) could stay open in a `MERGEABLE`/`CLEAN` state without ever merging. When `main` advances, `repo-autorebase` force-pushes open PR branches; if that force-push lands just after `repo-automerge` first enabled auto-merge, GitHub leaves auto-merge armed but never re-evaluates it against the new head.

This is exactly what stranded the **v0.35.0 docs snapshot** ([#691](https://github.com/trivoallan/regis/pull/691)): the snapshot was generated and auto-merge was enabled, but the PR never merged — so the published site had no 0.35 version. (#691 has since been merged manually to restore the docs.)

## Change

- Listen to `synchronize` in `repo-automerge.yml` so auto-merge is re-bound to the current head on every PR head update (re-arming after an autorebase force-push). `enable-pull-request-automerge` is idempotent.
- Add a per-PR `concurrency` group to coalesce the burst of `synchronize` events a force-push produces.

## Root cause (timeline of #691)

| UTC | Event |
|---|---|
| 05:47:51 | snapshot PR #691 created |
| 05:48:01 | `repo-automerge` arms auto-merge |
| 05:49:15 | `repo-autorebase` force-pushes the head (main had advanced) |

Checks went green on the new head (~05:50) but the merge never fired; 30+ min later the PR was still `CLEAN`/`MERGEABLE` with auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)