### PR TITLE
refactor(adapters): hexagonal P2b-1 — SubprocessToolRunner (scanner ToolRunner)

### DIFF
--- a/docs/superpowers/specs/2026-06-14-hexagonal-p2b-subprocess-adapters-design.md
+++ b/docs/superpowers/specs/2026-06-14-hexagonal-p2b-subprocess-adapters-design.md
@@ -1,0 +1,156 @@
+# P2b — Adaptateurs driven « subprocess » (`SubprocessToolRunner` + `RegctlImageInspector`)
+
+> Raffinement de phase de la spec maîtresse
+> [`2026-06-13-hexagonal-architecture-design.md`](./2026-06-13-hexagonal-architecture-design.md)
+> (PR #758, encore en draft à la rédaction). Ce document **fait autorité** pour la phase P2b et
+> **supersède** le placement de regctl décrit en §5.1 de la spec maîtresse.
+
+## 1. Contexte
+
+P0, P1 et P2a sont sur `main` (`7d60327`, `06a20ed`, `ae1df91`). P2a a livré les deux adaptateurs
+délégateurs triviaux (`RegistryImageInspector`, `EntryPointAnalyzerProvider`). P2b livre les
+adaptateurs driven restants qui encapsulent du **subprocess** — non triviaux : ils enveloppent les
+wrappers réels et tranchent un point de design laissé ouvert par la spec maîtresse (« le jeu exact
+de méthodes capacité sera figé au plan »).
+
+L'exploration des wrappers et de leurs consommateurs (2026-06-14) a établi deux faits :
+
+1. **Le port `ToolRunner` (P1) ment sur ses types.** Tout est typé `dict[str, Any]` alors que
+   `run_trufflehog → list[dict]`, le lint hadolint → `list[dict]`, et `run_regctl → str`.
+2. **`run_regctl` n'est pas un scanner.** Il est appelé par cinq analyzers (`oci`, `hadolint`,
+   `size`, `freshness`, `versioning`) pour `image inspect`, `manifest get`, `manifest head` et
+   `tag ls` — exactement les opérations que le port `ImageInspector` déclare déjà
+   (`get_manifest`/`get_blob`/`get_digest`/`list_tags`).
+
+## 2. Décision clé — regctl devient un 2ᵉ `ImageInspector`
+
+regctl est une **alternative CLI au client registry HTTP**, pas un outil de scan. Il implémente le
+même contrat d'inspection que `RegistryClient`. P2b le promeut donc en **seconde implémentation du
+port `ImageInspector`** (`RegctlImageInspector`), et **retire `inspect_platforms` du port
+`ToolRunner`**. `ToolRunner` redevient purement « scanners ».
+
+Conséquence : le port `ImageInspector` **reste inchangé** (4 méthodes, agnostique plateforme). La
+résolution par-plateforme que `run_regctl --platform` fait aujourd'hui en un appel devient de la
+**traversée d'index explicite** côté analyzer (récupérer l'index via `get_manifest`, choisir le
+digest de la plateforme, puis `get_manifest`/`get_blob` sur ce digest). C'est de la logique domaine,
+migrée en **P3** ; l'analyzer OCI le fait déjà par digest pour le cas index.
+
+Alternatives écartées : (a) garder `inspect_platforms` dans `ToolRunner` comme le dit la spec
+maîtresse — laisse une méthode étroite qui ne couvre pas tag-ls / config / digest ; (b) paramétrer
+le port `ImageInspector` par plateforme — déborde sur `RegistryClient` (l'API HTTP ne sait pas
+résoudre une plateforme), casse la symétrie des deux backends.
+
+## 3. Périmètre & découpage
+
+Deux PR courtes (préférence repo + machinerie autorebase), une par adaptateur :
+
+- **P2b-1** — `SubprocessToolRunner` (port `ToolRunner`, scanners) + révision honnête du port +
+  mise à jour de `FakeToolRunner`.
+- **P2b-2** — `RegctlImageInspector` (2ᵉ implémentation de `ImageInspector`).
+
+`FileReportSink` (l'ancien P2c de la spec maîtresse) reste en aval, hors périmètre P2b.
+
+## 4. P2b-1 — `ToolRunner` (scanners) + `SubprocessToolRunner`
+
+### 4.1 Port révisé (`regis/core/ports/tool_runner.py`)
+
+Touche du code P1 mergé, mais purement interne et pré-release. Aucun consommateur n'existe encore
+(les analyzers n'ont pas basculé sur `ctx` — P3).
+
+| Méthode | Type de retour | Wrapper / source |
+| --- | --- | --- |
+| `scan_vulnerabilities(image)` | `dict[str, Any]` | `run_grype` |
+| `generate_sbom(image)` | `dict[str, Any]` | `run_syft` |
+| `scan_secrets(image)` | **`list[dict[str, Any]]`** | `run_trufflehog` (pas d'arg `platform`) |
+| `lint_dockerfile(dockerfile: str)` | **`list[dict[str, Any]]`** | inline hadolint extrait |
+| `audit_image(image)` | `dict[str, Any]` | inline dockle extrait |
+| `run(tool, args, *, timeout=None)` | `ToolResult` | échappatoire plugins |
+| ~~`inspect_platforms`~~ | — | **supprimée** (partait sur regctl) |
+
+### 4.2 `SubprocessToolRunner` (`regis/adapters/driven/tools/subprocess_tool_runner.py`)
+
+- Détient les **credentials** (registry user/password) injectés par la composition root (P3). Un
+  analyzer ne voit plus jamais de mot de passe.
+- Construit la référence `registry/repo:tag` à partir de l'`ImageReference` (qui ne porte pas de
+  creds) ; passe `image.platform` aux outils qui le supportent (grype, syft) ; pas à trufflehog.
+- `scan_vulnerabilities`/`generate_sbom`/`scan_secrets` délèguent aux wrappers existants
+  `run_grype`/`run_syft`/`run_trufflehog`.
+- `lint_dockerfile(contents)` : **réplique** la portion subprocess de `HadolintAnalyzer.analyze`
+  (`regis/analyzers/hadolint.py:52`) — `ensure_tool("hadolint")` + `subprocess.run([…, "-f",
+  "json", "-"], input=contents)` + parse → **liste brute d'issues hadolint**. Ne fait QUE le
+  subprocess. La reconstruction du pseudo-Dockerfile depuis `config.history` et le mapping
+  issues/`issues_by_level`/report **restent dans l'analyzer** (domaine, P3).
+- `audit_image(image)` : **réplique** la portion subprocess de `DockleAnalyzer.analyze`
+  (`regis/analyzers/dockle.py:52`) — `ensure_tool("dockle")` + `subprocess.run([…, "-f", "json",
+  target])` (+ env `DOCKER_USER`/`DOCKER_PASSWORD`) + parse → **dict dockle brut**
+  (`{summary, details}`). Le mapping vers le report reste dans l'analyzer (domaine, P3).
+
+> **Réplication, pas réécriture.** Il n'existe pas de wrapper `utils/{hadolint,dockle}.py` : le
+> subprocess est inline dans les analyzers. P2b **recopie** cette portion subprocess dans
+> l'adaptateur (testée isolément) ; les analyzers `hadolint`/`dockle` **gardent leur code inline
+> inchangé** jusqu'à P3. L'adaptateur est construit mais **pas encore consommé** — exactement comme
+> `RegistryImageInspector` en P2a. La déduplication (l'analyzer délègue via `ctx.tools`) se fait en
+> P3, quand le contrat `analyze(ctx)` injecte enfin un `ToolRunner`.
+- `run(tool, args, timeout)` : échappatoire générique via `run_cmd`, renvoie un `ToolResult`.
+- **Erreurs** : lève `ToolError` (core). Traduit les échecs subprocess (non-zéro, timeout, JSON
+  invalide, outil manquant).
+
+## 5. P2b-2 — `RegctlImageInspector`
+
+Seconde implémentation du port `ImageInspector` **inchangé**, backend regctl CLI
+(`regis/adapters/driven/registry/regctl_image_inspector.py`) :
+
+| Port (inchangé) | Appel regctl |
+| --- | --- |
+| `list_tags()` | `tag ls <reg>/<repo>` → `splitlines` |
+| `get_manifest(reference)` | `manifest get <ref> --format raw-body` → JSON |
+| `get_blob(digest)` | `blob get <reg>/<repo> <digest>` → JSON |
+| `get_digest(reference)` | `manifest head <ref>` → `strip` |
+
+- Construit `<ref>` via `image_ref(registry, repository, reference)` (`regis/utils/regctl.py`).
+- Réutilise `run_regctl(client, …)` pour les credentials + le docker-config temporaire (déjà
+  testés). Construit avec un `RegistryClient` (coordonnées + creds), comme `RegistryImageInspector`.
+- **Erreurs** : traduit `AnalyzerError` / `subprocess.CalledProcessError` legacy en `RegistryError`
+  core, via un contextmanager (même pattern que P2a).
+- Non consommé par les analyzers en P2b (comme `RegistryImageInspector` en P2a) ; le câblage par la
+  composition root et la bascule des analyzers regctl arrivent en P3.
+
+## 6. Gestion d'erreurs
+
+Les **nouveaux** adaptateurs lèvent les erreurs *core* (`ToolError` pour le runner, `RegistryError`
+pour l'inspector regctl). Les wrappers legacy `regis/utils/{grype,syft,trufflehog,regctl}.py`
+**conservent `AnalyzerError`** tant que les analyzers les appellent directement — leur migration
+vers `ToolError` est reportée en **P3** (sinon ripple sur le `except AnalyzerError: raise` de
+`hadolint`). `core/*` n'importe toujours pas `click` ; le contrat import-linter reste vert.
+
+## 7. Stratégie de test
+
+- `FakeToolRunner` (`tests/fakes.py:50`) : retirer `inspect_platforms` ; corriger les types de
+  `scan_secrets`/`lint_dockerfile` (→ `list`). Vérifier qu'aucun test P1 n'asserte
+  `inspect_platforms`.
+- `SubprocessToolRunner` : tester chaque capacité avec un subprocess mocké (stdout canné) +
+  les chemins d'erreur/traduction (`ToolError`). Pour `lint_dockerfile`/`audit_image`, vérifier que
+  seule la sortie brute est renvoyée (pas de mapping).
+- `RegctlImageInspector` : `run_regctl` mocké, une assertion par méthode (args regctl attendus +
+  parse) + traduction `RegistryError`.
+- Suite verte ; double gate de couverture ≥ 90 % (global + par fichier).
+
+## 8. Hors périmètre (différés)
+
+- Bascule du contrat analyzer `analyze(ctx)` + traversée d'index domaine + migration des wrappers
+  legacy vers `ToolError` → **P3**.
+- Déménagement physique des modules → **P4**.
+- `FileReportSink` → phase dédiée (ex-P2c spec maîtresse).
+- Câblage composition root + factory inspector par thread → **P3**.
+
+## 9. Definition of Done (P2b)
+
+- [ ] `ToolRunner` révisé (types honnêtes, `inspect_platforms` retirée), `FakeToolRunner` aligné.
+- [ ] `SubprocessToolRunner` livré + testé (6 capacités, erreurs `ToolError`).
+- [ ] `RegctlImageInspector` livré + testé (4 méthodes, erreurs `RegistryError`).
+- [ ] Analyzers `hadolint`/`dockle` **strictement inchangés** (code inline conservé ; l'adaptateur
+      réplique mais ne rewire pas — dédup en P3). Suite d'analyzers existante toujours verte.
+- [ ] `lint-imports` vert ; suite verte ; couverture ≥ 90 % (double gate).
+- [ ] 2 PR mergées (P2b-1, P2b-2), branchées juste avant commit sur `main` à jour.
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-06-14-hexagonal-p2b-subprocess-adapters-design.md
+++ b/docs/superpowers/specs/2026-06-14-hexagonal-p2b-subprocess-adapters-design.md
@@ -57,15 +57,15 @@ Deux PR courtes (préférence repo + machinerie autorebase), une par adaptateur 
 Touche du code P1 mergé, mais purement interne et pré-release. Aucun consommateur n'existe encore
 (les analyzers n'ont pas basculé sur `ctx` — P3).
 
-| Méthode | Type de retour | Wrapper / source |
-| --- | --- | --- |
-| `scan_vulnerabilities(image)` | `dict[str, Any]` | `run_grype` |
-| `generate_sbom(image)` | `dict[str, Any]` | `run_syft` |
-| `scan_secrets(image)` | **`list[dict[str, Any]]`** | `run_trufflehog` (pas d'arg `platform`) |
-| `lint_dockerfile(dockerfile: str)` | **`list[dict[str, Any]]`** | inline hadolint extrait |
-| `audit_image(image)` | `dict[str, Any]` | inline dockle extrait |
-| `run(tool, args, *, timeout=None)` | `ToolResult` | échappatoire plugins |
-| ~~`inspect_platforms`~~ | — | **supprimée** (partait sur regctl) |
+| Méthode                            | Type de retour             | Wrapper / source                        |
+| ---------------------------------- | -------------------------- | --------------------------------------- |
+| `scan_vulnerabilities(image)`      | `dict[str, Any]`           | `run_grype`                             |
+| `generate_sbom(image)`             | `dict[str, Any]`           | `run_syft`                              |
+| `scan_secrets(image)`              | **`list[dict[str, Any]]`** | `run_trufflehog` (pas d'arg `platform`) |
+| `lint_dockerfile(dockerfile: str)` | **`list[dict[str, Any]]`** | inline hadolint extrait                 |
+| `audit_image(image)`               | `dict[str, Any]`           | inline dockle extrait                   |
+| `run(tool, args, *, timeout=None)` | `ToolResult`               | échappatoire plugins                    |
+| ~~`inspect_platforms`~~            | —                          | **supprimée** (partait sur regctl)      |
 
 ### 4.2 `SubprocessToolRunner` (`regis/adapters/driven/tools/subprocess_tool_runner.py`)
 
@@ -77,12 +77,12 @@ Touche du code P1 mergé, mais purement interne et pré-release. Aucun consommat
   `run_grype`/`run_syft`/`run_trufflehog`.
 - `lint_dockerfile(contents)` : **réplique** la portion subprocess de `HadolintAnalyzer.analyze`
   (`regis/analyzers/hadolint.py:52`) — `ensure_tool("hadolint")` + `subprocess.run([…, "-f",
-  "json", "-"], input=contents)` + parse → **liste brute d'issues hadolint**. Ne fait QUE le
+"json", "-"], input=contents)` + parse → **liste brute d'issues hadolint**. Ne fait QUE le
   subprocess. La reconstruction du pseudo-Dockerfile depuis `config.history` et le mapping
   issues/`issues_by_level`/report **restent dans l'analyzer** (domaine, P3).
 - `audit_image(image)` : **réplique** la portion subprocess de `DockleAnalyzer.analyze`
   (`regis/analyzers/dockle.py:52`) — `ensure_tool("dockle")` + `subprocess.run([…, "-f", "json",
-  target])` (+ env `DOCKER_USER`/`DOCKER_PASSWORD`) + parse → **dict dockle brut**
+target])` (+ env `DOCKER_USER`/`DOCKER_PASSWORD`) + parse → **dict dockle brut**
   (`{summary, details}`). Le mapping vers le report reste dans l'analyzer (domaine, P3).
 
 > **Réplication, pas réécriture.** Il n'existe pas de wrapper `utils/{hadolint,dockle}.py` : le
@@ -91,6 +91,7 @@ Touche du code P1 mergé, mais purement interne et pré-release. Aucun consommat
 > inchangé** jusqu'à P3. L'adaptateur est construit mais **pas encore consommé** — exactement comme
 > `RegistryImageInspector` en P2a. La déduplication (l'analyzer délègue via `ctx.tools`) se fait en
 > P3, quand le contrat `analyze(ctx)` injecte enfin un `ToolRunner`.
+
 - `run(tool, args, timeout)` : échappatoire générique via `run_cmd`, renvoie un `ToolResult`.
 - **Erreurs** : lève `ToolError` (core). Traduit les échecs subprocess (non-zéro, timeout, JSON
   invalide, outil manquant).
@@ -100,12 +101,12 @@ Touche du code P1 mergé, mais purement interne et pré-release. Aucun consommat
 Seconde implémentation du port `ImageInspector` **inchangé**, backend regctl CLI
 (`regis/adapters/driven/registry/regctl_image_inspector.py`) :
 
-| Port (inchangé) | Appel regctl |
-| --- | --- |
-| `list_tags()` | `tag ls <reg>/<repo>` → `splitlines` |
+| Port (inchangé)           | Appel regctl                                  |
+| ------------------------- | --------------------------------------------- |
+| `list_tags()`             | `tag ls <reg>/<repo>` → `splitlines`          |
 | `get_manifest(reference)` | `manifest get <ref> --format raw-body` → JSON |
-| `get_blob(digest)` | `blob get <reg>/<repo> <digest>` → JSON |
-| `get_digest(reference)` | `manifest head <ref>` → `strip` |
+| `get_blob(digest)`        | `blob get <reg>/<repo> <digest>` → JSON       |
+| `get_digest(reference)`   | `manifest head <ref>` → `strip`               |
 
 - Construit `<ref>` via `image_ref(registry, repository, reference)` (`regis/utils/regctl.py`).
 - Réutilise `run_regctl(client, …)` pour les credentials + le docker-config temporaire (déjà
@@ -117,7 +118,7 @@ Seconde implémentation du port `ImageInspector` **inchangé**, backend regctl C
 
 ## 6. Gestion d'erreurs
 
-Les **nouveaux** adaptateurs lèvent les erreurs *core* (`ToolError` pour le runner, `RegistryError`
+Les **nouveaux** adaptateurs lèvent les erreurs _core_ (`ToolError` pour le runner, `RegistryError`
 pour l'inspector regctl). Les wrappers legacy `regis/utils/{grype,syft,trufflehog,regctl}.py`
 **conservent `AnalyzerError`** tant que les analyzers les appellent directement — leur migration
 vers `ToolError` est reportée en **P3** (sinon ripple sur le `except AnalyzerError: raise` de
@@ -152,5 +153,5 @@ vers `ToolError` est reportée en **P3** (sinon ripple sur le `except AnalyzerEr
       réplique mais ne rewire pas — dédup en P3). Suite d'analyzers existante toujours verte.
 - [ ] `lint-imports` vert ; suite verte ; couverture ≥ 90 % (double gate).
 - [ ] 2 PR mergées (P2b-1, P2b-2), branchées juste avant commit sur `main` à jour.
-</content>
-</invoke>
+      </content>
+      </invoke>

--- a/regis/adapters/driven/tools/__init__.py
+++ b/regis/adapters/driven/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Driven adapters that run external tools as subprocesses."""

--- a/regis/adapters/driven/tools/subprocess_tool_runner.py
+++ b/regis/adapters/driven/tools/subprocess_tool_runner.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import subprocess  # nosec B404
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import Any
+
+import click
 
 from regis.core.domain.errors import AnalyzerError, ToolError
 from regis.core.model.image_reference import ImageReference
 from regis.core.ports.tool_runner import ToolResult, ToolRunner
 from regis.utils.grype import run_grype
+from regis.utils.process import ensure_tool
 from regis.utils.syft import run_syft
 from regis.utils.trufflehog import run_trufflehog
 
@@ -58,7 +63,25 @@ class SubprocessToolRunner(ToolRunner):
             return run_trufflehog(self._full_ref(image), self._username, self._password)
 
     def lint_dockerfile(self, dockerfile: str) -> list[dict[str, Any]]:
-        raise NotImplementedError  # Task 3
+        try:
+            binary = ensure_tool("hadolint")
+        except click.ClickException as exc:
+            raise ToolError(str(exc)) from exc
+        proc = subprocess.run(  # nosec B603
+            [binary, "-f", "json", "-"],
+            input=dockerfile,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        stdout = proc.stdout.strip()
+        if not stdout:
+            return []
+        try:
+            issues: list[dict[str, Any]] = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise ToolError(f"hadolint produced invalid JSON: {exc}") from exc
+        return issues
 
     def audit_image(self, image: ImageReference) -> dict[str, Any]:
         raise NotImplementedError  # Task 4

--- a/regis/adapters/driven/tools/subprocess_tool_runner.py
+++ b/regis/adapters/driven/tools/subprocess_tool_runner.py
@@ -1,0 +1,69 @@
+"""SubprocessToolRunner — ToolRunner backed by external scanner subprocesses."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+from regis.core.domain.errors import AnalyzerError, ToolError
+from regis.core.model.image_reference import ImageReference
+from regis.core.ports.tool_runner import ToolResult, ToolRunner
+from regis.utils.grype import run_grype
+from regis.utils.syft import run_syft
+from regis.utils.trufflehog import run_trufflehog
+
+
+@contextmanager
+def _as_tool_error() -> Iterator[None]:
+    """Translate a legacy AnalyzerError raised by a wrapper into the core ToolError."""
+    try:
+        yield
+    except AnalyzerError as exc:
+        raise ToolError(str(exc)) from exc
+
+
+class SubprocessToolRunner(ToolRunner):
+    """Runs external scanners as subprocesses.
+
+    Registry credentials live here (injected by the composition root in P3), so
+    the core never sees a password. The ``ImageReference`` carries no creds; this
+    adapter builds the full ``registry/repo:tag`` string and injects auth per tool.
+    """
+
+    def __init__(
+        self, username: str | None = None, password: str | None = None
+    ) -> None:
+        self._username = username
+        self._password = password
+
+    @staticmethod
+    def _full_ref(image: ImageReference) -> str:
+        return f"{image.registry}/{image.repository}:{image.tag}"
+
+    def scan_vulnerabilities(self, image: ImageReference) -> dict[str, Any]:
+        with _as_tool_error():
+            return run_grype(
+                self._full_ref(image), self._username, self._password, image.platform
+            )
+
+    def generate_sbom(self, image: ImageReference) -> dict[str, Any]:
+        with _as_tool_error():
+            return run_syft(
+                self._full_ref(image), self._username, self._password, image.platform
+            )
+
+    def scan_secrets(self, image: ImageReference) -> list[dict[str, Any]]:
+        with _as_tool_error():
+            return run_trufflehog(self._full_ref(image), self._username, self._password)
+
+    def lint_dockerfile(self, dockerfile: str) -> list[dict[str, Any]]:
+        raise NotImplementedError  # Task 3
+
+    def audit_image(self, image: ImageReference) -> dict[str, Any]:
+        raise NotImplementedError  # Task 4
+
+    def run(
+        self, tool: str, args: Sequence[str], *, timeout: int | None = None
+    ) -> ToolResult:
+        raise NotImplementedError  # Task 5

--- a/regis/adapters/driven/tools/subprocess_tool_runner.py
+++ b/regis/adapters/driven/tools/subprocess_tool_runner.py
@@ -111,4 +111,20 @@ class SubprocessToolRunner(ToolRunner):
     def run(
         self, tool: str, args: Sequence[str], *, timeout: int | None = None
     ) -> ToolResult:
-        raise NotImplementedError  # Task 5
+        try:
+            binary = ensure_tool(tool)
+        except click.ClickException as exc:
+            raise ToolError(str(exc)) from exc
+        try:
+            proc = subprocess.run(  # nosec B603
+                [binary, *args],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ToolError(f"{tool} timed out after {timeout}s") from exc
+        return ToolResult(
+            stdout=proc.stdout, stderr=proc.stderr, exit_code=proc.returncode
+        )

--- a/regis/adapters/driven/tools/subprocess_tool_runner.py
+++ b/regis/adapters/driven/tools/subprocess_tool_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess  # nosec B404
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -84,7 +85,28 @@ class SubprocessToolRunner(ToolRunner):
         return issues
 
     def audit_image(self, image: ImageReference) -> dict[str, Any]:
-        raise NotImplementedError  # Task 4
+        try:
+            binary = ensure_tool("dockle")
+        except click.ClickException as exc:
+            raise ToolError(str(exc)) from exc
+        env = os.environ.copy()
+        if self._username and self._password:
+            env["DOCKER_USER"] = self._username
+            env["DOCKER_PASSWORD"] = self._password
+        proc = subprocess.run(  # nosec B603
+            [binary, "-f", "json", self._full_ref(image)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        if not proc.stdout.strip():
+            raise ToolError(f"dockle produced no output. stderr: {proc.stderr}")
+        try:
+            report: dict[str, Any] = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise ToolError(f"dockle produced invalid JSON: {exc}") from exc
+        return report
 
     def run(
         self, tool: str, args: Sequence[str], *, timeout: int | None = None

--- a/regis/core/ports/tool_runner.py
+++ b/regis/core/ports/tool_runner.py
@@ -22,8 +22,9 @@ class ToolResult:
 class ToolRunner(ABC):
     """Port for running external scanners.
 
-    Capability methods return parsed output (a dict); ``run`` is a generic
-    escape hatch for plugin-supplied tools.
+    Capability methods return parsed output; ``run`` is a generic escape hatch
+    for plugin-supplied tools. Registry inspection (regctl) is NOT here — it is a
+    second ImageInspector (see RegctlImageInspector, P2b-2).
     """
 
     @abstractmethod
@@ -35,20 +36,16 @@ class ToolRunner(ABC):
         """Generate an SBOM for *image* (e.g. syft)."""
 
     @abstractmethod
-    def scan_secrets(self, image: ImageReference) -> dict[str, Any]:
-        """Scan *image* for embedded secrets (e.g. trufflehog)."""
+    def scan_secrets(self, image: ImageReference) -> list[dict[str, Any]]:
+        """Scan *image* for embedded secrets (e.g. trufflehog); one dict per finding."""
 
     @abstractmethod
-    def lint_dockerfile(self, dockerfile_contents: str) -> dict[str, Any]:
-        """Lint the given Dockerfile *contents* string (e.g. hadolint)."""
+    def lint_dockerfile(self, dockerfile: str) -> list[dict[str, Any]]:
+        """Lint a Dockerfile *contents* string (e.g. hadolint); one dict per issue."""
 
     @abstractmethod
     def audit_image(self, image: ImageReference) -> dict[str, Any]:
         """Audit *image* for best practices (e.g. dockle)."""
-
-    @abstractmethod
-    def inspect_platforms(self, image: ImageReference) -> dict[str, Any]:
-        """Inspect *image* manifest/platform data (e.g. regctl)."""
 
     @abstractmethod
     def run(

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -38,12 +38,23 @@ def test_scan_vulnerabilities_delegates_to_grype(monkeypatch) -> None:
 
 
 def test_generate_sbom_delegates_to_syft(monkeypatch) -> None:
-    monkeypatch.setattr(
-        mod,
-        "run_syft",
-        lambda image, username, password, platform: {"bomFormat": "CycloneDX"},
-    )
-    assert SubprocessToolRunner().generate_sbom(IMAGE) == {"bomFormat": "CycloneDX"}
+    captured: dict[str, object] = {}
+
+    def fake_run_syft(image, username, password, platform):
+        captured.update(
+            image=image, username=username, password=password, platform=platform
+        )
+        return {"bomFormat": "CycloneDX"}
+
+    monkeypatch.setattr(mod, "run_syft", fake_run_syft)
+    runner = SubprocessToolRunner("alice", "s3cret")
+    assert runner.generate_sbom(IMAGE) == {"bomFormat": "CycloneDX"}
+    assert captured == {
+        "image": "docker.io/library/nginx:1.27",
+        "username": "alice",
+        "password": "s3cret",
+        "platform": "linux/amd64",
+    }
 
 
 def test_scan_secrets_delegates_to_trufflehog_without_platform(monkeypatch) -> None:

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -134,3 +134,76 @@ def test_lint_dockerfile_missing_tool_raises_tool_error(monkeypatch) -> None:
     monkeypatch.setattr(mod, "ensure_tool", boom)
     with pytest.raises(ToolError):
         SubprocessToolRunner().lint_dockerfile("FROM scratch")
+
+
+def test_audit_image_parses_report_and_injects_creds(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env")
+        return SimpleNamespace(
+            stdout='{"summary": {"fatal": 0}, "details": []}', stderr="", returncode=0
+        )
+
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    result = SubprocessToolRunner("alice", "s3cret").audit_image(IMAGE)
+    assert result == {"summary": {"fatal": 0}, "details": []}
+    assert captured["cmd"] == [
+        "/usr/bin/dockle",
+        "-f",
+        "json",
+        "docker.io/library/nginx:1.27",
+    ]
+    assert captured["env"]["DOCKER_USER"] == "alice"
+    assert captured["env"]["DOCKER_PASSWORD"] == "s3cret"
+
+
+def test_audit_image_no_creds_omits_docker_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return SimpleNamespace(stdout='{"summary": {}}', stderr="", returncode=0)
+
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/dockle")
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    SubprocessToolRunner().audit_image(IMAGE)
+    assert "DOCKER_USER" not in captured["env"]
+    assert "DOCKER_PASSWORD" not in captured["env"]
+
+
+def test_audit_image_no_output_raises_tool_error(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/dockle")
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            stdout="", stderr="connection refused", returncode=1
+        ),
+    )
+    with pytest.raises(ToolError) as exc_info:
+        SubprocessToolRunner().audit_image(IMAGE)
+    assert "connection refused" in str(exc_info.value)
+
+
+def test_audit_image_missing_tool_raises_tool_error(monkeypatch) -> None:
+    def boom(name):
+        raise click.ClickException("dockle not available")
+
+    monkeypatch.setattr(mod, "ensure_tool", boom)
+    with pytest.raises(ToolError) as exc_info:
+        SubprocessToolRunner().audit_image(IMAGE)
+    assert "dockle not available" in str(exc_info.value)
+
+
+def test_audit_image_invalid_json_raises_tool_error(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/dockle")
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="not json", stderr="", returncode=0),
+    )
+    with pytest.raises(ToolError):
+        SubprocessToolRunner().audit_image(IMAGE)

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -1,0 +1,75 @@
+"""SubprocessToolRunner delegates to scanner wrappers and raises ToolError."""
+
+import pytest
+
+from regis.adapters.driven.tools import subprocess_tool_runner as mod
+from regis.adapters.driven.tools.subprocess_tool_runner import SubprocessToolRunner
+from regis.core.domain.errors import AnalyzerError, ToolError
+from regis.core.model.image_reference import ImageReference
+from regis.core.ports.tool_runner import ToolRunner
+
+IMAGE = ImageReference(
+    registry="docker.io", repository="library/nginx", tag="1.27", platform="linux/amd64"
+)
+
+
+def test_is_a_tool_runner() -> None:
+    assert isinstance(SubprocessToolRunner(), ToolRunner)
+
+
+def test_scan_vulnerabilities_delegates_to_grype(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_grype(image, username, password, platform):
+        captured.update(
+            image=image, username=username, password=password, platform=platform
+        )
+        return {"matches": []}
+
+    monkeypatch.setattr(mod, "run_grype", fake_run_grype)
+    runner = SubprocessToolRunner("alice", "s3cret")
+    assert runner.scan_vulnerabilities(IMAGE) == {"matches": []}
+    assert captured == {
+        "image": "docker.io/library/nginx:1.27",
+        "username": "alice",
+        "password": "s3cret",
+        "platform": "linux/amd64",
+    }
+
+
+def test_generate_sbom_delegates_to_syft(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "run_syft",
+        lambda image, username, password, platform: {"bomFormat": "CycloneDX"},
+    )
+    assert SubprocessToolRunner().generate_sbom(IMAGE) == {"bomFormat": "CycloneDX"}
+
+
+def test_scan_secrets_delegates_to_trufflehog_without_platform(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_trufflehog(image, username, password):
+        captured.update(image=image, username=username, password=password)
+        return [{"DetectorName": "AWS"}]
+
+    monkeypatch.setattr(mod, "run_trufflehog", fake_run_trufflehog)
+    assert SubprocessToolRunner("u", "p").scan_secrets(IMAGE) == [
+        {"DetectorName": "AWS"}
+    ]
+    assert captured == {
+        "image": "docker.io/library/nginx:1.27",
+        "username": "u",
+        "password": "p",
+    }
+
+
+def test_scanner_translates_analyzer_error_to_tool_error(monkeypatch) -> None:
+    def boom(*args, **kwargs):
+        raise AnalyzerError("grype failed: boom")
+
+    monkeypatch.setattr(mod, "run_grype", boom)
+    with pytest.raises(ToolError) as exc_info:
+        SubprocessToolRunner().scan_vulnerabilities(IMAGE)
+    assert "grype failed: boom" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, AnalyzerError)

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -9,7 +9,7 @@ from regis.adapters.driven.tools import subprocess_tool_runner as mod
 from regis.adapters.driven.tools.subprocess_tool_runner import SubprocessToolRunner
 from regis.core.domain.errors import AnalyzerError, ToolError
 from regis.core.model.image_reference import ImageReference
-from regis.core.ports.tool_runner import ToolRunner
+from regis.core.ports.tool_runner import ToolResult, ToolRunner
 
 IMAGE = ImageReference(
     registry="docker.io", repository="library/nginx", tag="1.27", platform="linux/amd64"
@@ -207,3 +207,41 @@ def test_audit_image_invalid_json_raises_tool_error(monkeypatch) -> None:
     )
     with pytest.raises(ToolError):
         SubprocessToolRunner().audit_image(IMAGE)
+
+
+def test_run_returns_tool_result_with_exit_code(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return SimpleNamespace(stdout="out", stderr="err", returncode=3)
+
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    result = SubprocessToolRunner().run("cosign", ["version"], timeout=5)
+    assert result == ToolResult(stdout="out", stderr="err", exit_code=3)
+    assert captured["cmd"] == ["/usr/bin/cosign", "version"]
+    assert captured["timeout"] == 5
+
+
+def test_run_missing_tool_raises_tool_error(monkeypatch) -> None:
+    def boom(name):
+        raise click.ClickException("cosign not available")
+
+    monkeypatch.setattr(mod, "ensure_tool", boom)
+    with pytest.raises(ToolError) as exc_info:
+        SubprocessToolRunner().run("cosign", ["version"])
+    assert "cosign not available" in str(exc_info.value)
+
+
+def test_run_timeout_raises_tool_error(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/cosign")
+
+    def boom(*a, **k):
+        raise mod.subprocess.TimeoutExpired(cmd="cosign", timeout=5)
+
+    monkeypatch.setattr(mod.subprocess, "run", boom)
+    with pytest.raises(ToolError) as exc_info:
+        SubprocessToolRunner().run("cosign", ["version"], timeout=5)
+    assert "cosign timed out" in str(exc_info.value)

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -1,5 +1,8 @@
 """SubprocessToolRunner delegates to scanner wrappers and raises ToolError."""
 
+from types import SimpleNamespace
+
+import click
 import pytest
 
 from regis.adapters.driven.tools import subprocess_tool_runner as mod
@@ -84,3 +87,50 @@ def test_scanner_translates_analyzer_error_to_tool_error(monkeypatch) -> None:
         SubprocessToolRunner().scan_vulnerabilities(IMAGE)
     assert "grype failed: boom" in str(exc_info.value)
     assert isinstance(exc_info.value.__cause__, AnalyzerError)
+
+
+def test_lint_dockerfile_parses_issue_list(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        return SimpleNamespace(stdout='[{"code": "DL3008"}]', stderr="", returncode=1)
+
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert SubprocessToolRunner().lint_dockerfile("FROM scratch") == [
+        {"code": "DL3008"}
+    ]
+    assert captured["cmd"] == ["/usr/bin/hadolint", "-f", "json", "-"]
+    assert captured["input"] == "FROM scratch"
+
+
+def test_lint_dockerfile_empty_output_is_empty_list(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/hadolint")
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="  \n", stderr="", returncode=0),
+    )
+    assert SubprocessToolRunner().lint_dockerfile("FROM scratch") == []
+
+
+def test_lint_dockerfile_invalid_json_raises_tool_error(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "ensure_tool", lambda name: "/usr/bin/hadolint")
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="not json", stderr="", returncode=0),
+    )
+    with pytest.raises(ToolError):
+        SubprocessToolRunner().lint_dockerfile("FROM scratch")
+
+
+def test_lint_dockerfile_missing_tool_raises_tool_error(monkeypatch) -> None:
+    def boom(name):
+        raise click.ClickException("hadolint not available")
+
+    monkeypatch.setattr(mod, "ensure_tool", boom)
+    with pytest.raises(ToolError):
+        SubprocessToolRunner().lint_dockerfile("FROM scratch")

--- a/tests/core/test_fakes.py
+++ b/tests/core/test_fakes.py
@@ -55,3 +55,20 @@ def test_fake_image_inspector_copies_and_honors_sentinel() -> None:
     # digest sentinel honored (None is valid for str | None); default is "sha256:fake".
     assert inspector.get_digest("1.27") is None
     assert FakeImageInspector().get_digest("1.27") == "sha256:fake"
+
+
+def test_fake_tool_runner_uses_honest_collection_types() -> None:
+    runner = FakeToolRunner(
+        scan_secrets=[{"finding": 1}],
+        lint_dockerfile=[{"code": "DL3008"}],
+    )
+    assert runner.scan_secrets(IMG) == [{"finding": 1}]
+    assert runner.lint_dockerfile("FROM scratch") == [{"code": "DL3008"}]
+    # Defaults are empty collections of the right type.
+    assert FakeToolRunner().scan_secrets(IMG) == []
+    assert FakeToolRunner().lint_dockerfile("FROM scratch") == []
+
+
+def test_tool_runner_has_no_inspect_platforms() -> None:
+    # regctl moved to a 2nd ImageInspector (P2b-2); ToolRunner is scanners-only.
+    assert not hasattr(ToolRunner, "inspect_platforms")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -51,7 +51,7 @@ class FakeImageInspector(ImageInspector):
 class FakeToolRunner(ToolRunner):
     """Returns canned tool output per capability; no subprocess."""
 
-    def __init__(self, **canned: dict[str, Any]) -> None:
+    def __init__(self, **canned: Any) -> None:
         self._canned = canned
 
     def scan_vulnerabilities(self, image: ImageReference) -> dict[str, Any]:
@@ -60,17 +60,14 @@ class FakeToolRunner(ToolRunner):
     def generate_sbom(self, image: ImageReference) -> dict[str, Any]:
         return self._canned.get("generate_sbom", {})
 
-    def scan_secrets(self, image: ImageReference) -> dict[str, Any]:
-        return self._canned.get("scan_secrets", {})
+    def scan_secrets(self, image: ImageReference) -> list[dict[str, Any]]:
+        return self._canned.get("scan_secrets", [])
 
-    def lint_dockerfile(self, dockerfile_contents: str) -> dict[str, Any]:
-        return self._canned.get("lint_dockerfile", {})
+    def lint_dockerfile(self, dockerfile: str) -> list[dict[str, Any]]:
+        return self._canned.get("lint_dockerfile", [])
 
     def audit_image(self, image: ImageReference) -> dict[str, Any]:
         return self._canned.get("audit_image", {})
-
-    def inspect_platforms(self, image: ImageReference) -> dict[str, Any]:
-        return self._canned.get("inspect_platforms", {})
 
     def run(
         self, tool: str, args: Sequence[str], *, timeout: int | None = None


### PR DESCRIPTION
## Summary

Phase **P2b-1** of the hexagonal migration (spec: `docs/superpowers/specs/2026-06-14-hexagonal-p2b-subprocess-adapters-design.md`).

- **`ToolRunner` port** (`regis/core/ports/tool_runner.py`) tightened to honest return types — `scan_secrets`/`lint_dockerfile` → `list[dict[str, Any]]` — and **`inspect_platforms` removed**: regctl is not a scanner; it is promoted to a 2nd `ImageInspector` (`RegctlImageInspector`) in the follow-up **P2b-2**. This supersedes §5.1 of the master hexagonal spec on regctl placement.
- **`SubprocessToolRunner`** driven adapter (`regis/adapters/driven/tools/`): the three delegated scanners (grype/syft/trufflehog via the existing `regis/utils/*` wrappers) + `lint_dockerfile`/`audit_image` (replicated hadolint/dockle subprocess) + a generic `run` escape hatch that preserves the exit code. Registry credentials live in the adapter, so the core never sees a password; every failure surfaces as core `ToolError`.
- The adapter is **not yet consumed** by any analyzer — wiring (and dedup of the replicated hadolint/dockle subprocess) is deferred to **P3**, mirroring P2a's `RegistryImageInspector`. Analyzers are strictly unchanged.

## Test Plan

- [x] `uv run pytest` — **798 passed, 1 skipped, 95.77%** total (global + per-file ≥90% gates).
- [x] New adapter file `subprocess_tool_runner.py` — **100% coverage**.
- [x] `uv run lint-imports` — **Hexagonal layering KEPT** (1 kept, 0 broken).
- [x] `git diff` confirms `regis/analyzers/` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)