### PR TITLE
fix(ci): check out the real release branch in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ fromJson(steps.release.outputs.pr).head_branch }}
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install uv


### PR DESCRIPTION
## Summary

Follow-up to #746. That PR added a `uv lock` sync step to the release-please workflow, which surfaced a **pre-existing latent bug** in the `Checkout PR branch` step:

```yaml
ref: ${{ fromJson(steps.release.outputs.pr).head_branch }}   # ❌ no such field
```

`release-please-action` v4 emits the PR object with **`headBranchName`** (see [`pull-request.ts`](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts)), not `head_branch`. The bad reference resolved to empty, so `actions/checkout` fell back to the default branch and the post-release steps ran on **`main`**.

This was invisible while the CHANGELOG-format step usually had nothing to push. But the new uv.lock step produces a commit, and its push to `main` was correctly rejected by branch protection:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

Fix: use `headBranchName` so the checkout — and therefore both the uv.lock-sync and CHANGELOG-format steps — operate on and push to the **release branch**, not `main`.

## Effect

Once merged, the next release-please run will check out `release-please--branches--main`, sync its `uv.lock` to 0.37.0, and push it there — clearing the pytest / pip-audit / image-size failures on #721.

## Test Plan

- [x] `headBranchName` confirmed against release-please's `PullRequest` interface.
- [x] Workflow YAML parses.
- [ ] After merge + release-please run: the release branch is checked out (not `main`), `uv.lock` syncs, and #721's checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)