### PR TITLE
refactor(report): derive failing analyzers from the verdict model

### DIFF
--- a/regis/playbook/verdict.py
+++ b/regis/playbook/verdict.py
@@ -31,6 +31,7 @@ class RuleLine:
     slug: str
     level: str
     message: str
+    analyzers: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,7 @@ def build_verdict(final_report: dict[str, Any]) -> Verdict:
             slug=r.get("slug", "unknown"),
             level=str(r.get("level") or "info").lower(),
             message=r.get("message", ""),
+            analyzers=list(r.get("analyzers") or []),
         )
 
     summary = src.get("rules_summary") or {}

--- a/regis/report/html.py
+++ b/regis/report/html.py
@@ -21,18 +21,6 @@ _SEVERITY_SPEC = [
 ]
 
 
-def _source_rules(report: dict[str, Any]) -> list[dict[str, Any]]:
-    """Return the evaluated rules (playbooks[0] first, else top-level)."""
-    playbooks = report.get("playbooks") or []
-    if playbooks:
-        src = playbooks[0]
-    elif "tier" in report or "rules" in report:
-        src = report
-    else:
-        return []
-    return list(src.get("rules") or [])
-
-
 def _build_context(report: dict[str, Any], sections: str) -> dict[str, Any]:
     """Build the full template context for a report (pure: no template I/O)."""
     # Parse sections directive
@@ -102,12 +90,7 @@ def _build_context(report: dict[str, Any], sections: str) -> dict[str, Any]:
             "clear": not verdict_view["failures"] and not verdict_view["incompletes"],
         }
 
-    failing_analyzers: set[str] = {
-        a
-        for r in _source_rules(report)
-        if not r.get("passed") and r.get("status") != "incomplete"
-        for a in (r.get("analyzers") or [])
-    }
+    failing_analyzers: set[str] = {a for f in _v.failures for a in f.analyzers}
 
     toc = [
         {


### PR DESCRIPTION
## Summary

Removes two duplications between the HTML report renderer (`regis/report/html.py`) and the verdict engine (`regis/playbook/verdict.py`), flagged during the Carbon HTML report UI overhaul (#706):

- **Playbook selection**: `_source_rules()` reimplemented `verdict._source()` (pick `playbooks[0]`, else top-level when `tier`/`rules` present).
- **Failed-rule predicate**: `not r.get("passed") and r.get("status") != "incomplete"` was duplicated in both `html.py` (building `failing_analyzers`) and `build_verdict`.

These agreed today, keeping the TOC `fail` badges consistent with the verdict/triage failures, but could silently drift if a new rule status value were introduced on one side.

The fix surfaces each rule's `analyzers` on the `RuleLine` model and populates it in `build_verdict`, so `_build_context` derives `failing_analyzers` from the already-computed `_v.failures`. This deletes `_source_rules` entirely and makes the verdict the single source of truth for which analyzers failed.

Non-breaking: the new `RuleLine.analyzers` field is defaulted (`field(default_factory=list)`), so existing `.failures` consumers are unaffected.

## Test Plan

- [x] `pipenv run pytest` — 736 passed, 1 skipped; global coverage 95.43%, per-file gate green
- [x] `tests/report/test_html_context.py` `TestToc` + `TestFailingAnalyzers` (behavior pins) stay green
- [x] `pipenv run ruff check` / `ruff format` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)