### PR TITLE
test(cli): assert full dummy result dict in metadata tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,8 +92,11 @@ class TestCliBasics:
             assert report["metadata"]["build"] == "123"
             assert report["metadata"]["env"] == "prod"
             assert report["metadata"]["flag_only"] == "true"
-            assert "error" not in report["results"]["dummy"]
-            assert report["results"]["dummy"]["analyzer"] == "dummy"
+            assert report["results"]["dummy"] == {
+                "analyzer": "dummy",
+                "repository": "library/nginx",
+                "tag": "latest",
+            }
 
     @patch("regis.commands.analyze.RegistryClient")
     @patch("regis.commands.analyze._discover_analyzers")
@@ -138,8 +141,11 @@ class TestCliBasics:
             assert report["metadata"]["project"] == "regis"
             # request.metadata was removed (canonical location is top-level metadata)
             assert "metadata" not in report["request"]
-            assert "error" not in report["results"]["dummy"]
-            assert report["results"]["dummy"]["analyzer"] == "dummy"
+            assert report["results"]["dummy"] == {
+                "analyzer": "dummy",
+                "repository": "library/nginx",
+                "tag": "latest",
+            }
 
 
 class TestAnalyzeParallelism:


### PR DESCRIPTION
## Summary

Strengthens the assertions in `test_analyze_with_metadata` and `test_analyze_with_nested_metadata` (`tests/test_cli.py`) to verify the dummy analyzer's full success result, not just the absence of an error.

Background: these two tests inject a `DummyAnalyzer` and run it through the real `AnalyzeImage` loop. Before P3a (#766) the dummies had a 3-arg `analyze(self, client, repo, tag)` signature, so the bridge's `platform=` keyword call raised `TypeError`, the use-case captured it into an `{"error": {"type": "unexpected"}}` stub, and the tests still passed because they only asserted `exit_code == 0` + the metadata block. P3a's M1 fix (commit `af1f377`) already added `platform=None` and a `"error" not in results["dummy"]` / `results["dummy"]["analyzer"] == "dummy"` pair.

This change replaces that weaker pair with a single full-dict equality:

```python
assert report["results"]["dummy"] == {
    "analyzer": "dummy",
    "repository": "library/nginx",
    "tag": "latest",
}
```

which additionally verifies the dummy received the correct `repository`/`tag` through the bridge's legacy branch — so the test now genuinely exercises a successful analyzer run alongside the metadata assertions.

## Test Plan
- [x] `uv run pytest tests/test_cli.py -k metadata -v --no-cov` → 2 passed (now meaningfully)
- [x] `uv run pytest` → 847 passed, 1 skipped, 95.93% (double coverage gate green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)