### PR TITLE
docs(website): run the CLI example through the official Docker image

### DIFF
--- a/docs/website/docs/usage/integrations/github.md
+++ b/docs/website/docs/usage/integrations/github.md
@@ -129,7 +129,7 @@ permissions:
 
 ### Complete Example
 
-The following example demonstrates a complete workflow that builds an image, pushes it to GHCR, and performs a security analysis.
+The following example demonstrates a complete workflow that builds an image, pushes it to GHCR, and performs a security analysis. It runs the `regis` CLI directly through the official Docker image — `regis` is distributed as a container image, not on PyPI — which gives access to flags the reusable action does not expose (such as `--meta`). If you don't need that control, prefer the [reusable action](#quick-start-with-the-reusable-action).
 
 ```yaml
 name: Build and Analyze
@@ -169,19 +169,17 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8
-
-      - name: Install regis
-        run: uv sync --locked --no-dev
-
       - name: Run Analysis
         run: |
-          uv run regis analyze ghcr.io/${{ github.repository }}:latest \
-            --auth ghcr.io=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-            --html \
-            --meta "trigger.user=${{ github.actor }}" \
-            --meta "trigger.url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          mkdir -p reports
+          docker run --rm \
+            -v "$PWD/reports:/home/regis/reports" \
+            ghcr.io/trivoallan/regis:latest \
+            analyze ghcr.io/${{ github.repository }}:latest \
+              --auth ghcr.io=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+              --html \
+              --meta "trigger.user=${{ github.actor }}" \
+              --meta "trigger.url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Upload Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- The "Complete Example" in the GitHub Actions integration guide installed regis with `uv sync --locked --no-dev` **in the user's own repository**, where regis is not a dependency — so the step installed nothing. The flaw predates the uv migration (`pipenv install --deploy` had the same problem).
- regis is not published on PyPI (the `regis` name there belongs to an unrelated project), so `uv tool install regis` / `uvx regis` would install the wrong package. The canonical CLI channel for CI is the official image: the example now runs `docker run ghcr.io/trivoallan/regis:latest analyze …` with a `reports/` volume mount (image user uid 1001 matches the Actions runner, so permissions line up).
- Intro sentence now explains when to use this pattern vs the reusable `trivoallan/regis-action@v1`.
- `versioned_docs/` untouched.

## Test plan

- [x] `trunk check` clean on the file
- [x] Volume/workdir semantics verified against the image (WORKDIR `/home/regis`, default output `reports/…`, entrypoint `regis`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)