### PR TITLE
style(tests): remove unused subprocess import in test_doctor

### DIFF
--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -119,7 +119,6 @@ def test_doctor_lists_tools_section(monkeypatch, tmp_path):
 
 def test_get_version_returns_output_line(monkeypatch):
     """Normal success path: returns the first line of stdout."""
-    import subprocess as _sp
     from unittest.mock import MagicMock
 
     mock_result = MagicMock()


### PR DESCRIPTION
## Summary

Removes a redundant, never-used `import subprocess as _sp` inside `test_get_version_returns_output_line` (ruff F401). The module-level `import subprocess` already covers the test's needs. Pre-existing on `main`, unrelated to any feature work — split out as its own change.

## Test Plan

- [x] `ruff check tests/commands/test_doctor.py` — clean
- [x] `pytest tests/commands/test_doctor.py` — 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)