### PR TITLE
docs(memory-bank): document the hexagonal architecture (P5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,28 +35,38 @@ Use `--no-cov` for fast iteration; run the full suite before opening a PR.
 
 ## Architecture
 
+Hexagonal (ports & adapters). The dependency rule — `adapters > core.application > core.domain > core.ports > core.model` — is enforced in CI by **import-linter** (job `hexagonal-layers`). The core is Click-free; driven adapters own all I/O. Full layer table + diagram: `docs/memory-bank/systemPatterns.md` § Architecture.
+
 ```
 regis/
-  cli.py              # `regis` console script entry point
-  analyzers/          # Pluggable analyzers (entry points in pyproject.toml)
-  analyzers/discovery.py  # discover_analyzers() — entry point loader
-  commands/           # CLI commands (analyze, archive, bootstrap, check, rules)
-  utils/process.py    # run_cmd(), require_tool() — subprocess helpers
-  utils/report.py     # write_report, run_playbooks, validate_report, render_*
-  playbook/           # Playbook evaluation engine (context, sections, evaluator)
-  rules/              # JSON Logic rule evaluation and merging
-  registry/           # Registry client, auth, URL parser
-  report/             # Report generation (Docusaurus SPA builder)
-  schemas/            # JSON Schema files for analyzer outputs and playbooks
-  playbooks/          # Built-in default playbook (default.yaml)
-apps/dashboard/       # Docusaurus + Tremor report viewer (pnpm workspace)
+  core/                 # Click-free hexagonal core
+    model/              #   value objects: ImageReference, Report, REPORT_SCHEMA_VERSION
+    ports/              #   driven interfaces: ImageInspector, ToolRunner, ReportSink, PresentationRenderer
+    domain/
+      analyzers/        #     BaseAnalyzer + discovery.py (entry-point loader) + 14 analyzers
+      playbook/         #     playbook engine (loader, evaluator, conditions, context, verdict)
+      rules/            #     JSON Logic criterion evaluation and merging
+      manifest.py · context.py (AnalysisContext) · errors.py
+    application/        #   use-cases: AnalyzeImage, Evaluate, playbook_runner, AnalyzerProvider (port)
+  adapters/
+    driven/
+      registry/         #     RegistryClient, auth, URL parser; Registry/Regctl ImageInspectors
+      tools/            #     SubprocessToolRunner + tool-fetch infra (manifest/fetcher/cosign + manifest.yaml)
+      report/           #     FileReportSink, CookiecutterPresentationRenderer, html report
+      analyzers/        #     EntryPointAnalyzerProvider
+    driving/
+      cli/              #     cli.py (`regis` console script), commands/, composition.py (wiring root)
+  utils/                # unlayered: process (run_cmd/require_tool), report shim, predicates, scanner wrappers
+  schemas/              # JSON Schema files for analyzer outputs and playbooks
+  playbooks/            # Built-in default playbook (default.yaml)
+  templates/ · cookiecutters/ · data/   # report template, scaffolds, static data
 ```
 
 ## Agent patterns (Regis-specific)
 
-- **Analyzer plugins**: subclass `BaseAnalyzer`, implement `analyze()`, `validate()`, `default_rules()`. Register via `project.entry-points."regis.analyzers"` in `pyproject.toml`.
-- **Rule templates**: `default_rules()` can return both concrete rules and slug-identified templates; playbooks instantiate them via `rule: <slug>` + `options:`.
-- **JSON Logic operators**: custom ops (`intersects`, `contains_all`, `subset`, `keys`, `get`, `env_contains`) registered in `rules/evaluator.py`.
+- **Analyzer plugins**: subclass `BaseAnalyzer` (in `regis/core/domain/analyzers/`), implement `analyze(self, ctx: AnalysisContext)` (external access via `ctx.tools` / `ctx.inspector`), `validate()`, `default_criteria()`. Register via `[project.entry-points."regis.analyzers"]` in `pyproject.toml` pointing at `regis.core.domain.analyzers.<mod>:<Cls>` — re-run `uv sync` after changing entry points (the group key `"regis.analyzers"` is the discovery contract, not a module path).
+- **Rule templates**: `default_criteria()` can return both concrete criteria and slug-identified templates; playbooks instantiate them via `criterion: <slug>` + `options:`.
+- **JSON Logic operators**: custom ops (`intersects`, `contains_all`, `subset`, `keys`, `get`, `env_contains`) registered in `core/domain/rules/evaluator.py`.
 - **Parallel analysis**: `ThreadPoolExecutor`, default 4 workers (`--max-workers` overrides). Each thread gets its own `RegistryClient`.
 - **Test patch targets**: patch at the _new_ module location after the CLI split — `regis.adapters.driving.cli.commands.analyze.{RegistryClient,_discover_analyzers}`, `regis.adapters.driving.cli.commands.check.{RegistryClient,version}`, `regis.utils.process.{shutil,subprocess}`, `regis.utils.report.jsonschema`. **Not** `regis.adapters.driving.cli.cli.*`.
 - **Lazy imports**: `from module import X` inside a function body — patch at the source (`module.X`), not the importing module.

--- a/docs/memory-bank/decisionLog.md
+++ b/docs/memory-bank/decisionLog.md
@@ -2,6 +2,42 @@
 
 > Supplemental file: this records historical decisions that complement the core Memory Bank files.
 
+## 2026-06: Hexagonal architecture migration (ports & adapters)
+
+- **Decision**: Restructurer le cœur `regis` en **ports & adapters** stricts,
+  avec la règle de dépendance imposée par **import-linter** en CI (contrat
+  _"Hexagonal layering"_, job `hexagonal-layers`) plutôt que par convention.
+  Cible : `regis/core/{model,ports,domain,application}` + `regis/adapters/{driven,driving}`.
+  Le cœur devient **Click-free** (Click confiné à l'adaptateur CLI driving) ; les
+  adaptateurs driven possèdent toute l'I/O (subprocess, HTTP registry, écritures
+  fichier, credentials). Voir `systemPatterns.md` § Architecture pour le schéma et
+  la table des couches.
+- **Contrat analyzer (cassant pour plugins tiers)** : `BaseAnalyzer.analyze(self,
+ctx: AnalysisContext)` remplace l'ancienne signature `analyze(client, repo, tag,
+platform=…)` ; les capacités externes passent par `ctx.tools` (`ToolRunner`) et
+  `ctx.inspector` (`ImageInspector`). `default_rules()` → `default_criteria()`
+  (shim de dépréciation conservé). Les entry-points `[project.entry-points."regis.analyzers"]`
+  pointent désormais vers `regis.core.domain.analyzers.<mod>:<Cls>` (la **clé de
+  groupe** `"regis.analyzers"` et le lookup `entry_points(group="regis.analyzers")`
+  sont inchangés — c'est le contrat de discovery, pas un module path).
+- **Phasage strangler P0→P5** : P0 squelette + contrat import-linter ; P1 value
+  objects + ports + `AnalysisContext` ; P2 adaptateurs driven (`SubprocessToolRunner`,
+  `RegctlImageInspector`, `FileReportSink`) ; P3 bascule du contrat `analyze(ctx)`
+  (14/14) + use-cases `AnalyzeImage`/`Evaluate` orchestrant boucle/playbooks/émission ;
+  P4a port `PresentationRenderer` puis **P4 sweep** = déménagement physique des
+  modules (`git mv` sous-arbre par sous-arbre, cosmétique car l'archi était déjà
+  imposée par import-linter) ; P5 docs (cette entrée). Un **plan éphémère par phase**
+  (jamais commité — `execution-plans-guard` rejette `docs/superpowers/plans/**`).
+- **Différé (à trancher)** : déplacer `AnalyzerProvider` vers `core/ports/` **et**
+  binder `available() -> type[BaseAnalyzer]` sont **incompatibles** sous l'ordre des
+  couches — binder le type domaine est légal depuis `core.application` (foyer actuel)
+  mais illégal depuis `core.ports` (ports ne peut importer domain). Laissé en
+  `application` avec retour `type` nu.
+- **Reference**: spec maîtresse `docs/superpowers/specs/2026-06-13-hexagonal-architecture-design.md`
+  (+ raffinements P2b/P3 specs) ; PRs sweep #780 (rules) / #781 (report) / #782
+  (registry) / #783 (tools) / #784 (playbook) / #785 (analyzers) / #786 (cli) ;
+  plans éphémères supprimés au merge.
+
 ## 2026-05-30: Probe — grype/syft/trufflehog output shapes locked
 
 - **Decision**: Migration trivy→grype/syft/trufflehog parse des formes de sortie

--- a/docs/memory-bank/projectbrief.md
+++ b/docs/memory-bank/projectbrief.md
@@ -32,8 +32,8 @@ Provide a single orchestration layer for container security, supply-chain eviden
 
 ### In Scope
 
-- CLI commands under `regis/commands/`
-- Analyzer plugins under `regis/analyzers/`
+- CLI commands under `regis/adapters/driving/cli/commands/`
+- Analyzer plugins under `regis/core/domain/analyzers/`
 - Playbook evaluation and rule logic
 - Registry integrations and report generation
 - Docusaurus documentation and dashboard UI

--- a/docs/memory-bank/systemPatterns.md
+++ b/docs/memory-bank/systemPatterns.md
@@ -1,16 +1,45 @@
 # System Patterns
 
-## Architecture
+## Architecture — hexagonal (ports & adapters)
 
-`regis` follows a modular, pluggable architecture.
+`regis` follows a strict **ports & adapters** layout. The dependency rule is
+enforced in CI by **import-linter** (`[tool.importlinter]` in `pyproject.toml`,
+contract _"Hexagonal layering"_, job `hexagonal-layers`): a layer may import only
+the layers below it. The migration that landed this (P0→P5, 2026-06) is recorded
+in `decisionLog.md`.
 
-### Key Components
+```mermaid
+flowchart TB
+    CLI["Driving adapter — adapters/driving/cli<br/>cli.py · commands/ · composition.py"]
+    APP["core.application<br/>AnalyzeImage · Evaluate · playbook_runner · AnalyzerProvider"]
+    DOM["core.domain<br/>analyzers/ · playbook/ · rules/ · manifest · context · errors"]
+    PORTS["core.ports<br/>ImageInspector · ToolRunner · ReportSink · PresentationRenderer"]
+    MODEL["core.model<br/>ImageReference · Report"]
+    DRIVEN["Driven adapters — adapters/driven<br/>registry/ · tools/ · report/ · analyzers/"]
 
-- **CLI (Click)**: Entry point for user interaction.
-- **Engine**: Orchestrates analysis and playbook evaluation.
-- **Analyzers**: Pluggable modules that extract specific data (e.g., regctl, grype, Hadolint).
-- **Playbook Engine**: Evaluates JSON logic rules against analyzer results.
-- **Report Generators**: Produces interactive SPA dashboards and machine-readable JSON.
+    CLI -->|may import| APP
+    APP -->|may import| DOM
+    DOM -->|may import| PORTS
+    PORTS -->|may import| MODEL
+    DRIVEN -->|implement| PORTS
+    CLI -->|composition root wires| DRIVEN
+```
+
+### Layers (top → bottom; each imports only those below)
+
+| Layer               | Package                       | Holds                                                                                                                                                                                                             |
+| ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Driving adapter** | `regis/adapters/driving/cli/` | `cli.py`, `commands/`, the composition root (`composition.py`) that wires use-cases to driven adapters                                                                                                            |
+| **Application**     | `regis/core/application/`     | use-cases `AnalyzeImage` / `Evaluate` (own the loop, playbooks, emission), `playbook_runner`, `AnalyzerProvider` port                                                                                             |
+| **Domain**          | `regis/core/domain/`          | `analyzers/` (base + discovery + 14 analyzers), `playbook/` engine, `rules/` (JSON Logic), `manifest`, `context` (`AnalysisContext`), `errors`                                                                    |
+| **Ports**           | `regis/core/ports/`           | driven-side interfaces: `ImageInspector`, `ToolRunner`, `ReportSink`, `PresentationRenderer`                                                                                                                      |
+| **Model**           | `regis/core/model/`           | value objects `ImageReference`, `Report`, `REPORT_SCHEMA_VERSION`                                                                                                                                                 |
+| **Driven adapters** | `regis/adapters/driven/`      | `registry/` (HTTP + regctl inspectors, auth, URL parser), `tools/` (subprocess runner + tool-fetch infra), `report/` (`FileReportSink`, cookiecutter renderer, html), `analyzers/` (`EntryPointAnalyzerProvider`) |
+
+The core is **Click-free** — Click lives only in the driving CLI adapter; driven
+adapters own all I/O (subprocesses, registry HTTP, file writes, credentials).
+Unlayered support packages (`utils/`, `schemas/`, `templates/`, `playbooks/`,
+`cookiecutters/`, `data/`) sit outside the contract.
 
 ## Report Output Format Extension Pattern
 


### PR DESCRIPTION
## Summary

Final **P5** phase of the hexagonal migration: sync the architecture docs to the now-completed ports & adapters layout (sweep #780–#786 all merged). Docs only — no code, tests, or layering touched.

- **systemPatterns.md**: replaced the old _modular/pluggable_ Architecture section with a hexagonal description, a **Mermaid layer diagram**, and a per-layer table; notes the import-linter _"Hexagonal layering"_ contract (job `hexagonal-layers`) enforces the dependency rule.
- **CLAUDE.md**: rewrote the Architecture tree to `core/{model,ports,domain,application}` + `adapters/{driven,driving}` (dropped the extracted `apps/dashboard/`); updated the analyzer-plugin pattern to the `analyze(self, ctx)` contract, `default_criteria()`, and the `regis.core.domain.analyzers` entry-point target.
- **decisionLog.md**: recorded the migration decision, the breaking analyzer contract, the P0→P5 phasing, and the deferred `AnalyzerProvider` question.
- **projectbrief.md**: fixed two stale in-scope module paths.

### Verification
- Mermaid diagram validated (renders clean).
- trunk (markdownlint + prettier): **No issues** across all 4 files.

### Closes out the migration
With this, P0→P5 are done. The only open item is the deferred decision from #785: move `AnalyzerProvider` → `core.ports` **or** bind `available() -> type[BaseAnalyzer]` (mutually exclusive under the layer order) — recorded in decisionLog, no action taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)