### PR TITLE
fix(ci): rebase newly opened PRs and serialize autorebase runs

### DIFF
--- a/.github/workflows/repo-autorebase.yml
+++ b/.github/workflows/repo-autorebase.yml
@@ -3,6 +3,14 @@ name: Repo / Auto-rebase
 on:
   push:
     branches: [main]
+  # A PR created or marked ready AFTER the last push to main has no rebase
+  # trigger and sits BEHIND until an unrelated merge lands — and with the
+  # ruleset's strict status checks, auto-merge cannot fire on a BEHIND
+  # branch. Rebasing the PR on arrival closes that gap. This event never
+  # checks out or executes PR code (the action only runs git plumbing), so
+  # pull_request_target is safe here.
+  pull_request_target:
+    types: [opened, ready_for_review]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -10,9 +18,19 @@ env:
 permissions:
   contents: read
 
+# Push runs rebase the whole fleet of open PRs; PR-scoped runs rebase a
+# single one. Keep the groups separate so a single-PR run never cancels a
+# fleet run, while bursts within each scope coalesce on the newest main.
+concurrency:
+  group: repo-autorebase-${{ github.event.pull_request.number || 'main' }}
+  cancel-in-progress: true
+
 jobs:
   rebase:
     runs-on: ubuntu-latest
+    # Fork heads cannot be force-pushed by the App token; only same-repo PRs
+    # are rebased on PR events (push runs are unaffected).
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write
@@ -29,3 +47,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           exclude-drafts: true
+          # On PR events, restrict the run to the PR that triggered it; on
+          # push events the filter is empty and every open PR is rebased.
+          # The action skips heads that are already up to date with main.
+          head: ${{ github.event.pull_request && format('{0}:{1}', github.event.pull_request.head.repo.owner.login, github.event.pull_request.head.ref) || '' }}


### PR DESCRIPTION
## Summary

- **Closes the auto-rebase trigger gap**: `repo-autorebase.yml` only fired on `push: main`, so a PR created or marked ready *after* the last push to `main` sat `BEHIND` with no rebase trigger — and the ruleset's `strict_required_status_checks_policy` keeps auto-merge from firing on a `BEHIND` branch. Observed live on #734 (11/11 checks green, auto-merge armed, stuck). New `pull_request_target: [opened, ready_for_review]` trigger rebases the arriving PR, scoped to its head ref via the action's `head` filter; the action already skips up-to-date heads. Fork heads are excluded (the App token can't force-push them).
- **Serializes runs**: per-scope `concurrency` groups (`main` fleet runs vs per-PR runs) so bursts coalesce on the newest `main` without a single-PR run ever cancelling a fleet run.

Safety note: `pull_request_target` never checks out or executes PR code here — `peter-evans/rebase` only runs git plumbing (fetch/rebase/push).

## Test plan

- [x] `trunk check` clean (actionlint/yamllint)
- [ ] After merge: open a PR while `main` is quiet → a `Repo / Auto-rebase` run fires on `opened` and the PR is rebased (or skipped as up-to-date) without waiting for a `main` push
- [ ] Existing behaviour preserved: next push to `main` still rebases the whole fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)