### PR TITLE
refactor(core): hexagonal P1 — model, ports & fakes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ layers = [
   "regis.core.application",
   "regis.core.domain",
   "regis.core.ports",
+  "regis.core.model",
 ]
 
 [tool.mypy]

--- a/regis/core/application/analyzer_provider.py
+++ b/regis/core/application/analyzer_provider.py
@@ -1,0 +1,19 @@
+"""AnalyzerProvider port — supplies the available analyzers to the application."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+
+
+class AnalyzerProvider(ABC):
+    """Application-facing port: discovers/provides the analyzer classes to run.
+
+    Returns analyzer *types*. The concrete bound (``type[BaseAnalyzer]``) is
+    deferred to P4 when analyzers move into ``regis.core.domain``; typed as
+    ``type`` here so the core stays free of legacy ``regis.analyzers`` imports.
+    """
+
+    @abstractmethod
+    def available(self) -> Mapping[str, type]:
+        """Return a mapping of analyzer slug -> analyzer class."""

--- a/regis/core/domain/context.py
+++ b/regis/core/domain/context.py
@@ -1,0 +1,18 @@
+"""AnalysisContext — the capabilities bundle passed to an analyzer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from regis.core.model.image_reference import ImageReference
+from regis.core.ports.image_inspector import ImageInspector
+from regis.core.ports.tool_runner import ToolRunner
+
+
+@dataclass
+class AnalysisContext:
+    """What an analyzer receives: the image under analysis and the ports it may use."""
+
+    image: ImageReference
+    inspector: ImageInspector
+    tools: ToolRunner

--- a/regis/core/model/__init__.py
+++ b/regis/core/model/__init__.py
@@ -1,0 +1,1 @@
+"""Model layer: pure value objects with no dependencies (lowest hexagonal layer)."""

--- a/regis/core/model/image_reference.py
+++ b/regis/core/model/image_reference.py
@@ -1,0 +1,15 @@
+"""ImageReference value object."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    """An immutable reference to an OCI image to analyze. Carries no credentials."""
+
+    registry: str
+    repository: str
+    tag: str
+    platform: str | None = None

--- a/regis/core/model/report.py
+++ b/regis/core/model/report.py
@@ -1,0 +1,23 @@
+"""Report value object — a thin wrapper over the analysis report envelope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Report:
+    """Wraps the report envelope payload (the JSON-Schema-validated dict).
+
+    Intentionally thin in P1: the dict payload remains the source of truth.
+    Rich field-level modeling is deferred to a later phase.
+    """
+
+    payload: dict[str, Any]
+
+    @property
+    def schema_version(self) -> int | None:
+        """The integer envelope schema version, or None if absent/non-integer."""
+        value = self.payload.get("schemaVersion")
+        return value if isinstance(value, int) else None

--- a/regis/core/ports/image_inspector.py
+++ b/regis/core/ports/image_inspector.py
@@ -1,0 +1,26 @@
+"""ImageInspector port — read-only access to an OCI registry."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ImageInspector(ABC):
+    """Port for inspecting an image in a registry."""
+
+    @abstractmethod
+    def list_tags(self) -> list[str]:
+        """Return the repository's tags."""
+
+    @abstractmethod
+    def get_manifest(self, reference: str) -> dict[str, Any]:
+        """Return the manifest for a tag or digest reference."""
+
+    @abstractmethod
+    def get_blob(self, digest: str) -> dict[str, Any]:
+        """Return the parsed blob (typically an image config) for a digest."""
+
+    @abstractmethod
+    def get_digest(self, reference: str) -> str | None:
+        """Return the content digest for a reference, or None if the registry omits it."""

--- a/regis/core/ports/report_sink.py
+++ b/regis/core/ports/report_sink.py
@@ -1,0 +1,19 @@
+"""ReportSink port — emission of analysis reports."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from pathlib import Path
+
+from regis.core.model.report import Report
+
+
+class ReportSink(ABC):
+    """Port for emitting a report in one or more formats to a destination."""
+
+    @abstractmethod
+    def emit(
+        self, report: Report, *, formats: Sequence[str], output_dir: Path
+    ) -> list[Path]:
+        """Emit *report* in *formats* under *output_dir*; return the written paths."""

--- a/regis/core/ports/tool_runner.py
+++ b/regis/core/ports/tool_runner.py
@@ -1,0 +1,57 @@
+"""ToolRunner port — execution of external scanners (capability-oriented)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from regis.core.model.image_reference import ImageReference
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """Generic result of running a tool via the escape hatch."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+class ToolRunner(ABC):
+    """Port for running external scanners.
+
+    Capability methods return parsed output (a dict); ``run`` is a generic
+    escape hatch for plugin-supplied tools.
+    """
+
+    @abstractmethod
+    def scan_vulnerabilities(self, image: ImageReference) -> dict[str, Any]:
+        """Scan *image* for vulnerabilities (e.g. grype)."""
+
+    @abstractmethod
+    def generate_sbom(self, image: ImageReference) -> dict[str, Any]:
+        """Generate an SBOM for *image* (e.g. syft)."""
+
+    @abstractmethod
+    def scan_secrets(self, image: ImageReference) -> dict[str, Any]:
+        """Scan *image* for embedded secrets (e.g. trufflehog)."""
+
+    @abstractmethod
+    def lint_dockerfile(self, dockerfile_contents: str) -> dict[str, Any]:
+        """Lint the given Dockerfile *contents* string (e.g. hadolint)."""
+
+    @abstractmethod
+    def audit_image(self, image: ImageReference) -> dict[str, Any]:
+        """Audit *image* for best practices (e.g. dockle)."""
+
+    @abstractmethod
+    def inspect_platforms(self, image: ImageReference) -> dict[str, Any]:
+        """Inspect *image* manifest/platform data (e.g. regctl)."""
+
+    @abstractmethod
+    def run(
+        self, tool: str, args: Sequence[str], *, timeout: int | None = None
+    ) -> ToolResult:
+        """Escape hatch: run an arbitrary resolved tool with *args*."""

--- a/tests/core/test_analyzer_provider.py
+++ b/tests/core/test_analyzer_provider.py
@@ -1,0 +1,10 @@
+"""AnalyzerProvider is an abstract, application-facing port."""
+
+import pytest
+
+from regis.core.application.analyzer_provider import AnalyzerProvider
+
+
+def test_analyzer_provider_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        AnalyzerProvider()

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,0 +1,22 @@
+"""AnalysisContext bundles the image and the domain-facing ports."""
+
+from unittest.mock import create_autospec
+
+from regis.core.domain.context import AnalysisContext
+from regis.core.model.image_reference import ImageReference
+from regis.core.ports.image_inspector import ImageInspector
+from regis.core.ports.tool_runner import ToolRunner
+
+
+def test_analysis_context_holds_image_and_ports() -> None:
+    # Field set catches an added/removed/renamed field.
+    assert set(AnalysisContext.__dataclass_fields__) == {"image", "inspector", "tools"}
+
+    # Construction + attribute round-trip exercises the dataclass itself.
+    image = ImageReference(registry="docker.io", repository="library/nginx", tag="1.27")
+    inspector = create_autospec(ImageInspector, instance=True)
+    tools = create_autospec(ToolRunner, instance=True)
+    ctx = AnalysisContext(image=image, inspector=inspector, tools=tools)
+    assert ctx.image is image
+    assert ctx.inspector is inspector
+    assert ctx.tools is tools

--- a/tests/core/test_fakes.py
+++ b/tests/core/test_fakes.py
@@ -1,0 +1,57 @@
+"""The fakes implement their ports and return canned data with no I/O."""
+
+from pathlib import Path
+
+from regis.core.application.analyzer_provider import AnalyzerProvider
+from regis.core.model.image_reference import ImageReference
+from regis.core.model.report import Report
+from regis.core.ports.image_inspector import ImageInspector
+from regis.core.ports.report_sink import ReportSink
+from regis.core.ports.tool_runner import ToolRunner
+from tests.fakes import (
+    FakeImageInspector,
+    FakeReportSink,
+    FakeToolRunner,
+    StubAnalyzerProvider,
+)
+
+IMG = ImageReference(registry="docker.io", repository="library/nginx", tag="1.27")
+
+
+def test_fakes_are_instances_of_their_ports() -> None:
+    assert isinstance(FakeImageInspector(), ImageInspector)
+    assert isinstance(FakeToolRunner(), ToolRunner)
+    assert isinstance(FakeReportSink(), ReportSink)
+    assert isinstance(StubAnalyzerProvider({}), AnalyzerProvider)
+
+
+def test_fake_tool_runner_returns_canned() -> None:
+    runner = FakeToolRunner(scan_vulnerabilities={"matches": [1, 2]})
+    assert runner.scan_vulnerabilities(IMG) == {"matches": [1, 2]}
+    assert runner.generate_sbom(IMG) == {}  # default empty
+
+
+def test_fake_report_sink_records_emissions() -> None:
+    sink = FakeReportSink()
+    paths = sink.emit(
+        Report(payload={}), formats=["json", "html"], output_dir=Path("/out")
+    )
+    assert paths == [Path("/out/report.json"), Path("/out/report.html")]
+    assert len(sink.emitted) == 1
+
+
+def test_stub_analyzer_provider_returns_mapping() -> None:
+    provider = StubAnalyzerProvider({"cve": object})
+    assert provider.available() == {"cve": object}
+
+
+def test_fake_image_inspector_copies_and_honors_sentinel() -> None:
+    inspector = FakeImageInspector(tags=["1.27"], blob={"config": "x"}, digest=None)
+    # Returned containers are independent (shallow) copies — top-level mutation must not leak.
+    inspector.list_tags().append("evil")
+    assert inspector.list_tags() == ["1.27"]
+    inspector.get_blob("sha256:x")["leak"] = True
+    assert inspector.get_blob("sha256:x") == {"config": "x"}
+    # digest sentinel honored (None is valid for str | None); default is "sha256:fake".
+    assert inspector.get_digest("1.27") is None
+    assert FakeImageInspector().get_digest("1.27") == "sha256:fake"

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,0 +1,26 @@
+"""Core value objects."""
+
+import dataclasses
+
+import pytest
+
+from regis.core.model.image_reference import ImageReference
+from regis.core.model.report import Report
+
+
+def test_image_reference_is_frozen_and_equal() -> None:
+    a = ImageReference(registry="docker.io", repository="library/nginx", tag="1.27")
+    b = ImageReference(registry="docker.io", repository="library/nginx", tag="1.27")
+    assert a == b
+    assert a.platform is None
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        a.tag = "1.28"  # type: ignore[misc]
+
+
+def test_report_exposes_schema_version() -> None:
+    assert Report(payload={"schemaVersion": 2, "results": {}}).schema_version == 2
+    assert Report(payload={"schemaVersion": 0}).schema_version == 0
+    assert Report(payload={}).schema_version is None
+    # Non-integer values are rejected by the int-guard.
+    assert Report(payload={"schemaVersion": "2"}).schema_version is None
+    assert Report(payload={"schemaVersion": 2.0}).schema_version is None

--- a/tests/core/test_ports.py
+++ b/tests/core/test_ports.py
@@ -1,0 +1,18 @@
+"""The infra ports are abstract and reference only the model layer."""
+
+import pytest
+
+from regis.core.ports.image_inspector import ImageInspector
+from regis.core.ports.report_sink import ReportSink
+from regis.core.ports.tool_runner import ToolResult, ToolRunner
+
+
+@pytest.mark.parametrize("port", [ImageInspector, ToolRunner, ReportSink])
+def test_ports_cannot_be_instantiated(port: type) -> None:
+    with pytest.raises(TypeError):
+        port()  # abstract — has unimplemented abstractmethods
+
+
+def test_tool_result_is_a_value() -> None:
+    r = ToolResult(stdout="out", stderr="", exit_code=0)
+    assert (r.stdout, r.exit_code) == ("out", 0)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,102 @@
+"""In-memory fakes implementing the hexagonal ports, for hermetic tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from regis.core.application.analyzer_provider import AnalyzerProvider
+from regis.core.model.image_reference import ImageReference
+from regis.core.model.report import Report
+from regis.core.ports.image_inspector import ImageInspector
+from regis.core.ports.report_sink import ReportSink
+from regis.core.ports.tool_runner import ToolResult, ToolRunner
+
+
+class FakeImageInspector(ImageInspector):
+    """Returns canned registry data; no network.
+
+    Limitation: ``get_manifest``/``get_blob`` ignore their reference/digest
+    argument and return the single canned value. Extend with a per-reference
+    map if a test must distinguish multiple references (e.g. a multi-arch path).
+    """
+
+    def __init__(
+        self,
+        *,
+        tags: list[str] | None = None,
+        manifest: dict[str, Any] | None = None,
+        blob: dict[str, Any] | None = None,
+        digest: str | None = "sha256:fake",
+    ) -> None:
+        self._tags = tags or []
+        self._manifest = manifest or {}
+        self._blob = blob or {}
+        self._digest = digest
+
+    def list_tags(self) -> list[str]:
+        return list(self._tags)
+
+    def get_manifest(self, reference: str) -> dict[str, Any]:
+        return dict(self._manifest)
+
+    def get_blob(self, digest: str) -> dict[str, Any]:
+        return dict(self._blob)
+
+    def get_digest(self, reference: str) -> str | None:
+        return self._digest
+
+
+class FakeToolRunner(ToolRunner):
+    """Returns canned tool output per capability; no subprocess."""
+
+    def __init__(self, **canned: dict[str, Any]) -> None:
+        self._canned = canned
+
+    def scan_vulnerabilities(self, image: ImageReference) -> dict[str, Any]:
+        return self._canned.get("scan_vulnerabilities", {})
+
+    def generate_sbom(self, image: ImageReference) -> dict[str, Any]:
+        return self._canned.get("generate_sbom", {})
+
+    def scan_secrets(self, image: ImageReference) -> dict[str, Any]:
+        return self._canned.get("scan_secrets", {})
+
+    def lint_dockerfile(self, dockerfile_contents: str) -> dict[str, Any]:
+        return self._canned.get("lint_dockerfile", {})
+
+    def audit_image(self, image: ImageReference) -> dict[str, Any]:
+        return self._canned.get("audit_image", {})
+
+    def inspect_platforms(self, image: ImageReference) -> dict[str, Any]:
+        return self._canned.get("inspect_platforms", {})
+
+    def run(
+        self, tool: str, args: Sequence[str], *, timeout: int | None = None
+    ) -> ToolResult:
+        # Always a zero-exit empty result; subclass if a test needs a failure path.
+        return ToolResult(stdout="", stderr="", exit_code=0)
+
+
+class FakeReportSink(ReportSink):
+    """Records emissions in memory; writes nothing to disk."""
+
+    def __init__(self) -> None:
+        self.emitted: list[tuple[Report, tuple[str, ...], Path]] = []
+
+    def emit(
+        self, report: Report, *, formats: Sequence[str], output_dir: Path
+    ) -> list[Path]:
+        self.emitted.append((report, tuple(formats), output_dir))
+        return [output_dir / f"report.{fmt}" for fmt in formats]
+
+
+class StubAnalyzerProvider(AnalyzerProvider):
+    """Returns a fixed analyzer mapping; no entry-point discovery."""
+
+    def __init__(self, analyzers: Mapping[str, type]) -> None:
+        self._analyzers = dict(analyzers)
+
+    def available(self) -> Mapping[str, type]:
+        return dict(self._analyzers)


### PR DESCRIPTION
## Summary

Phase 1 of the hexagonal (ports & adapters) migration — **purely additive, no behavior change, nothing wired into analyzers yet**. Adds the core's value objects, the four ports, the `AnalysisContext`, reusable test fakes, and extends the import-linter contract with the `model` layer. Builds on P0 (#759, merged).

Design spec: `docs/superpowers/specs/2026-06-13-hexagonal-architecture-design.md`. The phase plan was kept local (ephemeral — not committed).

## What's in this PR (5 commits)

- `refactor(core)`: `regis/core/model/` — `ImageReference` (frozen) + `Report` (thin envelope wrapper).
- `refactor(core)`: `regis/core/ports/` — `ImageInspector`, `ToolRunner` (capability-oriented + generic `run()` escape hatch) + `ToolResult`, `ReportSink`. Ports reference only `model`.
- `refactor(core)`: `regis/core/domain/context.py` (`AnalysisContext`) + `regis/core/application/analyzer_provider.py` (`AnalyzerProvider`).
- `test(core)`: `tests/fakes.py` — `FakeImageInspector` / `FakeToolRunner` / `FakeReportSink` / `StubAnalyzerProvider`.
- `refactor(core)`: govern `regis.core.model` as the bottom layer in the import-linter contract.

**Resolved layering** (linear, CI-enforced): `regis.adapters → regis.core.application → regis.core.domain → regis.core.ports → regis.core.model`.

## Out of scope (later phases)

Real adapters wrapping the existing infra (P2); the `BaseAnalyzer.analyze(ctx)` contract switch + wiring analyzers to ports (P3); the physical module move + binding `AnalyzerProvider.available()` to `type[BaseAnalyzer]` (P4); docs (P5).

## Verification

- `uv run pytest`: **774 passed, 1 skipped, 95.64% coverage** (≥90% global + per-file gates).
- `uv run lint-imports`: **1 kept, 0 broken** (with `model` now governed).

## Deferred follow-ups (from review — non-blocking)

- Consider `@dataclass(frozen=True)` for `AnalysisContext` (immutable capabilities bundle) — best done before P3 wires it.
- `FakeToolRunner.__init__(**canned)` annotation, port `__all__`/`__init__` re-exports, an `Emission` NamedTuple for `FakeReportSink`, an `ImageReference.__str__` canonical ref string.
- **P2 note**: `regis/utils/{grype,syft,trufflehog,regctl}.py` raise `AnalyzerError` where `ToolError` now fits — migrate when the tool adapter lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)