### PR TITLE
refactor(core): hexagonal P3d-1 — remove the uses_context bridge (analyze(ctx) is the contract)

### DIFF
--- a/regis/adapters/driving/cli/composition.py
+++ b/regis/adapters/driving/cli/composition.py
@@ -2,7 +2,7 @@
 
 This is the one place that knows the concrete adapter types. It hands the
 use-case **callables** (not adapter types) so ``core/application`` stays free of
-adapter imports. The legacy-client factory is temporary (removed in P3d).
+adapter imports.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ def build_analyze_image(username: str | None, password: str | None) -> AnalyzeIm
 
     - ``tools``: a shared, stateless SubprocessToolRunner (creds live here).
     - ``inspector_factory``: a fresh regctl ImageInspector per image (creds captured).
-    - ``legacy_client_factory``: a fresh RegistryClient per image (P3 bridge only).
     """
 
     def _client(image: ImageReference) -> RegistryClient:
@@ -37,5 +36,4 @@ def build_analyze_image(username: str | None, password: str | None) -> AnalyzeIm
     return AnalyzeImage(
         tools=SubprocessToolRunner(username, password),
         inspector_factory=_inspector,
-        legacy_client_factory=_client,
     )

--- a/regis/analyzers/base.py
+++ b/regis/analyzers/base.py
@@ -11,8 +11,8 @@ from typing import Any
 
 import jsonschema
 
+from regis.core.domain.context import AnalysisContext
 from regis.core.domain.errors import AnalyzerError
-from regis.registry.client import RegistryClient
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +45,6 @@ class BaseAnalyzer(ABC):
 
     #: Filename of the JSON Schema inside ``regis/reference/schemas/``.
     schema_file: str = ""
-
-    #: Bridge marker (P3): True once the analyzer consumes ``analyze(ctx)``.
-    #: The AnalyzeImage use-case dispatches on this during the migration; the
-    #: marker and the legacy branch are removed in P3d.
-    uses_context: bool = False
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -99,23 +94,8 @@ class BaseAnalyzer(ABC):
         return cls.default_criteria()
 
     @abstractmethod
-    def analyze(
-        self,
-        client: RegistryClient,
-        repository: str,
-        tag: str,
-        platform: str | None = None,
-    ) -> dict[str, Any]:
-        """Run the analysis and return a report dict.
-
-        Args:
-            client: An authenticated :class:`RegistryClient`.
-            repository: Full repository path (e.g. ``library/nginx``).
-            tag: The image tag to analyze.
-
-        Returns:
-            A dict conforming to the analyzer's JSON Schema.
-        """
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
+        """Run the analysis and return a report dict conforming to the JSON Schema."""
 
     # ------------------------------------------------------------------
     # Validation

--- a/regis/analyzers/cve.py
+++ b/regis/analyzers/cve.py
@@ -28,7 +28,6 @@ class CveAnalyzer(BaseAnalyzer):
 
     name = "cve"
     schema_file = "analyzer/cve.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -92,7 +91,7 @@ class CveAnalyzer(BaseAnalyzer):
                 source["checksum"] = unquote(checksum)
         return source
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Run grype analysis and return a report dict."""
         data = ctx.tools.scan_vulnerabilities(ctx.image)
         repository = ctx.image.repository

--- a/regis/analyzers/dockle.py
+++ b/regis/analyzers/dockle.py
@@ -13,7 +13,6 @@ class DockleAnalyzer(BaseAnalyzer):
 
     name = "dockle"
     schema_file = "analyzer/dockle.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -42,7 +41,7 @@ class DockleAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Return a report with dockle violations."""
         output = ctx.tools.audit_image(ctx.image)
         repository = ctx.image.repository

--- a/regis/analyzers/endoflife.py
+++ b/regis/analyzers/endoflife.py
@@ -131,9 +131,8 @@ class EndOfLifeAnalyzer(BaseAnalyzer):
 
     name = "endoflife"
     schema_file = "analyzer/endoflife.schema.json"
-    uses_context = True
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Fetch lifecycle data and match against the image tag."""
         repository = ctx.image.repository
         tag = ctx.image.tag

--- a/regis/analyzers/freshness.py
+++ b/regis/analyzers/freshness.py
@@ -29,7 +29,6 @@ class FreshnessAnalyzer(BaseAnalyzer):
 
     name = "freshness"
     schema_file = "analyzer/freshness.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -53,7 +52,7 @@ class FreshnessAnalyzer(BaseAnalyzer):
             }
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         repository = ctx.image.repository
         tag = ctx.image.tag
 

--- a/regis/analyzers/hadolint.py
+++ b/regis/analyzers/hadolint.py
@@ -17,7 +17,6 @@ class HadolintAnalyzer(BaseAnalyzer):
 
     name = "hadolint"
     schema_file = "analyzer/hadolint.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -46,7 +45,7 @@ class HadolintAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Return a report with hadolint violations."""
         # 1. Resolve platform
         platform = ctx.image.platform or "linux/amd64"

--- a/regis/analyzers/metadata.py
+++ b/regis/analyzers/metadata.py
@@ -64,7 +64,6 @@ class MetadataAnalyzer(BaseAnalyzer):
 
     name = "metadata"
     schema_file = ""  # MetadataAnalyzer validates metadata inputs, not its own output.
-    uses_context = True
 
     def __init__(
         self,
@@ -86,7 +85,7 @@ class MetadataAnalyzer(BaseAnalyzer):
     # BaseAnalyzer interface
     # ------------------------------------------------------------------
 
-    def analyze(self, ctx: AnalysisContext | None = None) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext | None = None) -> dict[str, Any]:
         """Validate metadata and return a result dict.
 
         Args:

--- a/regis/analyzers/oci.py
+++ b/regis/analyzers/oci.py
@@ -45,7 +45,6 @@ class OciAnalyzer(BaseAnalyzer):
 
     name = "oci"
     schema_file = "analyzer/oci.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -246,7 +245,7 @@ class OciAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(  # type: ignore[override]
+    def analyze(
         self,
         ctx: AnalysisContext,
     ) -> dict[str, Any]:

--- a/regis/analyzers/popularity.py
+++ b/regis/analyzers/popularity.py
@@ -21,9 +21,8 @@ class PopularityAnalyzer(BaseAnalyzer):
 
     name = "popularity"
     schema_file = "analyzer/popularity.schema.json"
-    uses_context = True
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         repository = ctx.image.repository
         url = f"{_DOCKERHUB_API}/{repository}"
         logger.debug("Fetching Docker Hub stats: %s", url)

--- a/regis/analyzers/provenance.py
+++ b/regis/analyzers/provenance.py
@@ -23,9 +23,8 @@ class ProvenanceAnalyzer(BaseAnalyzer):
 
     name = "provenance"
     schema_file = "analyzer/provenance.schema.json"
-    uses_context = True
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         repository = ctx.image.repository
         tag = ctx.image.tag
         labels: dict[str, str] = {}

--- a/regis/analyzers/sbom.py
+++ b/regis/analyzers/sbom.py
@@ -86,7 +86,6 @@ class SbomAnalyzer(BaseAnalyzer):
 
     name = "sbom"
     schema_file = "analyzer/sbom.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -128,7 +127,7 @@ class SbomAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         data = ctx.tools.generate_sbom(ctx.image)
         repository = ctx.image.repository
         tag = ctx.image.tag

--- a/regis/analyzers/scorecarddev.py
+++ b/regis/analyzers/scorecarddev.py
@@ -134,7 +134,6 @@ class ScorecardDevAnalyzer(BaseAnalyzer):
 
     name = "scorecarddev"
     schema_file = "analyzer/scorecarddev.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -158,7 +157,7 @@ class ScorecardDevAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Resolve the source repo and fetch its OpenSSF Scorecard."""
         repository = ctx.image.repository
         source_url = _resolve_source_repo(ctx.inspector, repository, ctx.image.tag)

--- a/regis/analyzers/secrets.py
+++ b/regis/analyzers/secrets.py
@@ -43,7 +43,6 @@ class SecretsAnalyzer(BaseAnalyzer):
 
     name = "secrets"
     schema_file = "analyzer/secrets.schema.json"
-    uses_context = True
 
     @classmethod
     def default_criteria(cls) -> list[dict[str, Any]]:
@@ -82,7 +81,7 @@ class SecretsAnalyzer(BaseAnalyzer):
             },
         ]
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         """Run trufflehog analysis and return a report dict."""
         raw = ctx.tools.scan_secrets(ctx.image)
         repository = ctx.image.repository

--- a/regis/analyzers/size.py
+++ b/regis/analyzers/size.py
@@ -27,9 +27,8 @@ class SizeAnalyzer(BaseAnalyzer):
 
     name = "size"
     schema_file = "analyzer/size.schema.json"
-    uses_context = True
 
-    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:  # type: ignore[override]
+    def analyze(self, ctx: AnalysisContext) -> dict[str, Any]:
         try:
             manifest = ctx.inspector.get_manifest(ctx.image.tag)
         except Exception as e:

--- a/regis/analyzers/versioning.py
+++ b/regis/analyzers/versioning.py
@@ -180,9 +180,8 @@ class VersioningAnalyzer(BaseAnalyzer):
 
     name = "versioning"
     schema_file = "analyzer/versioning.schema.json"
-    uses_context = True
 
-    def analyze(  # type: ignore[override]
+    def analyze(
         self,
         ctx: AnalysisContext,
     ) -> dict[str, Any]:

--- a/regis/core/application/analyze_image.py
+++ b/regis/core/application/analyze_image.py
@@ -1,14 +1,12 @@
 """AnalyzeImage — application use-case running the analyzer loop.
 
 Owns *only* the analyzer loop: it builds a ThreadPoolExecutor, dispatches each
-analyzer (bridging the legacy ``analyze(client, repo, tag, platform)`` contract
-and the hexagonal ``analyze(ctx)`` contract via the ``uses_context`` marker),
-validates each report, captures errors into stubs, and reports progress.
+analyzer via the hexagonal ``analyze(ctx)`` contract, validates each report,
+captures errors into stubs, and reports progress.
 
-Layering: this module imports ``regis.core.*`` only. The legacy ``RegistryClient``
+Layering: this module imports ``regis.core.*`` only. The ``RegistryClient``
 and the regctl ``ImageInspector`` are supplied as **injected callables** by the
-CLI composition root, so the core references no adapter type. The legacy branch
-and ``legacy_client_factory`` are removed in P3d.
+CLI composition root, so the core references no adapter type.
 """
 
 from __future__ import annotations
@@ -30,8 +28,6 @@ logger = logging.getLogger(__name__)
 
 #: Factory producing a per-image ImageInspector (regctl-backed in production).
 InspectorFactory = Callable[[ImageReference], ImageInspector]
-#: Temporary (P3 bridge) factory producing the per-image legacy registry client.
-LegacyClientFactory = Callable[[ImageReference], Any]
 
 
 @dataclass(frozen=True)
@@ -73,26 +69,18 @@ class AnalyzeImage:
         *,
         tools: ToolRunner,
         inspector_factory: InspectorFactory,
-        legacy_client_factory: LegacyClientFactory,
     ) -> None:
         self._tools = tools
         self._inspector_factory = inspector_factory
-        self._legacy_client_factory = legacy_client_factory
 
     # ------------------------------------------------------------------
-    # Dispatch (bridge)
+    # Dispatch
     # ------------------------------------------------------------------
 
     def _dispatch(self, analyzer: Any, image: ImageReference) -> dict[str, Any]:
         """Run one analyzer instance and validate its report."""
-        if getattr(analyzer, "uses_context", False):
-            ctx = AnalysisContext(image, self._inspector_factory(image), self._tools)
-            report = analyzer.analyze(ctx)
-        else:
-            client = self._legacy_client_factory(image)
-            report = analyzer.analyze(
-                client, image.repository, image.tag, platform=image.platform
-            )
+        ctx = AnalysisContext(image, self._inspector_factory(image), self._tools)
+        report = analyzer.analyze(ctx)
         analyzer.validate(report)
         return report
 

--- a/tests/adapters/test_composition.py
+++ b/tests/adapters/test_composition.py
@@ -7,7 +7,6 @@ from regis.adapters.driven.tools.subprocess_tool_runner import SubprocessToolRun
 from regis.adapters.driving.cli.composition import build_analyze_image
 from regis.core.application.analyze_image import AnalyzeImage
 from regis.core.model.image_reference import ImageReference
-from regis.registry.client import RegistryClient
 
 IMAGE = ImageReference(registry="reg.example", repository="ns/app", tag="1.0")
 
@@ -22,19 +21,3 @@ def test_inspector_factory_builds_regctl_inspector_for_image():
     uc = build_analyze_image("user", "pass")
     inspector = uc._inspector_factory(IMAGE)
     assert isinstance(inspector, RegctlImageInspector)
-
-
-def test_legacy_client_factory_builds_registry_client_with_repo_and_creds():
-    uc = build_analyze_image("user", "pass")
-    client = uc._legacy_client_factory(IMAGE)
-    assert isinstance(client, RegistryClient)
-    assert client.registry == "reg.example"
-    assert client.repository == "ns/app"
-    assert client.username == "user"
-    assert client.password == "pass"
-
-
-def test_creds_may_be_none():
-    uc = build_analyze_image(None, None)
-    client = uc._legacy_client_factory(IMAGE)
-    assert client.username is None and client.password is None

--- a/tests/core/test_analyze_image.py
+++ b/tests/core/test_analyze_image.py
@@ -15,27 +15,19 @@ from tests.fakes import FakeImageInspector, FakeToolRunner
 
 IMAGE = ImageReference(registry="reg.example", repository="ns/app", tag="1.0")
 
-_SENTINEL_CLIENT = object()
-
 
 def _make_use_case(*, tools=None):
-    """Build an AnalyzeImage with in-memory factories.
-
-    inspector_factory returns a FakeImageInspector; legacy_client_factory
-    returns a sentinel so legacy analyzers can assert what they receive.
-    """
+    """Build an AnalyzeImage with in-memory factories."""
     return AnalyzeImage(
         tools=tools or FakeToolRunner(),
         inspector_factory=lambda image: FakeImageInspector(),
-        legacy_client_factory=lambda image: _SENTINEL_CLIENT,
     )
 
 
 class _CtxAnalyzer:
-    """uses_context=True analyzer; reads tools + image from the context."""
+    """Ctx-based analyzer; reads tools + image from the context."""
 
     name = "ctxone"
-    uses_context = True
 
     def analyze(self, ctx: AnalysisContext) -> dict:
         assert isinstance(ctx, AnalysisContext)
@@ -49,20 +41,13 @@ class _CtxAnalyzer:
         pass
 
 
-class _LegacyAnalyzer:
-    """uses_context defaults False; old positional signature."""
+class _SimpleAnalyzer:
+    """Minimal ctx-based analyzer returning a fixed report."""
 
-    name = "legacyone"
-    uses_context = False
+    name = "simpleone"
 
-    def analyze(self, client, repository, tag, platform=None) -> dict:
-        assert client is _SENTINEL_CLIENT
-        return {
-            "analyzer": self.name,
-            "repository": repository,
-            "tag": tag,
-            "platform": platform,
-        }
+    def analyze(self, ctx: AnalysisContext) -> dict:
+        return {"analyzer": self.name, "repository": ctx.image.repository}
 
     def validate(self, report: dict) -> None:
         pass
@@ -70,8 +55,6 @@ class _LegacyAnalyzer:
 
 def _raiser(name, exc):
     class _Boom:
-        uses_context = True
-
         def analyze(self, ctx):
             raise exc
 
@@ -92,28 +75,15 @@ def test_dispatch_context_branch_uses_tools_and_image():
     }
 
 
-def test_dispatch_legacy_branch_passes_client_repo_tag_platform():
-    uc = _make_use_case()
-    image = ImageReference("reg.example", "ns/app", "1.0", platform="linux/arm64")
-    reports = uc.run(image, {"legacyone": _LegacyAnalyzer})
-    assert reports["legacyone"] == {
-        "analyzer": "legacyone",
-        "repository": "ns/app",
-        "tag": "1.0",
-        "platform": "linux/arm64",
-    }
-
-
 def test_run_collects_multiple_and_keys_by_selected_name():
     uc = _make_use_case(tools=FakeToolRunner(scan_vulnerabilities={"count": 1}))
-    reports = uc.run(IMAGE, {"a": _CtxAnalyzer, "b": _LegacyAnalyzer})
+    reports = uc.run(IMAGE, {"a": _CtxAnalyzer, "b": _SimpleAnalyzer})
     assert set(reports) == {"a", "b"}
 
 
 def test_validate_is_called_and_failure_is_captured():
     class _BadValidate:
         name = "bad"
-        uses_context = True
 
         def analyze(self, ctx):
             return {"x": 1}
@@ -148,16 +118,16 @@ def test_errors_are_classified_into_stubs(exc, etype):
 
 def test_failing_analyzer_does_not_abort_others():
     uc = _make_use_case()
-    selected = {"ok": _LegacyAnalyzer, "boom": _raiser("boom", ToolError("x"))}
+    selected = {"ok": _SimpleAnalyzer, "boom": _raiser("boom", ToolError("x"))}
     reports = uc.run(IMAGE, selected)
-    assert reports["ok"]["analyzer"] == "legacyone"
+    assert reports["ok"]["analyzer"] == "simpleone"
     assert reports["boom"]["error"]["type"] == "tool"
 
 
 def test_on_progress_receives_one_outcome_per_analyzer():
     uc = _make_use_case()
     seen: list[AnalyzerOutcome] = []
-    selected = {"ok": _LegacyAnalyzer, "boom": _raiser("boom", ToolError("x"))}
+    selected = {"ok": _SimpleAnalyzer, "boom": _raiser("boom", ToolError("x"))}
     uc.run(IMAGE, selected, on_progress=seen.append)
     by_name = {o.name: o for o in seen}
     assert set(by_name) == {"ok", "boom"}
@@ -177,11 +147,11 @@ def test_run_one_returns_report_and_reraises():
 def test_run_one_logs_debug_timing(caplog):
     uc = _make_use_case()
     with caplog.at_level(logging.DEBUG, logger="regis.core.application.analyze_image"):
-        uc.run_one(IMAGE, _LegacyAnalyzer)
+        uc.run_one(IMAGE, _SimpleAnalyzer)
     recs = [
         r
         for r in caplog.records
-        if "legacyone" in r.getMessage() and "finished in" in r.getMessage()
+        if "simpleone" in r.getMessage() and "finished in" in r.getMessage()
     ]
     assert len(recs) == 1
     assert recs[0].levelno == logging.DEBUG
@@ -203,11 +173,11 @@ def test_run_logs_timing_even_on_failure(caplog):
 def test_run_caps_workers_at_selection_size_and_runs_serially():
     # max_workers larger than selection must still succeed (no crash, all run).
     uc = _make_use_case()
-    reports = uc.run(IMAGE, {"a": _LegacyAnalyzer}, max_workers=10)
+    reports = uc.run(IMAGE, {"a": _SimpleAnalyzer}, max_workers=10)
     assert set(reports) == {"a"}
-    reports = uc.run(IMAGE, {"a": _LegacyAnalyzer}, max_workers=1)
+    reports = uc.run(IMAGE, {"a": _SimpleAnalyzer}, max_workers=1)
     assert set(reports) == {"a"}
-    reports = uc.run(IMAGE, {"a": _LegacyAnalyzer}, max_workers=0)
+    reports = uc.run(IMAGE, {"a": _SimpleAnalyzer}, max_workers=0)
     assert set(reports) == {"a"}
 
 

--- a/tests/test_analyzer_base.py
+++ b/tests/test_analyzer_base.py
@@ -32,7 +32,7 @@ class _NewStyleAnalyzer(BaseAnalyzer):
     def default_criteria(cls) -> list[dict[str, Any]]:
         return [_criterion()]
 
-    def analyze(self, client, repository, tag, platform=None):  # type: ignore[no-untyped-def]
+    def analyze(self, ctx: Any) -> dict[str, Any]:
         return {}
 
 
@@ -46,7 +46,7 @@ class _LegacyAnalyzer(BaseAnalyzer):
     def default_rules(cls) -> list[dict[str, Any]]:
         return [_criterion()]
 
-    def analyze(self, client, repository, tag, platform=None):  # type: ignore[no-untyped-def]
+    def analyze(self, ctx: Any) -> dict[str, Any]:
         return {}
 
 
@@ -90,27 +90,8 @@ def test_base_default_criteria_empty_without_override():
         name = "bare"
         schema_file = "analyzer/cve.schema.json"
 
-        def analyze(self, client, repository, tag, platform=None):  # type: ignore[no-untyped-def]
+        def analyze(self, ctx: Any) -> dict[str, Any]:
             return {}
 
     # No infinite recursion, returns empty defaults.
     assert _Bare.default_criteria() == []
-
-
-def test_base_analyzer_uses_context_defaults_false():
-    from regis.analyzers.base import BaseAnalyzer
-
-    assert BaseAnalyzer.uses_context is False
-
-
-def test_subclass_can_opt_into_context():
-    from regis.analyzers.base import BaseAnalyzer
-
-    class CtxAnalyzer(BaseAnalyzer):
-        uses_context = True
-
-        def analyze(self, ctx):  # type: ignore[override]
-            return {}
-
-    assert CtxAnalyzer.uses_context is True
-    assert CtxAnalyzer().uses_context is True

--- a/tests/test_analyzer_cve.py
+++ b/tests/test_analyzer_cve.py
@@ -83,9 +83,6 @@ class TestCveAnalyzer:
         with pytest.raises(ToolError, match="boom"):
             analyzer.analyze(_ctx(_Boom()))
 
-    def test_cve_uses_context(self):
-        assert CveAnalyzer.uses_context is True
-
 
 class TestCveSourceFromDescriptor:
     """Unit tests for CveAnalyzer._source_from_descriptor."""

--- a/tests/test_analyzer_dockle.py
+++ b/tests/test_analyzer_dockle.py
@@ -66,9 +66,6 @@ class TestDockleAnalyzer:
         with pytest.raises(ToolError, match="dockle missing"):
             DockleAnalyzer().analyze(_dockle_ctx(_Boom()))
 
-    def test_dockle_uses_context(self):
-        assert DockleAnalyzer.uses_context is True
-
     def test_default_criteria(self):
         criteria = DockleAnalyzer.default_criteria()
         assert len(criteria) >= 1

--- a/tests/test_analyzer_metadata.py
+++ b/tests/test_analyzer_metadata.py
@@ -212,10 +212,6 @@ class TestMetadataAnalyzerWithPlaybookSchema:
         assert invalid, "expected at least one invalid entry for the structural error"
 
 
-def test_metadata_uses_context():
-    from regis.analyzers.metadata import MetadataAnalyzer
-
-    assert MetadataAnalyzer.uses_context is True
 
 
 def test_metadata_analyze_ignores_context():

--- a/tests/test_analyzer_metadata.py
+++ b/tests/test_analyzer_metadata.py
@@ -212,8 +212,6 @@ class TestMetadataAnalyzerWithPlaybookSchema:
         assert invalid, "expected at least one invalid entry for the structural error"
 
 
-
-
 def test_metadata_analyze_ignores_context():
     """analyze accepts a context but ignores it; result depends only on __init__ data."""
     from regis.analyzers.metadata import MetadataAnalyzer

--- a/tests/test_analyzer_popularity.py
+++ b/tests/test_analyzer_popularity.py
@@ -85,5 +85,3 @@ def test_popularity_last_updated_migrated_to_source(monkeypatch):
     assert result["date_registered"] == "2020-01-01T00:00:00Z"
 
 
-def test_popularity_uses_context():
-    assert PopularityAnalyzer.uses_context is True

--- a/tests/test_analyzer_popularity.py
+++ b/tests/test_analyzer_popularity.py
@@ -83,5 +83,3 @@ def test_popularity_last_updated_migrated_to_source(monkeypatch):
     assert "last_updated" not in result
     assert result["source"]["built_at"] == "2026-06-05T12:00:00Z"
     assert result["date_registered"] == "2020-01-01T00:00:00Z"
-
-

--- a/tests/test_analyzer_provenance.py
+++ b/tests/test_analyzer_provenance.py
@@ -76,6 +76,3 @@ class TestProvenanceAnalyzer:
         mock_inspector.get_blob.return_value = {"config": {"Labels": {}}}
         res = analyzer.analyze(_ctx(mock_inspector, repository="r", tag="t"))
         assert res["has_cosign_signature"] is False
-
-    def test_provenance_uses_context(self):
-        assert ProvenanceAnalyzer.uses_context is True

--- a/tests/test_analyzer_secrets.py
+++ b/tests/test_analyzer_secrets.py
@@ -77,9 +77,6 @@ class TestSecretsAnalyzer:
         )
         assert bool(jsonLogic(criteria["secret-scan"]["condition"], ctx)) is scan_pass
 
-    def test_secrets_uses_context(self, analyzer):
-        assert SecretsAnalyzer.uses_context is True
-
     @patch("regis.analyzers.secrets._scanner_version", return_value="3.95.3")
     def test_analyze_counts(self, _mock_ver, analyzer):
         ctx = _secrets_ctx(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from regis.cli import main
+from regis.core.domain.context import AnalysisContext
 
 
 class TestCliBasics:
@@ -57,8 +58,12 @@ class TestCliBasics:
         from regis.analyzers.base import BaseAnalyzer
 
         class DummyAnalyzer(BaseAnalyzer):
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": "dummy", "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": "dummy",
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -104,8 +109,12 @@ class TestCliBasics:
         from regis.analyzers.base import BaseAnalyzer
 
         class DummyAnalyzer(BaseAnalyzer):
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": "dummy", "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": "dummy",
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -158,8 +167,12 @@ class TestAnalyzeParallelism:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -223,7 +236,7 @@ class TestAnalyzeParallelism:
         class FailingAnalyzer(BaseAnalyzer):
             name = "failing"
 
-            def analyze(self, client, repo, tag, platform=None):
+            def analyze(self, ctx: AnalysisContext) -> dict:
                 raise AnalyzerError("boom")
 
             def validate(self, report):
@@ -388,7 +401,7 @@ class TestAnalyzeCacheAndFail:
         from regis.analyzers.base import BaseAnalyzer
 
         class DummyAnalyzer(BaseAnalyzer):
-            def analyze(self, client, repo, tag, platform=None):
+            def analyze(self, ctx: AnalysisContext) -> dict:
                 return {"analyzer": "dummy"}
 
             def validate(self, report):
@@ -430,8 +443,12 @@ class TestAnalyzeSkip:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -514,9 +531,13 @@ class TestAnalyzeEnvVars:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                DummyAnalyzer.last_platform = platform
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                DummyAnalyzer.last_platform = ctx.image.platform
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -595,8 +616,12 @@ class TestQuietFlag:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -653,7 +678,7 @@ class TestQuietFlag:
         class FailingAnalyzer(BaseAnalyzer):
             name = "failing"
 
-            def analyze(self, client, repo, tag, platform=None):
+            def analyze(self, ctx: AnalysisContext) -> dict:
                 raise AnalyzerError("boom")
 
             def validate(self, report):
@@ -679,8 +704,12 @@ class TestAnalyzerProgressFeedback:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass
@@ -726,7 +755,7 @@ class TestAnalyzerProgressFeedback:
         class FailingAnalyzer(BaseAnalyzer):
             name = "failing"
 
-            def analyze(self, client, repo, tag, platform=None):
+            def analyze(self, ctx: AnalysisContext) -> dict:
                 raise AnalyzerError("boom")
 
             def validate(self, report):
@@ -754,8 +783,12 @@ class TestAnalyzeSummary:
         class DummyAnalyzer(BaseAnalyzer):
             analyzer_name = name
 
-            def analyze(self, client, repo, tag, platform=None):
-                return {"analyzer": self.analyzer_name, "repository": repo, "tag": tag}
+            def analyze(self, ctx: AnalysisContext) -> dict:
+                return {
+                    "analyzer": self.analyzer_name,
+                    "repository": ctx.image.repository,
+                    "tag": ctx.image.tag,
+                }
 
             def validate(self, report):
                 pass

--- a/tests/test_endoflife.py
+++ b/tests/test_endoflife.py
@@ -135,9 +135,6 @@ class TestEndOfLifeAnalyzer:
         },
     ]
 
-    def test_endoflife_uses_context(self):
-        assert EndOfLifeAnalyzer.uses_context is True
-
     @patch("regis.analyzers.endoflife._fetch_cycles")
     def test_known_product(self, mock_fetch):
         """Test with nginx which is known on endoflife.date."""

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -29,6 +29,3 @@ class TestFreshnessAnalyzer:
         assert report["age_days"] is not None
         assert report["behind_latest_days"] == 1
         assert report["is_latest"] is False
-
-    def test_freshness_uses_context(self):
-        assert FreshnessAnalyzer.uses_context is True

--- a/tests/test_hadolint.py
+++ b/tests/test_hadolint.py
@@ -26,9 +26,6 @@ class TestHadolintAnalyzer:
         tools = FakeToolRunner(lint_dockerfile=issues)
         return make_ctx(inspector=inspector, tools=tools, platform=platform)
 
-    def test_hadolint_uses_context(self, analyzer):
-        assert HadolintAnalyzer.uses_context is True
-
     def test_hadolint_passes(self, analyzer):
         ctx = self._make_ctx(_HISTORY_WITH_ENTRIES, [])
         report = analyzer.analyze(ctx)

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -240,8 +240,6 @@ def test_oci_name_and_schema():
     assert analyzer.schema_file == "analyzer/oci.schema.json"
 
 
-def test_oci_uses_context():
-    assert OciAnalyzer.uses_context is True
 
 
 def test_oci_default_criteria_use_oci_paths():

--- a/tests/test_oci_analyzer.py
+++ b/tests/test_oci_analyzer.py
@@ -240,8 +240,6 @@ def test_oci_name_and_schema():
     assert analyzer.schema_file == "analyzer/oci.schema.json"
 
 
-
-
 def test_oci_default_criteria_use_oci_paths():
     serialized = json.dumps(OciAnalyzer.default_criteria())
     assert "results.oci." in serialized

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -197,6 +197,3 @@ class TestSbomAnalyzer:
 
         with pytest.raises(ToolError, match="syft down"):
             SbomAnalyzer().analyze(_sbom_ctx(_Boom()))
-
-    def test_sbom_uses_context(self):
-        assert SbomAnalyzer.uses_context is True

--- a/tests/test_scorecarddev.py
+++ b/tests/test_scorecarddev.py
@@ -168,5 +168,3 @@ def test_scorecard_source_extracted_from_raw(monkeypatch):
     assert result["source"]["built_at"] == "2026-06-01T00:00:00Z"
     assert result["source"]["version"] == "v5.0.0"
     assert isinstance(result["source"]["fetched_at"], str)
-
-

--- a/tests/test_scorecarddev.py
+++ b/tests/test_scorecarddev.py
@@ -170,6 +170,3 @@ def test_scorecard_source_extracted_from_raw(monkeypatch):
     assert isinstance(result["source"]["fetched_at"], str)
 
 
-def test_uses_context_flag():
-    """ScorecardDevAnalyzer must declare uses_context = True."""
-    assert ScorecardDevAnalyzer.uses_context is True

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -22,8 +22,6 @@ class TestHumanSize:
 
 
 class TestSizeAnalyzer:
-    def test_size_uses_context(self):
-        assert SizeAnalyzer.uses_context is True
 
     def test_single_manifest(self):
         single_manifest = {

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -126,9 +126,6 @@ class TestClassifyTag:
 class TestVersioningAnalyzer:
     """Test the versioning analyzer end-to-end."""
 
-    def test_uses_context(self):
-        assert VersioningAnalyzer.uses_context is True
-
     def test_semver_dominant(self):
         tags = ["1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.0.0-rc.1", "latest"]
         ctx = make_ctx(


### PR DESCRIPTION
## Summary

First sub-PR of phase **P3d**. Now that all 14 analyzers are on `analyze(self, ctx)` (P3a–P3c), the temporary `uses_context` bridge and the legacy dispatch branch are dead. This removes them **atomically** — `analyze(self, ctx: AnalysisContext)` is now the one and only analyzer contract.

- **`BaseAnalyzer.analyze`** flipped from the legacy `analyze(self, client, repository, tag, platform=None)` to `analyze(self, ctx: AnalysisContext) -> dict`. `base.py` drops its `RegistryClient` import (the last one in `regis/analyzers/`) and the `uses_context` marker.
- **All 14 analyzers**: the `# type: ignore[override]` and `uses_context = True` are removed — the override now matches the base, so mypy is happy with no suppressions. `metadata` keeps `analyze(self, ctx: AnalysisContext | None = None)` (a contravariant-valid widened override, so still no `type: ignore`) to preserve the CLI rerun path's no-arg `meta_analyzer.analyze()` call.
- **`AnalyzeImage`**: `legacy_client_factory` (param + attr + `LegacyClientFactory` alias) removed; `_dispatch` collapses to the pure ctx path (`ctx = AnalysisContext(image, inspector_factory(image), tools); analyzer.analyze(ctx); analyzer.validate(report)`). `inspector_factory`/`tools`/`run`/`run_one` unchanged.
- **`composition.py`**: drops `legacy_client_factory=` from the `AnalyzeImage(...)` wiring (keeps the inspector factory).
- **Tests**: the obsolete bridge/marker tests are removed (the legacy-branch dispatch test, the 14 `*_uses_context` assertions, the legacy composition-factory tests, `_LegacyAnalyzer`/`_SENTINEL_CLIENT`); multi-analyzer tests that used `_LegacyAnalyzer` are converted in-place to ctx fakes with their assertions preserved. No real behavioral coverage lost (suite 869→850, all removed tests were marker/bridge-only).

The remaining P3d work (separate PRs): **P3d-2** `utils/{grype,syft,trufflehog,regctl,process} → ToolError`/`RegistryError` + remove `click` from the tools layer; **P3d-3** fold playbooks/emission/verdict into the use-case (via `ReportSink`); **P3d-4** sketch the `Evaluate` use-case.

Spec: `docs/superpowers/specs/2026-06-14-hexagonal-p3-analyzer-contract-design.md` (§6 P3d, §9 DoD).

## Test Plan
- [x] `uv run pytest` → 850 passed, 1 skipped, **96.25%** (global ≥90% AND per-file gate)
- [x] `uv run lint-imports` → Hexagonal layering KEPT
- [x] mypy (via `trunk check`) green with **zero** `# type: ignore[override]` in `regis/analyzers/`
- [x] `grep` confirms 0 `uses_context` / `legacy_client_factory` / `LegacyClientFactory` in `regis/`; 0 `RegistryClient` import in `regis/analyzers/`
- [x] `uv run pytest tests/test_analyze_rerun.py` → metadata rerun no-arg `analyze()` path intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)