### PR TITLE
fix(playbook): render security evidence with v4 playbook result

### DIFF
--- a/regis/cookiecutters/mr-evidence/{{cookiecutter.report_dir}}/SECURITY_EVIDENCE.md
+++ b/regis/cookiecutters/mr-evidence/{{cookiecutter.report_dir}}/SECURITY_EVIDENCE.md
@@ -13,7 +13,9 @@ Analysis performed on **{{ cookiecutter.regis.request.timestamp }}**.
 ## 📊 Playbook Results: {{ cookiecutter.regis.playbook.playbook_name }}
 
 - **Score**: `{{ cookiecutter.regis.playbook.score }}%`
-- **Passed Scorecards**: `{{ cookiecutter.regis.playbook.passed_scorecards }}/{{ cookiecutter.regis.playbook.total_scorecards }}`
+{% set tier = cookiecutter.regis.playbook.tier | default(None) %}
+{% if tier %}- **Tier**: `{{ tier }}`
+{% endif %}
 
 {% set cve = cookiecutter.regis.results.cve | default({}) %}
 {% if cve %}

--- a/tests/test_presentation_templates.py
+++ b/tests/test_presentation_templates.py
@@ -52,6 +52,44 @@ def test_packaged_template_resolved_to_local_path(
     assert Path(template_arg).is_dir()
 
 
+def test_mr_evidence_renders_with_v4_playbook_result(tmp_path: Path) -> None:
+    """The packaged mr-evidence template renders against a v4 playbook result.
+
+    Regression for the v4 schema bump (#703) that dropped ``passed_scorecards`` /
+    ``total_scorecards`` from the playbook result: the template still referenced
+    them, so Cookiecutter's StrictUndefined aborted the render with
+    ``'dict object' has no attribute 'passed_scorecards'``.
+    """
+    report = {
+        "request": {
+            "registry": "registry-1.docker.io",
+            "repository": "library/busybox",
+            "tag": "latest",
+            "digest": "sha256:fd8d9aa",
+            "timestamp": "2026-06-09",
+        },
+        "playbook": {"playbook_name": "regis", "score": 69},
+        "playbooks": [
+            {
+                "playbook_name": "regis",
+                "score": 69,
+                "templates": [
+                    {"package": "regis", "directory": "cookiecutters/mr-evidence"}
+                ],
+            }
+        ],
+        "results": {},
+    }
+
+    render_presentation_templates(report, str(tmp_path))
+
+    produced = list(tmp_path.rglob("SECURITY_EVIDENCE.md"))
+    assert produced, "mr-evidence template failed to produce SECURITY_EVIDENCE.md"
+    text = produced[0].read_text(encoding="utf-8")
+    assert "library/busybox" in text
+    assert "69%" in text
+
+
 def test_default_playbook_templates_are_packaged() -> None:
     """The shipped default playbook must not clone a remote template."""
     pb_path = resources.files("regis") / "playbooks" / "default" / "playbook.yaml"


### PR DESCRIPTION
## Summary

`regis analyze … --html` printed a warning and failed to generate `SECURITY_EVIDENCE.md`:

```
Warning: Failed to render template 'regis': Unable to create file 'SECURITY_EVIDENCE.md'.
Error message: 'dict object' has no attribute 'passed_scorecards'.
```

The v4 result schema (#703) dropped `passed_scorecards` and `total_scorecards` from the playbook result, but the `mr-evidence` cookiecutter template still referenced both. cookiecutter renders with `StrictUndefined`, so the missing keys aborted the render **for every image** — the Scorecard 404 seen in the original report was an unrelated red herring.

## What changed

- **Template** `regis/cookiecutters/mr-evidence/.../SECURITY_EVIDENCE.md`: replace the removed `passed_scorecards`/`total_scorecards` line with the v4 `tier`, surfaced only when present and guarded with `| default(None)` so an absent key can never break the render again.
- **Test**: add `test_mr_evidence_renders_with_v4_playbook_result`, which renders the packaged template against a real v4 result and asserts `SECURITY_EVIDENCE.md` is produced. The existing test only mocked cookiecutter, so it never exercised the actual render — hence the blind spot.

## Verification

- Before the fix the new test fails, reproducing the exact `'dict object' has no attribute 'passed_scorecards'` error.
- After the fix: `37 passed` across the report/playbook/presentation test files, `ruff` clean.
- Grep confirms this was the last stale reference to the removed v3 scorecard fields under `regis/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)