### PR TITLE
refactor(adapters): hexagonal P2a — registry & analyzer driven adapters

### DIFF
--- a/regis/adapters/driven/analyzers/__init__.py
+++ b/regis/adapters/driven/analyzers/__init__.py
@@ -1,0 +1,1 @@
+"""Analyzer-discovery driven adapter: implements AnalyzerProvider over entry points."""

--- a/regis/adapters/driven/analyzers/entry_point_provider.py
+++ b/regis/adapters/driven/analyzers/entry_point_provider.py
@@ -1,0 +1,15 @@
+"""EntryPointAnalyzerProvider — AnalyzerProvider backed by entry-point discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from regis.analyzers.discovery import discover_analyzers
+from regis.core.application.analyzer_provider import AnalyzerProvider
+
+
+class EntryPointAnalyzerProvider(AnalyzerProvider):
+    """Adapts ``regis.analyzers`` entry-point discovery to the AnalyzerProvider port."""
+
+    def available(self) -> Mapping[str, type]:
+        return discover_analyzers()

--- a/regis/adapters/driven/registry/__init__.py
+++ b/regis/adapters/driven/registry/__init__.py
@@ -1,0 +1,1 @@
+"""Registry driven adapter: implements ImageInspector over the OCI RegistryClient."""

--- a/regis/adapters/driven/registry/image_inspector.py
+++ b/regis/adapters/driven/registry/image_inspector.py
@@ -1,0 +1,51 @@
+"""RegistryImageInspector — ImageInspector backed by the OCI RegistryClient."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from regis.core.domain.errors import RegistryError
+from regis.core.ports.image_inspector import ImageInspector
+from regis.registry.client import RegistryClient
+from regis.registry.client import RegistryError as _ClientRegistryError
+
+
+@contextmanager
+def _as_core_registry_error() -> Iterator[None]:
+    """Translate the legacy client RegistryError into the core RegistryError."""
+    try:
+        yield
+    except _ClientRegistryError as exc:
+        raise RegistryError(str(exc)) from exc
+
+
+class RegistryImageInspector(ImageInspector):
+    """Adapts the concrete :class:`RegistryClient` to the ImageInspector port.
+
+    Credentials and connection state live in the injected client, not in the
+    core. The per-thread factory that builds these lives in the composition
+    root (P3). The client's ``tag`` parameter accepts a tag *or* a digest
+    reference (the registry ``/manifests/<ref>`` endpoint handles both), so the
+    port's wider ``reference`` contract is honored by positional pass-through.
+    """
+
+    def __init__(self, client: RegistryClient) -> None:
+        self._client = client
+
+    def list_tags(self) -> list[str]:
+        with _as_core_registry_error():
+            return self._client.list_tags()
+
+    def get_manifest(self, reference: str) -> dict[str, Any]:
+        with _as_core_registry_error():
+            return self._client.get_manifest(reference)
+
+    def get_blob(self, digest: str) -> dict[str, Any]:
+        with _as_core_registry_error():
+            return self._client.get_blob(digest)
+
+    def get_digest(self, reference: str) -> str | None:
+        with _as_core_registry_error():
+            return self._client.get_digest(reference)

--- a/tests/adapters/test_entry_point_provider.py
+++ b/tests/adapters/test_entry_point_provider.py
@@ -1,0 +1,17 @@
+"""EntryPointAnalyzerProvider delegates to discover_analyzers."""
+
+from regis.adapters.driven.analyzers import entry_point_provider
+from regis.adapters.driven.analyzers.entry_point_provider import (
+    EntryPointAnalyzerProvider,
+)
+from regis.core.application.analyzer_provider import AnalyzerProvider
+
+
+def test_is_an_analyzer_provider() -> None:
+    assert isinstance(EntryPointAnalyzerProvider(), AnalyzerProvider)
+
+
+def test_available_delegates_to_discovery(monkeypatch) -> None:
+    stub = {"cve": object, "sbom": object}
+    monkeypatch.setattr(entry_point_provider, "discover_analyzers", lambda: stub)
+    assert EntryPointAnalyzerProvider().available() == stub

--- a/tests/adapters/test_registry_image_inspector.py
+++ b/tests/adapters/test_registry_image_inspector.py
@@ -1,0 +1,47 @@
+"""RegistryImageInspector delegates to RegistryClient and translates errors."""
+
+from unittest.mock import create_autospec
+
+import pytest
+
+from regis.adapters.driven.registry.image_inspector import RegistryImageInspector
+from regis.core.domain.errors import RegistryError
+from regis.core.ports.image_inspector import ImageInspector
+from regis.registry.client import RegistryClient
+from regis.registry.client import RegistryError as ClientRegistryError
+
+
+def _inspector() -> tuple[RegistryImageInspector, RegistryClient]:
+    client = create_autospec(RegistryClient, instance=True)
+    return RegistryImageInspector(client), client
+
+
+def test_is_an_image_inspector() -> None:
+    inspector, _ = _inspector()
+    assert isinstance(inspector, ImageInspector)
+
+
+def test_delegates_each_method() -> None:
+    inspector, client = _inspector()
+    client.list_tags.return_value = ["1.27"]
+    client.get_manifest.return_value = {"schemaVersion": 2}
+    client.get_blob.return_value = {"config": {}}
+    client.get_digest.return_value = "sha256:abc"
+
+    assert inspector.list_tags() == ["1.27"]
+    assert inspector.get_manifest("1.27") == {"schemaVersion": 2}
+    assert inspector.get_blob("sha256:abc") == {"config": {}}
+    assert inspector.get_digest("1.27") == "sha256:abc"
+    client.get_manifest.assert_called_once_with("1.27")
+    client.get_blob.assert_called_once_with("sha256:abc")
+    client.get_digest.assert_called_once_with("1.27")
+
+
+def test_translates_legacy_registry_error() -> None:
+    # One method suffices — all four share the same contextmanager.
+    inspector, client = _inspector()
+    client.list_tags.side_effect = ClientRegistryError("boom")
+    with pytest.raises(RegistryError) as exc_info:
+        inspector.list_tags()
+    assert "boom" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, ClientRegistryError)


### PR DESCRIPTION
## Summary

First slice of Phase 2 of the hexagonal migration — the two **trivial driven adapters** that delegate 1:1 to existing infra. Purely additive: **no existing code modified, nothing moved** (the physical move of `registry/` and `analyzers/discovery.py` into `adapters/driven/` is P4). Builds on P0+P1 (on `main`).

## What's in this PR (2 commits)

- `refactor(registry)`: `RegistryImageInspector` (`regis/adapters/driven/registry/`) — implements the `ImageInspector` port over an injected `RegistryClient`; translates the legacy `regis.registry.client.RegistryError` (plain `Exception`) into the core `regis.core.domain.errors.RegistryError` via a contextmanager, preserving the cause chain.
- `refactor(analyzer)`: `EntryPointAnalyzerProvider` (`regis/adapters/driven/analyzers/`) — implements the `AnalyzerProvider` port over the existing `discover_analyzers()` entry-point discovery.

Both are dependency-injected / monkeypatchable, tested in isolation (mocked client / stubbed discovery).

## Out of scope (next slices)

- **P2b**: the complex adapters — `SubprocessToolRunner` (6 capability methods + auth + extracting the inline hadolint/dockle subprocess logic) and `FileReportSink` (report emission).
- **P3**: the composition-root factory + use-cases wiring; the `BaseAnalyzer.analyze(ctx)` contract switch.
- **P4**: physical module move + binding `AnalyzerProvider.available() -> type[BaseAnalyzer]`.

## Verification

- `uv run pytest`: **779 passed, 1 skipped, 95.69% coverage** (≥90% global + per-file).
- `uv run lint-imports`: **1 kept, 0 broken**.

Each adapter passed an independent spec-compliance + code-quality review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)