### PR TITLE
ci(lint): guard against execution plans on main

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -141,3 +141,24 @@ jobs:
             exit 1
           fi
           echo "No generated documentation artifacts committed."
+
+  execution-plans-guard:
+    name: No Execution Plans
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reject committed execution plans
+        run: |
+          set -euo pipefail
+
+          matches="$(git ls-files -- 'docs/superpowers/plans/**')"
+          if [ -n "$matches" ]; then
+            echo "::error::Execution plans are ephemeral and must not be merged to main. Delete docs/superpowers/plans/ before merging; only specs (docs/superpowers/specs/) are durable."
+            echo "$matches"
+            exit 1
+          fi
+          echo "No execution plans committed."


### PR DESCRIPTION
## Summary

Adds a CI guard that prevents execution plans from being merged to `main`, so the leak cleaned up in #710 cannot recur.

- New `execution-plans-guard` job in `.github/workflows/ci-lint.yml`, mirroring the existing `generated-artifacts-guard`.
- Fails any PR/push to `main` that carries files under `docs/superpowers/plans/`, with a clear message: delete the plan before merging; only specs (`docs/superpowers/specs/`) are durable.

Rationale: plans are ephemeral and meant to be dropped before squash-merge (per `CLAUDE.md`). The previous leak happened because the removal landed on the branch *after* the squash. This guard makes the policy enforceable rather than manual.

## Test Plan

- [x] `execution-plans-guard` passes on this branch (no files under `docs/superpowers/plans/`).
- [x] Workflow YAML parses; job mirrors the proven `generated-artifacts-guard` pattern (`git ls-files` + non-empty check).
- [ ] CI green on this PR.
