### PR TITLE
docs(memory-bank): document stale editable-install entry points pitfall

### DIFF
--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -59,6 +59,10 @@ Les deux gates lisent le même seuil : `[tool.coverage.report].fail_under` dans 
 `tests/` est exclu de la mesure (pas de récursion). Les fichiers sans aucune instruction sont
 ignorés. `--no-cov` désactive les deux gates.
 
+## Dev Environment Gotchas
+
+- **Stale editable-install entry points**: the analyzer registry (`discover_analyzers()`) is resolved from `importlib.metadata` entry points, which are **frozen into `entry_points.txt` at `pip install -e` time** and do **not** update when `pyproject.toml`'s `[project.entry-points."regis.analyzers"]` changes. After any pull/branch switch that adds, removes, or renames an analyzer entry point, **re-run `pipenv install --dev`** (or `pipenv run pip install -e . --no-deps`) to regenerate the metadata. Symptom: `ModuleNotFoundError` warnings for removed/renamed analyzers (`skopeo`, `trivy`) **and**, more insidiously, **silent absence** of newly added analyzers (`oci`, `cve`) — `analyze` runs without them and emits no error. Verify with `pipenv run python -c "from importlib.metadata import entry_points; [print(ep.name) for ep in entry_points(group='regis.analyzers')]"` and compare against `pyproject.toml`.
+
 ## CI/CD Gotchas
 
 - **`ci-test.yml`** includes `pip-audit` and enforces a HIGH/CRITICAL severity gate via `scripts/enforce_pip_audit_severity.py` (severity is resolved from OSV metadata).


### PR DESCRIPTION
## Summary

Records a dev-environment pitfall in `docs/memory-bank/systemPatterns.md` under a new **Dev Environment Gotchas** section.

The analyzer registry is resolved from `importlib.metadata` entry points, which are **frozen into `entry_points.txt` at `pip install -e` time** and are not regenerated when `pyproject.toml` changes. After a pull/branch switch that adds, removes, or renames an analyzer, the stale metadata causes:

- `ModuleNotFoundError` warnings for removed/renamed analyzers (e.g. `skopeo`, `trivy`), and
- **silent absence** of newly added analyzers (e.g. `oci`, `cve`) — `analyze` runs without them and emits no error.

The note captures the mechanism, the fix (`pipenv install --dev`), and a verification command.

## Context

Surfaced from a real `regis analyze nginx:latest` run whose stale 0.28.6 editable metadata still listed `skopeo`/`trivy` and lacked `oci`/`cve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)