### PR TITLE
chore(ci): clear stale mypy cache in pre-commit hook to dodge mypy 1.19.1 crash

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -65,7 +65,14 @@ actions:
     - id: trunk-check-fix-pre-commit
       triggers:
         - git_hooks: [pre-commit]
-      run: trunk check --fix
+      # ponytail: clear mypy's incremental cache before linting. mypy 1.19.1
+      # crashes (AssertionError in fix_cross_refs: "Cannot find module ...",
+      # reported as "No diagnostics found ... exit code non-zero") on a warm but
+      # stale cache after a symbol is relocated between modules — a per-file
+      # false positive that forced `git commit --no-verify`. A cold cache never
+      # hits it (CI starts cold and is unaffected); clearing it here makes each
+      # commit's mypy as reliable as CI, at the cost of a few seconds re-check.
+      run: rm -rf .mypy_cache && trunk check --fix
   disabled:
     - trunk-announce
     - trunk-check-pre-push


### PR DESCRIPTION
## Summary

The Trunk pre-commit hook (`trunk-check-fix-pre-commit`) intermittently crashed mypy and blocked commits, forcing `git commit --no-verify`. Crash:

```
AssertionError: Cannot find module for regis.core.model.report.REPORT_SCHEMA_VERSION
  ... mypy/build.py fix_cross_refs -> mypy/fixup.py -> mypy/lookup.py
```

surfaced by Trunk as *"No diagnostics found in mypy output, but exit code was non-zero."* It's a **mypy 1.19.1 incremental-cache false positive**: the per-file runs the hook does (`mypy ... <one file>`) load other modules from a warm cache and `fix_cross_refs` can't resolve a symbol that was relocated between modules since the cache was written.

**Fix:** clear `.mypy_cache` before `trunk check --fix` in the pre-commit action. A cold cache never hits the crash — **CI starts cold and was never affected** — so this just gives every local commit the same cold-cache reliability as CI, costing a few seconds of re-check. Scoped to the pre-commit hook only; CI and ad-hoc `trunk check` keep their incremental cache.

### Why here (not a config / version pin)

I verified the alternatives don't apply:
- Trunk's sandboxed mypy **does not read `pyproject.toml`'s `[tool.mypy]`** (tested: an invalid `incremental` value there produces no config error). So `incremental = false` in pyproject is inert — and the **pre-existing `[[tool.mypy.overrides]] follow_imports = "skip"` block is likewise inert** (it never actually suppressed this crash; that's why it kept recurring). Left untouched here to keep the diff minimal — safe to remove in a follow-up.
- A `lint.definitions` override adding `--no-incremental` is **not applied** by Trunk for the managed mypy linter (command stays the plugin default, even after a daemon restart).
- mypy still writes a `.mypy_cache` dir even with `--no-incremental`, so the dir's presence isn't the signal — the crash lives in the cache-*read* path, which a cold cache avoids.

## Test plan

- [x] Commit this change **without** `--no-verify` — the new hook action runs `rm -rf .mypy_cache && trunk check --fix` and passes.
- [x] Cold per-file mypy is clean: `rm -rf .mypy_cache && trunk check --filter=mypy regis/commands/analyze.py regis/core/application/evaluate.py` → No issues.
- [x] Type-checking is **not** weakened — a deliberate `x: int = "str"` canary is still flagged (`mypy/assignment`); this change only clears the cache, it disables no checks.
- [x] `.trunk/trunk.yaml` valid (yamllint clean).

Note: the crash is warm-stale-cache-dependent and so not deterministically reproducible on a clean tree; the fix removes its precondition rather than patching mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)