### PR TITLE
refactor(analyzers): remove dead SizeAnalyzer._empty (cleanup)

### DIFF
--- a/regis/analyzers/size.py
+++ b/regis/analyzers/size.py
@@ -163,17 +163,3 @@ class SizeAnalyzer(BaseAnalyzer):
             "layers": [],
             "platforms": platforms,
         }
-
-    def _empty(self, repository: str, tag: str) -> dict[str, Any]:
-        return {
-            "analyzer": self.name,
-            "repository": repository,
-            "tag": tag,
-            "multi_arch": False,
-            "total_compressed_bytes": 0,
-            "total_compressed_human": "0.0 B",
-            "layer_count": 0,
-            "config_size_bytes": 0,
-            "layers": [],
-            "platforms": None,
-        }

--- a/tests/test_analyzer_size.py
+++ b/tests/test_analyzer_size.py
@@ -91,9 +91,6 @@ class TestSizeAnalyzer:
         with pytest.raises(AnalyzerError):
             analyzer.analyze(ctx)
 
-        # _empty helper
-        assert analyzer._empty("r", "t")["layer_count"] == 0
-
         # Platform override with no matching platform → empty platforms list
         index = {
             "mediaType": "index",


### PR DESCRIPTION
## Summary

Removes `SizeAnalyzer._empty(self, repository, tag)` from `regis/analyzers/size.py` — dead production code. `SizeAnalyzer.analyze()` raises `AnalyzerError` on a manifest-fetch failure (it never returns `_empty(...)`), so the method had no production call site; it was referenced only by a direct-call assertion in `tests/test_analyzer_size.py::test_size_errors_exhaustive`, which inflated apparent coverage of otherwise-unreachable code.

- Deleted the `_empty` method and the single pinning assertion (the rest of `test_size_errors_exhaustive` — the raising-inspector and platform-override-no-match paths — is untouched).
- `PopularityAnalyzer._empty` is a **different, live** method (called by `popularity.analyze()` on the Docker Hub API-failure path) — **not** touched.

Surfaced during the hexagonal P3c code review (#772); `_empty` predates that migration and is unrelated, hence this separate cleanup.

## Test Plan
- [x] `uv run pytest tests/test_analyzer_size.py tests/test_size.py -v --no-cov` → 14 passed
- [x] `uv run pytest` → 869 passed, 1 skipped, **96.27%**; `regis/analyzers/size.py` now **100%** (all reachable code), double gate green
- [x] `uv run lint-imports` → Hexagonal layering KEPT
- [x] `grep` confirms no `_empty` in `size.py`; `PopularityAnalyzer._empty` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)