### PR TITLE
feat(report): emit a SARIF pass receipt so clean images read as governed

### DIFF
--- a/docs/website/docs/reference/cli.md
+++ b/docs/website/docs/reference/cli.md
@@ -37,7 +37,7 @@ _Output options:_
 - `--html`: Generate a self-contained single-file `report.html`.
 - `--sections all|summary|<slugs>`: Sections to include in the HTML report. Only applies to `--html`.
 - `--markdown`: Also emit a Markdown summary report (`report.md`).
-- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`) for upload to GitHub Code Scanning (or any SARIF consumer). Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level and a `helpUri` to the criterion's docs.
+- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`) for upload to GitHub Code Scanning (or any SARIF consumer). Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level and a `helpUri` to the criterion's docs. A clean run (rules evaluated, no breach) instead emits a single `kind: "pass"` receipt carrying the image digest, so "evaluated and clean" stays distinguishable from "never analyzed" — an empty run means the image was not governed.
 - `--pretty/--no-pretty`: Pretty-print the JSON output (default: on).
 
 _Evaluation options:_

--- a/regis/adapters/driven/report/sarif.py
+++ b/regis/adapters/driven/report/sarif.py
@@ -90,8 +90,8 @@ def build_sarif(
             "ruleIndex": index[slug],
             # kind="fail" marks this as a governance verdict, not a vulnerability:
             # houba keys on result.kind to bucket it under policy.* instead of
-            # vuln.*. ponytail: only breaches are emitted, so no "pass" branch
-            # (add kind="pass" + level="none" if passing checks ever become results).
+            # vuln.*. A clean run instead emits a single kind="pass" receipt
+            # below, so "evaluated & clean" is distinguishable from "never ran".
             "kind": "fail",
             "level": level,
             "message": {"text": text, "markdown": markdown},
@@ -116,6 +116,50 @@ def build_sarif(
                 }
             ]
         results.append(result)
+
+    # Positive coverage receipt. A clean run (rules evaluated, zero breaches)
+    # would otherwise be an empty SARIF run -- indistinguishable from "Regis
+    # never ran" once every breach counter reads zero. Emit one kind="pass"
+    # result, keyed to the digest, so a present run proves governance happened
+    # for this exact image. houba buckets on result.kind, so it surfaces as a
+    # policy pass with no consumer change. Skipped entirely when no rules were
+    # evaluated (truly not governed) or when breaches already prove the run.
+    if rules and not results:
+        receipt_index = len(descriptors)
+        descriptors.append(
+            {
+                "id": "regis-evaluated",
+                "name": "RegisEvaluated",
+                "shortDescription": {
+                    "text": "Image evaluated by Regis; no policy rule was breached."
+                },
+                "defaultConfiguration": {"level": "none"},
+            }
+        )
+        receipt: dict[str, Any] = {
+            "ruleId": "regis-evaluated",
+            "ruleIndex": receipt_index,
+            "kind": "pass",
+            "level": "none",
+            "message": {
+                "text": "Regis evaluated this image; no policy rule was breached."
+            },
+            "properties": {
+                "image": req.get("url"),
+                "digest": req.get("digest"),
+                "evaluated": len(rules),
+            },
+        }
+        if dockerfile:
+            receipt["locations"] = [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": dockerfile},
+                        "region": {"startLine": 1},
+                    }
+                }
+            ]
+        results.append(receipt)
 
     return {
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",

--- a/tests/report/test_sarif.py
+++ b/tests/report/test_sarif.py
@@ -195,7 +195,35 @@ def test_location_defaults_to_dockerfile_and_is_overridable():
 
 
 def test_no_rules_yields_valid_empty_sarif():
+    # No playbook ran -> not evaluated -> empty run (the "Regis never ran"
+    # signal). The pass receipt fires only when rules were actually evaluated.
     s = json.loads(render_sarif(_report([])))
     assert s["version"] == "2.1.0"
     assert s["runs"][0]["results"] == []
     assert s["runs"][0]["tool"]["driver"]["name"] == "Regis"
+
+
+def test_clean_run_emits_pass_receipt_keyed_to_digest():
+    # A clean run (rules evaluated, zero breaches) must NOT be an empty SARIF
+    # run -- that is indistinguishable from "Regis never ran". One kind="pass"
+    # result, carrying the digest, proves governance happened for this image.
+    s = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("a", "warning", "passed"),
+                    _rule("b", "info", "incomplete"),
+                ],
+                digest="sha256-CLEAN",
+            )
+        )
+    )
+    results = s["runs"][0]["results"]
+    assert len(results) == 1
+    receipt = results[0]
+    assert receipt["kind"] == "pass"
+    assert receipt["level"] == "none"
+    assert receipt["properties"]["digest"] == "sha256-CLEAN"
+    # self-consistent: the receipt's ruleIndex resolves to its descriptor
+    rules = s["runs"][0]["tool"]["driver"]["rules"]
+    assert rules[receipt["ruleIndex"]]["id"] == receipt["ruleId"]


### PR DESCRIPTION
## Summary

Regis-produced SARIF now distinguishes **evaluated and clean** from **never analyzed**. A clean image previously produced an empty SARIF run — byte-for-byte indistinguishable from an image Regis never scanned. Consumers that key on results (breaches) saw zero policy facts in both cases, so absence of a breach failed *open* (clean ⇒ governed) instead of *closed*.

A clean run now emits a single `kind: "pass"` receipt anchored at the `Dockerfile` and carrying the image **digest** in its properties. The contract becomes three-valued:

- **no Regis run** → not governed
- **run + `kind: "pass"` receipt** → governed & clean
- **run + `kind: "fail"` results** → governed, failing

## Why

The policy projection only ever emitted breaches, so `policy.passed` was structurally always `0` from Regis. By the counters alone, a clean image and an unscanned image had the same fingerprint (zero `policy.*` facts) — you could not tell *governance passed* from *governance absent*. For decoupled consumers (dashboards, Code Scanning read weeks later, Backstage), a CI job that silently failed to run Regis looked identical to all-green.

The coverage signal already existed in the SARIF run (`tool.driver.rules` is populated even when clean), but the consumer buckets on `result.kind` and a clean run has no results. The fix surfaces the positive verdict where the consumer actually reads it, without any consumer-side change.

## Scope / design notes

- **One** envelope receipt per clean run, not one pass-result per rule — avoids flooding consumers with green noise.
- Keyed to the **digest** so coverage is answerable per-image, not just per repo:tag.
- `level: "none"` ⇒ GitHub Code Scanning does not surface it as an alert.
- Emitted only when rules were evaluated and no breach was found; an empty-rules report (no playbook ran) stays an empty run — the genuine "not governed" signal.
- No core change: this is a pure SARIF-projection fix in the report adapter.

**Deliberately deferred:** the receipt does not yet carry the `playbook_hash`. "Ran against *which* playbook?" — a receipt against a trivial playbook is governed on paper, not in substance. Add when a consumer needs to distinguish that.

## Tests

- New `test_clean_run_emits_pass_receipt_keyed_to_digest`; clarified the empty-run test.
- `sarif.py` at 100% coverage; full suite **898 passed, 1 skipped**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)