### PR TITLE
docs(readme): repoint example report links to live alpine page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 Regis provides unified container analysis, custom playbooks, and highly customizable interactive reports for production-ready CI/CD.
 
-[![Dashboard Overview](.github/assets/report-overview.png)](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)
+[![Dashboard Overview](.github/assets/report-overview.png)](https://trivoallan.github.io/regis/docs/reference/playbooks/default/examples/alpine)
 
-**[Explore the interactive example report →](https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html)**
+**[Explore the interactive example report →](https://trivoallan.github.io/regis/docs/reference/playbooks/default/examples/alpine)**
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

The README's two "interactive example report" links — the hero image link and the `Explore the interactive example report →` text link — were pinned to `https://trivoallan.github.io/regis/regis/0.14.0/_attachments/examples/alpine/index.html`. That URL **404s** on the published site.

Both links now point to the latest-aliased alpine example doc page:
`https://trivoallan.github.io/regis/docs/reference/playbooks/default/examples/alpine`

## Why

I probed the published site before editing. Findings:

- The pinned `0.14.0` raw-report URL is already dead.
- **Every** raw interactive-report URL 404s — including the exact `_attachments/.../index.html` paths the live docs site itself emits. The `static/examples/` report HTML simply isn't deployed to Pages right now. Bumping the version to `0.35.0` or `latest` would just produce a different 404.
- The only example-related URLs that resolve (HTTP 200, never version-pinned) are the Docusaurus example doc pages. The alpine page is the canonical entry point the published nav links to.

So rather than swap in a guessed version that 404s, both links target the live, latest-aliased alpine example doc page.

## Reviewer notes

- ⚠️ Separately, the live docs site's own "View the report" links (the embedded raw `index.html` reports) are broken upstream — the example report assets aren't being deployed to Pages. That's a deploy/CI issue out of scope for this README fix, worth tracking on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)