### PR TITLE
fix(ci): switch Dependabot Python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  # Native uv ecosystem (pyproject.toml + uv.lock); replaces the former pip
+  # entry that watched the now-removed Pipfile. Version-update PRs stay
+  # disabled (limit 0) — this entry exists so security alerts keep flowing.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

- Replace the `pip` Dependabot entry (which watched the `Pipfile` removed by #731) with the native `uv` ecosystem so Python dependency security alerts keep flowing to `repo-dependabot-critical-vulns.yml`.
- `open-pull-requests-limit: 0` preserved — alerts/security only, no version-bump PRs.
- Dependabot supports uv natively: [version updates GA (2025-03)](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/), [security updates (2025-12)](https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/).

⚠️ **Merge after #731** — the `uv` ecosystem needs `pyproject.toml` + `uv.lock` on `main`; draft until then.

Follow-up deferred by `docs/superpowers/specs/2026-06-10-pipenv-to-uv-migration-design.md` (out of scope there).

## Test plan

- [x] `trunk check .github/dependabot.yml` clean
- [ ] After merge: Dependabot job parses the config without errors (Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)