### PR TITLE
fix(report): SARIF results carry kind=fail so houba reads verdicts as policy, not vulns

### DIFF
--- a/regis/adapters/driven/report/sarif.py
+++ b/regis/adapters/driven/report/sarif.py
@@ -88,6 +88,11 @@ def build_sarif(
         result: dict[str, Any] = {
             "ruleId": slug,
             "ruleIndex": index[slug],
+            # kind="fail" marks this as a governance verdict, not a vulnerability:
+            # houba keys on result.kind to bucket it under policy.* instead of
+            # vuln.*. ponytail: only breaches are emitted, so no "pass" branch
+            # (add kind="pass" + level="none" if passing checks ever become results).
+            "kind": "fail",
             "level": level,
             "message": {"text": text, "markdown": markdown},
             "partialFingerprints": {"regisRuleRepo/v1": _fingerprint(slug, req)},

--- a/tests/report/test_sarif.py
+++ b/tests/report/test_sarif.py
@@ -49,6 +49,25 @@ def test_emits_one_result_per_breach():
     assert [r["ruleId"] for r in s["runs"][0]["results"]] == ["a", "c"]
 
 
+def test_every_result_is_kind_fail():
+    # houba keys on result.kind to classify a verdict as a governance breach
+    # (policy.*) rather than a vulnerability (vuln.*); regis only emits breaches.
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("a", "critical", "failed"),
+                    _rule("b", "warning", "passed"),
+                    _rule("c", "info", "failed"),
+                ]
+            )
+        )
+    )
+    results = s["runs"][0]["results"]
+    assert results  # sanity: breaches present
+    assert all(r["kind"] == "fail" for r in results)
+
+
 def test_maps_severity_to_level_and_security_severity():
     s = json.loads(
         render_sarif(


### PR DESCRIPTION
## Summary

`regis analyze --sarif` now stamps `result.kind: "fail"` on every result it emits, so a SARIF consumer can tell a regis **governance verdict** apart from a **vulnerability finding**.

As of [houba#166](https://github.com/trivoallan/houba/pull/166), houba uses the standard SARIF `result.kind` as the discriminator — never the tool name. A result *with* a kind is a policy verdict (counted in `policy.*`); a result *without* one is a vulnerability (counted in `vuln.*`, what grype/trivy emit). The writer added in #789 emitted `security-severity` but no `kind`, so regis verdicts landed in the kind-less branch and were miscounted as CVEs — corrupting blast-radius queries and the `--fail-on vuln` gate. A regis policy breach is a verdict, not a CVE.

## What changed

- `regis/adapters/driven/report/sarif.py`: add `"kind": "fail"` to each result. The writer only emits failed rules (skips pass + incomplete), so every result is a breach.
- `properties.security-severity` and `properties.regis-level` are unchanged — houba reads `security-severity` to bucket the verdict by severity (`≥9.0 → policy.critical`, `≥7.0 → policy.high`, …).
- The `kind: "pass"` + `level: "none"` branch is **not** added: passing checks never become results today. A code comment records the upgrade path for when/if they do.

## Reviewer notes

- `"fail"` is a valid `result.kind` in SARIF 2.1.0, so the output still validates.
- The houba-side acceptance (`houba attach … --report regis.sarif.json` → `io.houba.scan.policy.*`, zero `vuln.*` from breaches) lives in the houba repo; the regis-side guarantee (every result has `kind: "fail"`) is covered by the new `test_every_result_is_kind_fail`.

Reference: houba `domain/scan/formats/sarif.py` (`_classify`), houba ADR 0039.