### PR TITLE
feat(cli): align verdict rule lines and show per-rule severity

### DIFF
--- a/regis/commands/analyze.py
+++ b/regis/commands/analyze.py
@@ -81,6 +81,7 @@ def _render_verdict_block(final_report: dict[str, Any], *, quiet: bool) -> None:
         badge_emoji,
         build_verdict,
         format_counts,
+        level_emoji,
         tier_label,
     )
 
@@ -100,14 +101,21 @@ def _render_verdict_block(final_report: dict[str, Any], *, quiet: bool) -> None:
         chips = "   ".join(f"{badge_emoji(b.klass)} {b.label}" for b in v.badges)
         click.echo(f"  {chips}", err=True)
 
-    # Failed rules
+    # Failed and incomplete rules — pad the severity and [slug] columns so the
+    # messages all line up. Each line reads: "<glyph> <emoji> <level>  [slug]  <msg>".
+    rules = (*v.failures, *v.incompletes)
+    tag_width = max((len(r.slug) + 2 for r in rules), default=0)
+    level_width = max((len(r.level) for r in rules), default=0)
     for f in v.failures:
         colour = LEVEL_STYLE.get(f.level, None)
-        line = f"  ✗ [{f.slug}]   {f.message}"
+        severity = f"{level_emoji(f.level) or '⬜'} {f.level:<{level_width}}"
+        line = f"  ✗ {severity}  {f'[{f.slug}]':<{tag_width}}   {f.message}"
         click.echo(click.style(line, fg=colour) if colour else line, err=True)
-    # Incomplete rules
     for i in v.incompletes:
-        click.echo(f"  ⚠ [{i.slug}]   {i.message}", err=True)
+        severity = f"{level_emoji(i.level) or '⬜'} {i.level:<{level_width}}"
+        click.echo(
+            f"  ⚠ {severity}  {f'[{i.slug}]':<{tag_width}}   {i.message}", err=True
+        )
 
 
 def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -900,9 +900,9 @@ class TestAnalyzeSummary:
         out = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().err)
         assert "🥉 Bronze · 33/100" in out
         assert "2 failed" in out
-        assert "✗ [trivy.no-critical-cves]" in out
+        assert "[trivy.no-critical-cves]" in out
         assert "2 critical CVEs found" in out
-        assert "✗ [freshness.max-age-days]" in out
+        assert "[freshness.max-age-days]" in out
 
     def test_render_verdict_block_no_playbooks_silent(self, capsys):
         from regis.commands.analyze import _render_verdict_block
@@ -910,6 +910,90 @@ class TestAnalyzeSummary:
         _render_verdict_block({}, quiet=False)
         _render_verdict_block({"playbooks": []}, quiet=False)
         assert capsys.readouterr().err == ""
+
+    def test_render_verdict_block_aligns_messages(self, capsys):
+        """Messages line up regardless of differing slug lengths."""
+        import re
+
+        from regis.commands.analyze import _render_verdict_block
+
+        _render_verdict_block(
+            {
+                "playbooks": [
+                    {
+                        "tier": "Bronze",
+                        "tier_icon": "🥉",
+                        "rules_summary": {"score": 33, "total": 2, "passed": 0},
+                        "rules": [
+                            {
+                                "slug": "cve-high",
+                                "passed": False,
+                                "level": "high",
+                                "status": "failed",
+                                "message": "msg one",
+                            },
+                            {
+                                "slug": "scorecard-min",
+                                "passed": False,
+                                "level": "warning",
+                                "status": "failed",
+                                "message": "msg two",
+                            },
+                        ],
+                        "badge_labels": [],
+                    }
+                ]
+            },
+            quiet=False,
+        )
+        out = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().err)
+        rule_lines = [ln for ln in out.splitlines() if ln.lstrip().startswith("✗")]
+        assert len(rule_lines) == 2
+        # The message text starts at the same column on every rule line.
+        cols = [ln.index("msg ") for ln in rule_lines]
+        assert cols[0] == cols[1]
+        # The slug tag likewise lines up under a fixed column.
+        slug_cols = [ln.index("[") for ln in rule_lines]
+        assert slug_cols[0] == slug_cols[1]
+
+    def test_render_verdict_block_shows_severity(self, capsys):
+        """Each rule line carries its severity (emoji + level word)."""
+        import re
+
+        from regis.commands.analyze import _render_verdict_block
+
+        _render_verdict_block(
+            {
+                "playbooks": [
+                    {
+                        "tier": "Bronze",
+                        "tier_icon": "🥉",
+                        "rules_summary": {"score": 33, "total": 2, "passed": 0},
+                        "rules": [
+                            {
+                                "slug": "cve-critical",
+                                "passed": False,
+                                "level": "critical",
+                                "status": "failed",
+                                "message": "boom",
+                            },
+                            {
+                                "slug": "age",
+                                "passed": False,
+                                "level": "warning",
+                                "status": "failed",
+                                "message": "old",
+                            },
+                        ],
+                        "badge_labels": [],
+                    }
+                ]
+            },
+            quiet=False,
+        )
+        out = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().err)
+        assert "🟥 critical" in out
+        assert "🟧 warning" in out
 
     @patch("regis.commands.analyze.RegistryClient")
     @patch("regis.commands.analyze._discover_analyzers")


### PR DESCRIPTION
## Summary

Improves the analyze verdict block so failed/incomplete rule lines are easier to scan:

- **Aligned messages**: the `[slug]` token is padded to a common width, so every rule message starts at the same column.
- **Per-rule severity**: each line now carries its severity (emoji + level), placed between the `✗`/`⚠` glyph and the slug, reusing the same `LEVEL_EMOJI` vocabulary as the `worst: 🟥 critical` counts line.

Before:
```
✗ [cve-critical]   Image has 40 critical CVEs (max allowed: 0).
✗ [hadolint-error]   Hadolint found 1 error issues (max allowed: 0).
✗ [age]   Image is older than 90 days (1303 days).
```

After:
```
✗ 🟥 critical  [cve-critical]     Image has 40 critical CVEs (max allowed: 0).
✗ 🟥 critical  [hadolint-error]   Hadolint found 1 error issues (max allowed: 0).
✗ 🟦 info      [age]              Image is older than 90 days (1303 days).
```

## Notes for reviewers

- The `level` field is a free-form string (schema has no enum). Levels outside the canonical critical/warning/info triad fall back to a neutral `⬜` emoji, preserving column alignment.
- Both the severity column and the slug tag are padded to the max width across failures **and** incompletes, so the two lists stay aligned with each other.

## Tests

- New `test_render_verdict_block_shows_severity` asserts the emoji + level appear.
- `test_render_verdict_block_aligns_messages` extended to assert both the message and slug columns line up.
- Full suite green (753 passed, coverage 95.51%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)