### PR TITLE
fix(ci): sync uv.lock version on the release-please PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,25 @@ jobs:
           ref: ${{ fromJson(steps.release.outputs.pr).head_branch }}
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Install uv
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Sync uv.lock to the released version
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          # release-please bumps the version in pyproject.toml but leaves uv.lock,
+          # which pins the project's own version, untouched. That desyncs the
+          # lockfile and fails every `uv ... --locked` step (pytest, pip-audit,
+          # image build) on the release PR. Re-lock only the `regis` package so
+          # no dependencies are upgraded as a side effect.
+          uv lock --upgrade-package regis
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add uv.lock
+          git commit -m "build(deps): sync uv.lock to the released version" || echo "No changes to commit"
+          git push
+
       - name: Install Trunk
         if: ${{ steps.release.outputs.pr }}
         uses: trunk-io/trunk-action/install@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4


### PR DESCRIPTION
## Summary

The release PR #721 (`release 0.37.0`) fails **pytest**, **pip-audit**, and both **image-size** checks with the same root cause:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Since the pipenv→uv migration (#731), release-please bumps the version in `pyproject.toml` (0.36.0 → 0.37.0) but leaves `uv.lock`, which pins the project's **own** version, at 0.36.0. Every `uv … --locked` step then refuses to run on the release branch.

This adds a step to the release-please workflow — right after it checks out the release PR branch, mirroring the existing CHANGELOG-format step — that re-locks **only** the project package and commits the result:

```
uv lock --upgrade-package regis
```

`--upgrade-package regis` updates just the `regis` version line in `uv.lock` (verified: a 2-line diff, no dependency upgrades).

## Effect

- Future release PRs get a synced `uv.lock` automatically.
- To fix the **current** PR #721, re-run the release-please workflow once this lands (it will update #721's `uv.lock` and clear all four red checks).

## Test Plan

- [x] `uv lock --upgrade-package regis` after a local 0.37.0 bump produces a clean 2-line `uv.lock` diff (regis version only).
- [x] Workflow YAML parses; the new step is gated on `steps.release.outputs.pr` like the sibling steps; `setup-uv` uses the repo's pinned SHA.
- [ ] After merge + a release-please run: #721's pytest / pip-audit / image-size checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)