### PR TITLE
feat(report): emit SARIF of playbook verdicts (--sarif)

### DIFF
--- a/docs/website/docs/reference/cli.md
+++ b/docs/website/docs/reference/cli.md
@@ -37,6 +37,7 @@ _Output options:_
 - `--html`: Generate a self-contained single-file `report.html`.
 - `--sections all|summary|<slugs>`: Sections to include in the HTML report. Only applies to `--html`.
 - `--markdown`: Also emit a Markdown summary report (`report.md`).
+- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`) for upload to GitHub Code Scanning (or any SARIF consumer). Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level and a `helpUri` to the criterion's docs.
 - `--pretty/--no-pretty`: Pretty-print the JSON output (default: on).
 
 _Evaluation options:_
@@ -110,6 +111,7 @@ _Options:_
 
 - `-p, --playbook PATH`: Path or URL to custom playbook YAML/JSON file(s).
 - `--html`: Generate a self-contained single-file `report.html`.
+- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`).
 
 ### `check`
 

--- a/regis/adapters/driven/report/sarif.py
+++ b/regis/adapters/driven/report/sarif.py
@@ -1,0 +1,146 @@
+"""Render playbook verdicts as SARIF 2.1.0 for GitHub Code Scanning et al.
+
+Maps playbook *rule outcomes* (verdicts), not raw analyzer findings: each
+evaluated rule becomes a reportingDescriptor, each breach a result. Regis'
+three severity levels map to SARIF ``level`` plus a numeric ``security-severity``
+(0-10) that GitHub reads to bucket Critical/High/Low.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+DOCS_BASE = "https://trivoallan.github.io/regis/docs/reference/rules"
+
+# Regis level -> (SARIF level, security-severity). security-severity buckets in
+# GitHub: >=9.0 Critical, 7.0-8.9 High, 4.0-6.9 Medium, <4.0 Low.
+_LEVEL_MAP: dict[str, tuple[str, str]] = {
+    "critical": ("error", "9.0"),
+    "warning": ("warning", "7.0"),
+    "info": ("note", "2.0"),
+}
+_DEFAULT_LEVEL = ("note", "2.0")
+
+
+def _sarif_level(regis_level: Any) -> tuple[str, str]:
+    return _LEVEL_MAP.get(str(regis_level).lower(), _DEFAULT_LEVEL)
+
+
+def _help_uri(rule: dict[str, Any]) -> str | None:
+    criterion = rule.get("criterion")
+    if not criterion:
+        return None
+    analyzers = rule.get("analyzers") or []
+    category = analyzers[0] if analyzers else "core"
+    return f"{DOCS_BASE}/{category}/{criterion}"
+
+
+def _fingerprint(slug: str, req: dict[str, Any]) -> str:
+    # Stable across rebuilds: keyed on (rule, repo:tag), never the digest.
+    key = f"{slug}|{req.get('registry')}/{req.get('repository')}:{req.get('tag')}"
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def build_sarif(
+    report: dict[str, Any],
+    *,
+    report_url: str = "",
+    dockerfile: str | None = "Dockerfile",
+) -> dict[str, Any]:
+    """Build the SARIF document (dict) from an evaluated report."""
+    req = report.get("request", {})
+    rules = report.get("rules", []) or []
+
+    descriptors: list[dict[str, Any]] = []
+    index: dict[str, int] = {}
+    for r in rules:
+        slug = r.get("slug", "")
+        index[slug] = len(descriptors)
+        level, sev = _sarif_level(r.get("level", "info"))
+        descriptor: dict[str, Any] = {
+            "id": slug,
+            "name": "".join(p.capitalize() for p in slug.split("-")),
+            "shortDescription": {"text": r.get("description") or slug},
+            "defaultConfiguration": {"level": level},
+            "properties": {
+                "tags": r.get("tags", []),
+                "security-severity": sev,
+                "regis-level": r.get("level"),
+            },
+        }
+        uri = _help_uri(r)
+        if uri:
+            descriptor["helpUri"] = uri
+        descriptors.append(descriptor)
+
+    results: list[dict[str, Any]] = []
+    for r in rules:
+        if r.get("status") != "failed":  # breaches only (skip pass + incomplete)
+            continue
+        slug = r.get("slug", "")
+        level, sev = _sarif_level(r.get("level", "info"))
+        text = r.get("message") or slug
+        markdown = text + (
+            f"  \n[Full Regis report]({report_url})" if report_url else ""
+        )
+        result: dict[str, Any] = {
+            "ruleId": slug,
+            "ruleIndex": index[slug],
+            "level": level,
+            "message": {"text": text, "markdown": markdown},
+            "partialFingerprints": {"regisRuleRepo/v1": _fingerprint(slug, req)},
+            "properties": {
+                "security-severity": sev,
+                "regis-level": r.get("level"),
+                "image": req.get("url"),
+            },
+        }
+        # GitHub Code Scanning rejects results without a location, so every
+        # result is anchored at the Dockerfile (the artifact the image was built
+        # from) by default. Pass dockerfile=None only for a consumer that
+        # tolerates location-less results.
+        if dockerfile:
+            result["locations"] = [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": dockerfile},
+                        "region": {"startLine": 1},
+                    }
+                }
+            ]
+        results.append(result)
+
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "Regis",
+                        "informationUri": "https://github.com/trivoallan/regis",
+                        "version": str(report.get("version", "")),
+                        "rules": descriptors,
+                    }
+                },
+                "automationDetails": {"id": f"regis/{req.get('repository')}"},
+                "results": results,
+            }
+        ],
+    }
+
+
+def render_sarif(
+    report: dict[str, Any],
+    *,
+    report_url: str = "",
+    dockerfile: str | None = "Dockerfile",
+) -> str:
+    """Render the report as a SARIF 2.1.0 JSON string."""
+    return json.dumps(
+        build_sarif(report, report_url=report_url, dockerfile=dockerfile),
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/regis/adapters/driving/cli/commands/analyze.py
+++ b/regis/adapters/driving/cli/commands/analyze.py
@@ -261,6 +261,13 @@ def _parse_meta(meta: tuple[str, ...]) -> dict[str, Any]:
     help="Also emit a Markdown summary report (report.md).",
 )
 @click.option(
+    "--sarif",
+    "sarif",
+    is_flag=True,
+    default=False,
+    help="Also emit a SARIF report of playbook verdicts (report.sarif).",
+)
+@click.option(
     "--merge-meta",
     "merge_meta",
     is_flag=True,
@@ -291,6 +298,7 @@ def analyze(
     rerun: str | None = None,
     report_dir: Path | None = None,
     markdown: bool = False,
+    sarif: bool = False,
     merge_meta: bool = False,
 ) -> None:
     """Analyze a Docker image and evaluate playbooks.
@@ -359,6 +367,8 @@ def analyze(
         formats = ["json"]
         if markdown:
             formats.append("md")
+        if sarif:
+            formats.append("sarif")
         rerun_report = run_playbooks(
             playbook_paths, existing_report, formats, show_rules=evaluate
         )
@@ -409,6 +419,8 @@ def analyze(
         formats.append("html")
     if markdown:
         formats.append("md")
+    if sarif:
+        formats.append("sarif")
 
     if sections != "all" and not html_single:
         _info("  Warning: --sections has no effect without --html.", quiet=quiet)
@@ -636,6 +648,13 @@ def analyze(
     type=click.Choice(["default"], case_sensitive=False),
     help="Theme to use for HTML report (default: default).",
 )
+@click.option(
+    "--sarif",
+    "sarif",
+    is_flag=True,
+    default=False,
+    help="Also emit a SARIF report of playbook verdicts (report.sarif).",
+)
 def evaluate_cmd(
     input_path: str,
     playbook_paths: tuple[str, ...],
@@ -645,6 +664,7 @@ def evaluate_cmd(
     theme: str,
     html_single: bool = False,
     sections: str = "all",
+    sarif: bool = False,
 ) -> None:
     """Evaluate playbooks against an existing analysis report (dry-run).
 
@@ -667,6 +687,8 @@ def evaluate_cmd(
     formats = ["json"]
     if html_single:
         formats.append("html")
+    if sarif:
+        formats.append("sarif")
 
     if sections != "all" and not html_single:
         click.echo("  Warning: --sections has no effect without --html.", err=True)

--- a/regis/core/domain/rules/evaluator.py
+++ b/regis/core/domain/rules/evaluator.py
@@ -195,6 +195,9 @@ def resolve_rules(
                         slug = f"{template_name}.{len(processed_custom)}"
 
                 instance["slug"] = slug
+                # Remember which criterion template this instance came from, so
+                # downstream (e.g. SARIF help_uri) can link to its docs.
+                instance["criterion"] = template_name
                 # Binding a criterion template in a playbook activates it by
                 # default; criteria shipped with `enable: False` (opt-in) become
                 # active when referenced. An explicit `enable: false` in the rule
@@ -418,18 +421,19 @@ def evaluate_rules(
                 if len(parts) > 1:
                     involved_analyzers.add(parts[1])
 
-        results.append(
-            {
-                "slug": rule.get("slug", ""),
-                "description": rule.get("description", ""),
-                "level": rule.get("level", "info"),
-                "tags": rule.get("tags", []),
-                "passed": passed,
-                "status": status,
-                "message": message_resolved,
-                "analyzers": sorted(involved_analyzers),
-            }
-        )
+        entry = {
+            "slug": rule.get("slug", ""),
+            "description": rule.get("description", ""),
+            "level": rule.get("level", "info"),
+            "tags": rule.get("tags", []),
+            "passed": passed,
+            "status": status,
+            "message": message_resolved,
+            "analyzers": sorted(involved_analyzers),
+        }
+        if rule.get("criterion"):
+            entry["criterion"] = rule["criterion"]
+        results.append(entry)
 
     # Sort results to be deterministic: failures first over passes, then by level, then slug
     # Levels ordered by severity

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -101,6 +101,10 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "List of analyzers that contributed data to this rule."
+          },
+          "criterion": {
+            "type": "string",
+            "description": "Slug of the criterion template this rule instantiated, when applicable."
           }
         }
       }

--- a/regis/schemas/report/report.schema.json
+++ b/regis/schemas/report/report.schema.json
@@ -182,6 +182,10 @@
               "type": "string"
             },
             "description": "List of analyzers that contributed data to this rule."
+          },
+          "criterion": {
+            "type": "string",
+            "description": "Slug of the criterion template this rule instantiated, when applicable."
           }
         }
       }

--- a/regis/utils/report.py
+++ b/regis/utils/report.py
@@ -289,6 +289,20 @@ def render_and_save_reports(
                     rendered=rendered,
                 )
             )
+        elif fmt == "sarif":
+            from regis.adapters.driven.report.sarif import render_sarif
+
+            rendered = render_sarif(report)
+            file_tmpl = output_template or "report.sarif"
+            paths.append(
+                write_report(
+                    dir_tmpl=output_dir_template or ".",
+                    file_tmpl=file_tmpl,
+                    report=report,
+                    fmt=fmt,
+                    rendered=rendered,
+                )
+            )
         else:
             indent = 2 if pretty else None
             rendered = json.dumps(report, indent=indent, ensure_ascii=False)

--- a/tests/commands/test_analyze_sarif.py
+++ b/tests/commands/test_analyze_sarif.py
@@ -1,0 +1,17 @@
+"""The --sarif flag is registered on analyze and evaluate."""
+
+from click.testing import CliRunner
+
+from regis.adapters.driving.cli.commands.analyze import analyze, evaluate_cmd
+
+
+def test_analyze_help_contains_sarif_flag():
+    result = CliRunner().invoke(analyze, ["--help"])
+    assert result.exit_code == 0
+    assert "--sarif" in result.output
+
+
+def test_evaluate_help_contains_sarif_flag():
+    result = CliRunner().invoke(evaluate_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "--sarif" in result.output

--- a/tests/report/test_sarif.py
+++ b/tests/report/test_sarif.py
@@ -1,0 +1,182 @@
+"""Unit tests for the SARIF renderer (playbook verdicts -> SARIF 2.1.0)."""
+
+import json
+
+from regis.adapters.driven.report.sarif import DOCS_BASE, render_sarif
+
+
+def _rule(slug, level, status, *, criterion=None, analyzers=None, message="msg"):
+    return {
+        "slug": slug,
+        "description": f"{slug} desc",
+        "level": level,
+        "status": status,
+        "passed": status == "passed",
+        "message": message,
+        "tags": ["security"],
+        "analyzers": analyzers if analyzers is not None else [],
+        **({"criterion": criterion} if criterion else {}),
+    }
+
+
+def _report(rules, *, digest="sha256-AAA"):
+    return {
+        "version": "0.37.0",
+        "request": {
+            "url": "python:3.9-slim",
+            "registry": "registry-1.docker.io",
+            "repository": "library/python",
+            "tag": "3.9-slim",
+            "digest": digest,
+        },
+        "rules": rules,
+    }
+
+
+def test_emits_one_result_per_breach():
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("a", "critical", "failed"),
+                    _rule("b", "warning", "passed"),
+                    _rule("c", "info", "failed"),
+                    _rule("d", "warning", "incomplete"),
+                ]
+            )
+        )
+    )
+    assert [r["ruleId"] for r in s["runs"][0]["results"]] == ["a", "c"]
+
+
+def test_maps_severity_to_level_and_security_severity():
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("crit", "critical", "failed"),
+                    _rule("warn", "warning", "failed"),
+                    _rule("note", "info", "failed"),
+                ]
+            )
+        )
+    )
+    res = {r["ruleId"]: r for r in s["runs"][0]["results"]}
+    assert (res["crit"]["level"], res["crit"]["properties"]["security-severity"]) == (
+        "error",
+        "9.0",
+    )
+    assert (res["warn"]["level"], res["warn"]["properties"]["security-severity"]) == (
+        "warning",
+        "7.0",
+    )
+    assert (res["note"]["level"], res["note"]["properties"]["security-severity"]) == (
+        "note",
+        "2.0",
+    )
+
+
+def test_help_uri_points_to_criterion_doc():
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule(
+                        "cve-critical",
+                        "critical",
+                        "failed",
+                        criterion="cve-count",
+                        analyzers=["cve"],
+                    ),
+                ]
+            )
+        )
+    )
+    desc = s["runs"][0]["tool"]["driver"]["rules"][0]
+    assert desc["helpUri"] == f"{DOCS_BASE}/cve/cve-count"
+
+
+def test_help_uri_falls_back_to_core_when_no_analyzer():
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule(
+                        "registry-domain-whitelist",
+                        "critical",
+                        "failed",
+                        criterion="registry-domain-whitelist",
+                        analyzers=[],
+                    ),
+                ]
+            )
+        )
+    )
+    desc = s["runs"][0]["tool"]["driver"]["rules"][0]
+    assert desc["helpUri"] == f"{DOCS_BASE}/core/registry-domain-whitelist"
+
+
+def test_fingerprint_ignores_digest():
+    f1 = json.loads(
+        render_sarif(_report([_rule("a", "warning", "failed")], digest="sha256-AAA"))
+    )
+    f2 = json.loads(
+        render_sarif(_report([_rule("a", "warning", "failed")], digest="sha256-ZZZ"))
+    )
+    assert (
+        f1["runs"][0]["results"][0]["partialFingerprints"]
+        == f2["runs"][0]["results"][0]["partialFingerprints"]
+    )
+
+
+def test_every_result_indexes_its_descriptor():
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("a", "critical", "failed"),
+                    _rule("b", "warning", "passed"),
+                ]
+            )
+        )
+    )
+    rules = s["runs"][0]["tool"]["driver"]["rules"]
+    assert {d["id"] for d in rules} == {"a", "b"}  # every evaluated rule -> descriptor
+    for res in s["runs"][0]["results"]:
+        assert rules[res["ruleIndex"]]["id"] == res["ruleId"]
+
+
+def test_message_links_to_full_report():
+    s = json.loads(
+        render_sarif(
+            _report([_rule("a", "warning", "failed")]),
+            report_url="https://ci/report.html",
+        )
+    )
+    assert "https://ci/report.html" in s["runs"][0]["results"][0]["message"]["markdown"]
+
+
+def test_location_defaults_to_dockerfile_and_is_overridable():
+    # GitHub Code Scanning rejects results without a location, so every result
+    # carries one, anchored at the Dockerfile by default (the artifact the image
+    # was built from) — overridable for repos that keep it elsewhere.
+    default = json.loads(render_sarif(_report([_rule("a", "warning", "failed")])))
+    loc = default["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+    assert loc["artifactLocation"]["uri"] == "Dockerfile"
+
+    custom = json.loads(
+        render_sarif(
+            _report([_rule("a", "warning", "failed")]), dockerfile="build/Dockerfile"
+        )
+    )
+    uri = custom["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]["uri"]
+    assert uri == "build/Dockerfile"
+
+
+def test_no_rules_yields_valid_empty_sarif():
+    s = json.loads(render_sarif(_report([])))
+    assert s["version"] == "2.1.0"
+    assert s["runs"][0]["results"] == []
+    assert s["runs"][0]["tool"]["driver"]["name"] == "Regis"

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -48,6 +48,52 @@ def test_resolve_rules_instantiates_template():
     assert resolved[0]["messages"]["pass"] == "fresh"
 
 
+def test_resolve_rules_stamps_criterion_name():
+    # A rule whose slug differs from the criterion it instantiates must remember
+    # which criterion it came from (needed to link to per-criterion docs).
+    templates = [
+        {
+            "provider": "cve",
+            "slug": "cve-count",
+            "description": "CVE count",
+            "params": {},
+            "condition": {"==": [1, 1]},
+            "messages": {"pass": "ok", "fail": "no"},
+        }
+    ]
+    declared = [
+        {
+            "provider": "cve",
+            "criterion": "cve-count",
+            "slug": "cve-critical",
+            "options": {},
+        }
+    ]
+    resolved = resolve_rules(templates, declared)
+    assert resolved[0]["slug"] == "cve-critical"
+    assert resolved[0]["criterion"] == "cve-count"
+
+
+def test_evaluate_rules_result_carries_criterion():
+    report = {
+        "request": {"analyzers": ["freshness"]},
+        "results": {"freshness": {"age_days": 10}},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "provider": "freshness",
+                "criterion": "age",
+                "slug": "my-age",
+                "options": {},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    rule = next(r for r in res["rules"] if r["slug"] == "my-age")
+    assert rule["criterion"] == "age"
+
+
 def test_resolve_rules_drops_unreferenced_templates():
     templates = [
         {"provider": "oci", "slug": "max-size", "condition": {"==": [1, 1]}},

--- a/tests/test_utils_report.py
+++ b/tests/test_utils_report.py
@@ -399,3 +399,39 @@ def test_render_and_save_reports_md_format(tmp_path):
     assert len(paths) == 1
     assert paths[0].suffix == ".md"
     assert paths[0].read_text(encoding="utf-8").startswith("#")
+
+
+def test_render_and_save_reports_sarif_format(tmp_path):
+    """render_and_save_reports with fmt=sarif writes a SARIF file (not raw report)."""
+    import json
+
+    from regis.utils.report import render_and_save_reports
+
+    report = {
+        "version": "0.37.0",
+        "request": {"registry": "r", "repository": "x", "tag": "t", "url": "x:t"},
+        "rules": [
+            {
+                "slug": "cve-critical",
+                "level": "critical",
+                "status": "failed",
+                "message": "boom",
+                "analyzers": ["cve"],
+                "criterion": "cve-count",
+            },
+        ],
+    }
+    paths = render_and_save_reports(
+        report,
+        formats=["sarif"],
+        output_template=str(tmp_path / "report.sarif"),
+        output_dir_template=".",
+        theme="default",
+        pretty=False,
+    )
+    assert len(paths) == 1
+    assert paths[0].suffix == ".sarif"
+    doc = json.loads(paths[0].read_text(encoding="utf-8"))
+    assert doc["version"] == "2.1.0"
+    assert doc["runs"][0]["tool"]["driver"]["name"] == "Regis"
+    assert [r["ruleId"] for r in doc["runs"][0]["results"]] == ["cve-critical"]


### PR DESCRIPTION
## Summary

`regis analyze --sarif` (and `regis evaluate --sarif`) now emit a SARIF 2.1.0 report of **playbook verdicts**, ready to upload to **GitHub Code Scanning** or any SARIF consumer. It's a low-friction adoption surface: a project's policy breaches show up directly in the Security tab and on PRs without standing up the dashboard.

Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level (so GitHub buckets it Critical/High/Low), a link back to the full Regis report, and a `helpUri` to the criterion's documentation.

## What it maps

- **Verdicts, not raw findings.** Each evaluated playbook rule → a `reportingDescriptor`; each breach → a `result`. The policy layer (your differentiation) is preserved instead of re-emitting what scanners already produce.
- **Severity:** `critical → error / 9.0`, `warning → warning / 7.0`, `info → note / 2.0` (SARIF `level` + numeric `security-severity`).
- **Stable fingerprints** keyed on `(rule, repo:tag)` — never the digest — so re-runs don't spam aggregators with "new" alerts.
- **Locations** anchored at the `Dockerfile` by default (GitHub Code Scanning rejects results without a location — verified against the live API).
- **Doc links:** the evaluator now stamps `criterion` onto each rule result, so each alert links to its per-criterion docs without the renderer duplicating the playbook's mapping.

## Implementation

- New renderer `regis/adapters/driven/report/sarif.py` (driven adapter, mirrors the relocated HTML renderer).
- Evaluator stamps `criterion` on rule results; documented as an optional field in the report/result JSON schemas.
- Wired as `--sarif` on `analyze` (normal + `--rerun` paths) and `evaluate`, via the existing report-output extension pattern.

## Verification

- TDD: 14 new tests (renderer mapping, fingerprint stability, criterion stamp, format dispatch, flag registration).
- Full suite **896 passed / 96.63%** (double gate), import-linter **layering KEPT**, ruff + trunk (mypy) clean.
- **End-to-end against GitHub Code Scanning**: uploaded a real `python:3.9-slim` report's SARIF → processing complete, **0 errors**; 7 verdicts rendered with correct severity buckets, Dockerfile anchors, and resolving criterion helpUris.

## Follow-ups (not in this PR)

- `regis-action` step to auto-upload `report.sarif` to Code Scanning (the turnkey adoption path).
- Optional `--sarif-dockerfile PATH` flag to point the anchor at a non-root Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
