### PR TITLE
feat(report): tamper-evident ruleset_hash on the SARIF pass receipt

### DIFF
--- a/docs/superpowers/specs/2026-06-24-playbook-ruleset-hash-design.md
+++ b/docs/superpowers/specs/2026-06-24-playbook-ruleset-hash-design.md
@@ -1,0 +1,148 @@
+# Empreinte de ruleset (`ruleset_hash`) — rendre le reçu SARIF tamper-evident
+
+> Suite directe de [#797](https://github.com/trivoallan/regis/pull/797) (reçu SARIF `kind:"pass"`
+> qui distingue « évalué & clean » de « jamais analysé »). Ce document fait autorité pour le
+> sous-chantier **`ruleset_hash`**.
+
+## 1. Contexte
+
+#797 a réglé l'ambiguïté *absence* (clean vs jamais-scanné) en émettant un reçu positif
+`kind:"pass"` keyé au digest. Reste une faille de **substance** : le reçu dit « gouverné »,
+pas « gouverné **contre quel** ruleset ». Un reçu obtenu contre un playbook trivial — ou contre
+un playbook trafiqué qui garde le même nom/version mais **desserre un seuil** (`cve-count.max`
+0 → 9999) — est gouverné sur le papier. Par l'identité seule (`slug`+`version`, déjà présente),
+c'est indétectable : l'identité est *gameable*.
+
+L'identité déclarative est insuffisante car le report ne porte **pas** les `options` des règles :
+l'entry d'issue est `{slug, description, level, tags, passed, status, message, analyzers,
+criterion}` ([`evaluator.py:424-436`](../../../regis/core/domain/rules/evaluator.py)), où
+`criterion` est le seul *nom* du template. Le seuil n'y figure jamais → hasher les rules d'issue
+n'attrape pas le tampering paramétrique.
+
+En revanche, la règle **résolue** qui est réellement évaluée porte sa `condition` (le JSON Logic
+avec le seuil baked-in, [`evaluator.py:382-400`](../../../regis/core/domain/rules/evaluator.py)).
+Hasher la `condition` défait le tampering paramétrique **par construction**.
+
+## 2. Décisions (tranchées au brainstorming, 2026-06-24)
+
+1. **Modèle de menace : tamper-evidence totale, seuils inclus** (pas seulement structurelle). Le
+   consommateur découplé doit pouvoir détecter « mêmes règles, seuils desserrés », pas seulement
+   « mauvais playbook ».
+2. **Hash du *ruleset résolu*, pas du fichier source.** Calculé sur ce qui a réellement mordu
+   (templates instanciés + règles activées), pas sur le YAML source — meilleur sémantiquement
+   (capture l'instanciation, ignore commentaires/whitespace) et placé dans le cœur (fait du
+   domaine), rendu par l'adaptateur.
+3. **Placement du calcul : cœur** (`core.domain.rules`), pas l'adaptateur SARIF. L'empreinte « ce
+   qui a été imposé » est un fait du domaine ; l'adaptateur ne fait que la *rendre*.
+4. **Surface : sur le reçu `kind:"pass"`** (donc cas clean uniquement). C'est exactement le
+   périmètre de la menace. Un run en échec n'a pas de reçu, mais ses breaches *sont* la preuve
+   d'un ruleset réel. Pin sur les runs en échec = **extension différée**.
+5. **Un hash par playbook** (les playbooks sont évalués indépendamment,
+   [`playbook_runner.py:64-107`](../../../regis/core/application/playbook_runner.py)) ; le reçu
+   surface celui du **primaire** (`playbooks[0]`). Pas de hash-merge multi-playbook spéculatif.
+
+## 3. Design
+
+### 3.1 Unité : `ruleset_fingerprint`
+
+Nouveau module pur `regis/core/domain/rules/fingerprint.py` :
+
+```python
+def ruleset_fingerprint(enabled_rules: list[dict[str, Any]]) -> str:
+    """Empreinte stable du ruleset résolu réellement imposé.
+
+    Tamper-evident : tout changement de ce qui mord (règle ajoutée/retirée,
+    sévérité modifiée, seuil desserré dans la condition) change le hash.
+    """
+```
+
+- **Input** : `enabled_rules` — les règles résolues **et activées** (`enable=False` déjà filtré,
+  [`evaluator.py:387`](../../../regis/core/domain/rules/evaluator.py)). Une règle désactivée
+  n'entre pas (correct : non imposée).
+- **Champs retenus par règle** : `{slug, level, condition}`. La `condition` (JSON Logic résolu)
+  porte le seuil. **Exclus** : `description`, `message`, `tags` (cosmétique/présentation/scoring —
+  ne changent pas le verdict pass/fail d'une règle).
+- **Canonicalisation** : règles triées par `slug` ; `json.dumps(payload, sort_keys=True,
+  separators=(",", ":"), ensure_ascii=False)` ; `sha256` du UTF-8.
+- **Sortie** : `"sha256:<hex64>"` (préfixe auto-descriptif, **non tronqué** — pin de sécurité).
+
+**Propriétés garanties (= tests) :** déterministe · indépendant de l'ordre des règles · *sensible
+au seuil* (changer une valeur de `condition` change le hash) · *insensible au cosmétique*
+(changer `description`/`message`/`tags` ne change pas le hash).
+
+### 3.2 Câblage / data flow
+
+1. `evaluate_rules` ([`evaluator.py:362`](../../../regis/core/domain/rules/evaluator.py)) calcule
+   `ruleset_hash = ruleset_fingerprint(enabled_rules)` après le filtre `enable`, et l'ajoute à son
+   `rules_results` retourné.
+2. Le `result` du playbook ([`evaluator.py:98-106`](../../../regis/core/domain/playbook/evaluator.py))
+   gagne `"ruleset_hash": rules_results["ruleset_hash"]`.
+3. Il remonte tel quel dans `report["playbook"]` / `report["playbooks"][i]` via `run_playbooks`
+   (aucune transformation requise).
+
+### 3.3 Surface SARIF
+
+`build_sarif` ([`sarif.py`](../../../regis/adapters/driven/report/sarif.py)) lit
+`report.get("playbook", {}).get("ruleset_hash")` et, **s'il est présent**, l'ajoute aux
+`properties` du reçu `kind:"pass"`, à côté de `digest` :
+
+```json
+"properties": { "image": "...", "digest": "sha256-...", "evaluated": 14,
+                "ruleset_hash": "sha256:9f2c..." }
+```
+
+Le consommateur épingle la valeur attendue : un playbook trafiqué → hash différent → reçu rejeté.
+
+### 3.4 Schéma
+
+- **Bump `REPORT_SCHEMA_VERSION` 5 → 6** ([`report.py:8`](../../../regis/core/model/report.py)).
+  Changement **additif** (champ optionnel) : un consommateur v5 parse encore un report v6 (champ
+  ignoré) ; exiger v6 permet de *se reposer* sur le hash.
+- Déclarer `ruleset_hash` (string optionnel, non `required`) sur l'objet playbook-result dans :
+  - `regis/schemas/playbook/result.schema.json` (validation de `regis playbook`),
+  - la section `playbook` / `playbooks` de `regis/schemas/report/report.schema.json`
+    (`report.schema.json` est `additionalProperties:false` au top-level — vérifier que la
+    sous-définition du playbook-result l'est aussi et y ajouter le champ).
+
+## 4. Gestion d'erreur
+
+- `condition` est un dict JSON Logic déjà validé par le schéma playbook → JSON-sérialisable par
+  construction. Pas de `try/except` autour du `json.dumps` (échouer fort = bug de schéma en amont).
+- `ruleset_hash` absent du report (reports legacy < v6, ou report sans playbook) → `build_sarif`
+  l'omet simplement (`.get` → `None` → propriété non émise). **Rétro-compatible**, aucune erreur.
+- Ruleset vide (`enabled_rules == []`) → pas de reçu émis de toute façon (#797 exige `rules`), donc
+  le hash d'un ruleset vide n'est jamais surfacé.
+
+## 5. Tests
+
+| Cible | Cas |
+| --- | --- |
+| `ruleset_fingerprint` | déterminisme ; ordre-indépendant ; **seuil → hash change** (le test qui prouve la menace défaite) ; cosmétique → hash stable ; format `sha256:` |
+| `evaluate_rules` / playbook result | le `result` porte `ruleset_hash` |
+| SARIF | reçu porte `ruleset_hash` issu de `report["playbook"]["ruleset_hash"]` ; **absent** quand pas dans le report (rétro-compat) |
+| Schéma | report v6 avec `ruleset_hash` valide ; `result.schema.json` valide |
+
+Gates : couverture par-fichier ≥ 90 % sur les fichiers touchés ; suite complète verte ; ruff clean.
+
+## 6. Hors périmètre / différé
+
+- **Pin sur les runs en échec** (porter `ruleset_hash` aussi sur les results `kind:"fail"` ou au
+  niveau `run.properties`). La menace stated est le cas *pass* ; les breaches prouvent déjà un
+  ruleset réel.
+- **Hash-merge multi-playbook** (une empreinte unique couvrant tous les playbooks). Per-playbook
+  suffit ; le reçu pin le primaire.
+- **Distribution d'une allowlist de hashes approuvés** côté consommateur (houba) — hors de ce repo.
+
+## 7. Fichiers touchés (indicatif)
+
+| Fichier | Changement |
+| --- | --- |
+| `regis/core/domain/rules/fingerprint.py` | **nouveau** — `ruleset_fingerprint` |
+| `regis/core/domain/rules/evaluator.py` | calcule + expose `ruleset_hash` dans `rules_results` |
+| `regis/core/domain/playbook/evaluator.py` | propage `ruleset_hash` dans le `result` |
+| `regis/core/model/report.py` | bump `REPORT_SCHEMA_VERSION` 5 → 6 |
+| `regis/schemas/playbook/result.schema.json` | champ optionnel `ruleset_hash` |
+| `regis/schemas/report/report.schema.json` | champ optionnel `ruleset_hash` (sous-déf playbook) |
+| `regis/adapters/driven/report/sarif.py` | rend `ruleset_hash` sur le reçu |
+| `tests/…` | cf. §5 |
+| `docs/website/docs/reference/cli.md` | mentionner le `ruleset_hash` du reçu |

--- a/docs/superpowers/specs/2026-06-24-playbook-ruleset-hash-design.md
+++ b/docs/superpowers/specs/2026-06-24-playbook-ruleset-hash-design.md
@@ -6,17 +6,17 @@
 
 ## 1. Contexte
 
-#797 a réglé l'ambiguïté *absence* (clean vs jamais-scanné) en émettant un reçu positif
+#797 a réglé l'ambiguïté _absence_ (clean vs jamais-scanné) en émettant un reçu positif
 `kind:"pass"` keyé au digest. Reste une faille de **substance** : le reçu dit « gouverné »,
 pas « gouverné **contre quel** ruleset ». Un reçu obtenu contre un playbook trivial — ou contre
 un playbook trafiqué qui garde le même nom/version mais **desserre un seuil** (`cve-count.max`
 0 → 9999) — est gouverné sur le papier. Par l'identité seule (`slug`+`version`, déjà présente),
-c'est indétectable : l'identité est *gameable*.
+c'est indétectable : l'identité est _gameable_.
 
 L'identité déclarative est insuffisante car le report ne porte **pas** les `options` des règles :
 l'entry d'issue est `{slug, description, level, tags, passed, status, message, analyzers,
 criterion}` ([`evaluator.py:424-436`](../../../regis/core/domain/rules/evaluator.py)), où
-`criterion` est le seul *nom* du template. Le seuil n'y figure jamais → hasher les rules d'issue
+`criterion` est le seul _nom_ du template. Le seuil n'y figure jamais → hasher les rules d'issue
 n'attrape pas le tampering paramétrique.
 
 En revanche, la règle **résolue** qui est réellement évaluée porte sa `condition` (le JSON Logic
@@ -28,14 +28,14 @@ Hasher la `condition` défait le tampering paramétrique **par construction**.
 1. **Modèle de menace : tamper-evidence totale, seuils inclus** (pas seulement structurelle). Le
    consommateur découplé doit pouvoir détecter « mêmes règles, seuils desserrés », pas seulement
    « mauvais playbook ».
-2. **Hash du *ruleset résolu*, pas du fichier source.** Calculé sur ce qui a réellement mordu
+2. **Hash du _ruleset résolu_, pas du fichier source.** Calculé sur ce qui a réellement mordu
    (templates instanciés + règles activées), pas sur le YAML source — meilleur sémantiquement
    (capture l'instanciation, ignore commentaires/whitespace) et placé dans le cœur (fait du
    domaine), rendu par l'adaptateur.
 3. **Placement du calcul : cœur** (`core.domain.rules`), pas l'adaptateur SARIF. L'empreinte « ce
-   qui a été imposé » est un fait du domaine ; l'adaptateur ne fait que la *rendre*.
+   qui a été imposé » est un fait du domaine ; l'adaptateur ne fait que la _rendre_.
 4. **Surface : sur le reçu `kind:"pass"`** (donc cas clean uniquement). C'est exactement le
-   périmètre de la menace. Un run en échec n'a pas de reçu, mais ses breaches *sont* la preuve
+   périmètre de la menace. Un run en échec n'a pas de reçu, mais ses breaches _sont_ la preuve
    d'un ruleset réel. Pin sur les runs en échec = **extension différée**.
 5. **Un hash par playbook** (les playbooks sont évalués indépendamment,
    [`playbook_runner.py:64-107`](../../../regis/core/application/playbook_runner.py)) ; le reçu
@@ -63,11 +63,11 @@ def ruleset_fingerprint(enabled_rules: list[dict[str, Any]]) -> str:
   porte le seuil. **Exclus** : `description`, `message`, `tags` (cosmétique/présentation/scoring —
   ne changent pas le verdict pass/fail d'une règle).
 - **Canonicalisation** : règles triées par `slug` ; `json.dumps(payload, sort_keys=True,
-  separators=(",", ":"), ensure_ascii=False)` ; `sha256` du UTF-8.
+separators=(",", ":"), ensure_ascii=False)` ; `sha256` du UTF-8.
 - **Sortie** : `"sha256:<hex64>"` (préfixe auto-descriptif, **non tronqué** — pin de sécurité).
 
-**Propriétés garanties (= tests) :** déterministe · indépendant de l'ordre des règles · *sensible
-au seuil* (changer une valeur de `condition` change le hash) · *insensible au cosmétique*
+**Propriétés garanties (= tests) :** déterministe · indépendant de l'ordre des règles · _sensible
+au seuil_ (changer une valeur de `condition` change le hash) · _insensible au cosmétique_
 (changer `description`/`message`/`tags` ne change pas le hash).
 
 ### 3.2 Câblage / data flow
@@ -93,41 +93,48 @@ au seuil* (changer une valeur de `condition` change le hash) · *insensible au c
 
 Le consommateur épingle la valeur attendue : un playbook trafiqué → hash différent → reçu rejeté.
 
-### 3.4 Schéma
+### 3.4 Schéma — **pas de bump de version**
 
-- **Bump `REPORT_SCHEMA_VERSION` 5 → 6** ([`report.py:8`](../../../regis/core/model/report.py)).
-  Changement **additif** (champ optionnel) : un consommateur v5 parse encore un report v6 (champ
-  ignoré) ; exiger v6 permet de *se reposer* sur le hash.
-- Déclarer `ruleset_hash` (string optionnel, non `required`) sur l'objet playbook-result dans :
-  - `regis/schemas/playbook/result.schema.json` (validation de `regis playbook`),
-  - la section `playbook` / `playbooks` de `regis/schemas/report/report.schema.json`
-    (`report.schema.json` est `additionalProperties:false` au top-level — vérifier que la
-    sous-définition du playbook-result l'est aussi et y ajouter le champ).
+`ruleset_hash` atterrit sur le playbook `result`, qui est la section **ouverte** du contrat :
+`result.schema.json` n'a **pas** d'`additionalProperties:false` top-level, donc le champ **valide
+additivement, sans aucune édition de schéma**. (L'enveloppe `report.schema.json` est scellée
+top-level, mais `playbooks`/`playbook` y sont des `$ref` vers `result.schema.json` — un seul
+schéma, ouvert.)
+
+- **Pas de bump `REPORT_SCHEMA_VERSION`.** Le sceau ne forcerait un bump _substantiel_ que si le
+  hash était un champ **top-level** scellé (un hash unique par run). Le choix « par-playbook dans
+  `result` » le rend additif silencieux. Le champ reste optionnel : la version ne _garantirait_ pas
+  sa présence de toute façon, le consommateur teste la présence.
+- Déclarer `ruleset_hash` (string optionnel, non `required`) dans `result.schema.json` —
+  **purement documentaire** (le contrat publié reste honnête), pas requis pour la validation.
 
 ## 4. Gestion d'erreur
 
 - `condition` est un dict JSON Logic déjà validé par le schéma playbook → JSON-sérialisable par
   construction. Pas de `try/except` autour du `json.dumps` (échouer fort = bug de schéma en amont).
-- `ruleset_hash` absent du report (reports legacy < v6, ou report sans playbook) → `build_sarif`
-  l'omet simplement (`.get` → `None` → propriété non émise). **Rétro-compatible**, aucune erreur.
+- `ruleset_hash` absent du report (report sans playbook, ou produit par un regis antérieur) →
+  `build_sarif` l'omet simplement (`.get` → `None` → propriété non émise). **Rétro-compatible**,
+  aucune erreur.
 - Ruleset vide (`enabled_rules == []`) → pas de reçu émis de toute façon (#797 exige `rules`), donc
   le hash d'un ruleset vide n'est jamais surfacé.
 
 ## 5. Tests
 
-| Cible | Cas |
-| --- | --- |
-| `ruleset_fingerprint` | déterminisme ; ordre-indépendant ; **seuil → hash change** (le test qui prouve la menace défaite) ; cosmétique → hash stable ; format `sha256:` |
-| `evaluate_rules` / playbook result | le `result` porte `ruleset_hash` |
-| SARIF | reçu porte `ruleset_hash` issu de `report["playbook"]["ruleset_hash"]` ; **absent** quand pas dans le report (rétro-compat) |
-| Schéma | report v6 avec `ruleset_hash` valide ; `result.schema.json` valide |
+| Cible                              | Cas                                                                                                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ruleset_fingerprint`              | déterminisme ; ordre-indépendant ; **seuil → hash change** (le test qui prouve la menace défaite) ; cosmétique → hash stable ; format `sha256:` |
+| `evaluate_rules` / playbook result | le `result` porte `ruleset_hash`                                                                                                                |
+| SARIF                              | reçu porte `ruleset_hash` issu de `report["playbook"]["ruleset_hash"]` ; **absent** quand pas dans le report (rétro-compat)                     |
+
+(Pas de test de schéma : l'ajout dans `result.schema.json` est documentaire — la section est
+ouverte, le champ valide avec ou sans déclaration, un test ne l'exercerait pas.)
 
 Gates : couverture par-fichier ≥ 90 % sur les fichiers touchés ; suite complète verte ; ruff clean.
 
 ## 6. Hors périmètre / différé
 
 - **Pin sur les runs en échec** (porter `ruleset_hash` aussi sur les results `kind:"fail"` ou au
-  niveau `run.properties`). La menace stated est le cas *pass* ; les breaches prouvent déjà un
+  niveau `run.properties`). La menace stated est le cas _pass_ ; les breaches prouvent déjà un
   ruleset réel.
 - **Hash-merge multi-playbook** (une empreinte unique couvrant tous les playbooks). Per-playbook
   suffit ; le reçu pin le primaire.
@@ -135,14 +142,12 @@ Gates : couverture par-fichier ≥ 90 % sur les fichiers touchés ; suite compl�
 
 ## 7. Fichiers touchés (indicatif)
 
-| Fichier | Changement |
-| --- | --- |
-| `regis/core/domain/rules/fingerprint.py` | **nouveau** — `ruleset_fingerprint` |
-| `regis/core/domain/rules/evaluator.py` | calcule + expose `ruleset_hash` dans `rules_results` |
-| `regis/core/domain/playbook/evaluator.py` | propage `ruleset_hash` dans le `result` |
-| `regis/core/model/report.py` | bump `REPORT_SCHEMA_VERSION` 5 → 6 |
-| `regis/schemas/playbook/result.schema.json` | champ optionnel `ruleset_hash` |
-| `regis/schemas/report/report.schema.json` | champ optionnel `ruleset_hash` (sous-déf playbook) |
-| `regis/adapters/driven/report/sarif.py` | rend `ruleset_hash` sur le reçu |
-| `tests/…` | cf. §5 |
-| `docs/website/docs/reference/cli.md` | mentionner le `ruleset_hash` du reçu |
+| Fichier                                     | Changement                                           |
+| ------------------------------------------- | ---------------------------------------------------- |
+| `regis/core/domain/rules/fingerprint.py`    | **nouveau** — `ruleset_fingerprint`                  |
+| `regis/core/domain/rules/evaluator.py`      | calcule + expose `ruleset_hash` dans `rules_results` |
+| `regis/core/domain/playbook/evaluator.py`   | propage `ruleset_hash` dans le `result`              |
+| `regis/schemas/playbook/result.schema.json` | champ optionnel `ruleset_hash` (documentaire)        |
+| `regis/adapters/driven/report/sarif.py`     | rend `ruleset_hash` sur le reçu                      |
+| `tests/…`                                   | cf. §5                                               |
+| `docs/website/docs/reference/cli.md`        | mentionner le `ruleset_hash` du reçu                 |

--- a/docs/website/docs/reference/cli.md
+++ b/docs/website/docs/reference/cli.md
@@ -37,7 +37,7 @@ _Output options:_
 - `--html`: Generate a self-contained single-file `report.html`.
 - `--sections all|summary|<slugs>`: Sections to include in the HTML report. Only applies to `--html`.
 - `--markdown`: Also emit a Markdown summary report (`report.md`).
-- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`) for upload to GitHub Code Scanning (or any SARIF consumer). Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level and a `helpUri` to the criterion's docs. A clean run (rules evaluated, no breach) instead emits a single `kind: "pass"` receipt carrying the image digest, so "evaluated and clean" stays distinguishable from "never analyzed" — an empty run means the image was not governed.
+- `--sarif`: Also emit a SARIF report of playbook verdicts (`report.sarif`) for upload to GitHub Code Scanning (or any SARIF consumer). Each breached rule becomes a SARIF result anchored at the `Dockerfile`, with a `security-severity` mapped from the rule level and a `helpUri` to the criterion's docs. A clean run (rules evaluated, no breach) instead emits a single `kind: "pass"` receipt carrying the image digest, so "evaluated and clean" stays distinguishable from "never analyzed" — an empty run means the image was not governed. The receipt also carries a `ruleset_hash` — a tamper-evident `sha256` fingerprint of the resolved, enforced ruleset (thresholds included) — so a consumer can pin the expected playbook and reject a receipt produced against a loosened or swapped one.
 - `--pretty/--no-pretty`: Pretty-print the JSON output (default: on).
 
 _Evaluation options:_

--- a/regis/adapters/driven/report/sarif.py
+++ b/regis/adapters/driven/report/sarif.py
@@ -136,6 +136,17 @@ def build_sarif(
                 "defaultConfiguration": {"level": "none"},
             }
         )
+        receipt_properties: dict[str, Any] = {
+            "image": req.get("url"),
+            "digest": req.get("digest"),
+            "evaluated": len(rules),
+        }
+        # Tamper-evident pin of the resolved ruleset: lets a consumer reject a
+        # receipt produced against a loosened or swapped playbook. Omitted when
+        # the report predates this field (backward compatible).
+        ruleset_hash = (report.get("playbook") or {}).get("ruleset_hash")
+        if ruleset_hash:
+            receipt_properties["ruleset_hash"] = ruleset_hash
         receipt: dict[str, Any] = {
             "ruleId": "regis-evaluated",
             "ruleIndex": receipt_index,
@@ -144,11 +155,7 @@ def build_sarif(
             "message": {
                 "text": "Regis evaluated this image; no policy rule was breached."
             },
-            "properties": {
-                "image": req.get("url"),
-                "digest": req.get("digest"),
-                "evaluated": len(rules),
-            },
+            "properties": receipt_properties,
         }
         if dockerfile:
             receipt["locations"] = [

--- a/regis/core/domain/playbook/evaluator.py
+++ b/regis/core/domain/playbook/evaluator.py
@@ -103,6 +103,7 @@ def evaluate(
         "rules": report["rules"],
         "rules_summary": report["rules_summary"],
         "slug": playbook.get("slug"),
+        "ruleset_hash": rules_results["ruleset_hash"],
     }
 
     # Build the full context that includes the evaluation result itself (for badges

--- a/regis/core/domain/rules/evaluator.py
+++ b/regis/core/domain/rules/evaluator.py
@@ -11,6 +11,7 @@ import json_logic
 from json_logic import jsonLogic
 
 from regis.core.domain.playbook.context import MissingDataTracker, _build_context
+from regis.core.domain.rules.fingerprint import ruleset_fingerprint
 from regis.utils.predicates import is_empty, is_falsy, is_truthy, is_url, matches
 
 logger = logging.getLogger(__name__)
@@ -485,4 +486,5 @@ def evaluate_rules(
         "passed_rules": passed_rule_slugs,
         "by_tag": by_tag,
         "rules": results,
+        "ruleset_hash": ruleset_fingerprint(enabled_rules),
     }

--- a/regis/core/domain/rules/fingerprint.py
+++ b/regis/core/domain/rules/fingerprint.py
@@ -1,0 +1,29 @@
+"""Stable, tamper-evident fingerprint of the resolved, enforced ruleset."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def ruleset_fingerprint(enabled_rules: list[dict[str, Any]]) -> str:
+    """Return a stable hash of what the ruleset actually enforces.
+
+    Keys on ``slug``, ``level``, and the resolved JSON Logic ``condition``
+    (thresholds baked in), so loosening a threshold changes the hash. Cosmetic
+    fields (description, message, tags) are excluded. Rules are sorted by slug so
+    declaration order does not affect the result.
+    """
+    canonical = [
+        {
+            "slug": r.get("slug", ""),
+            "level": r.get("level", "info"),
+            "condition": r.get("condition", {}),
+        }
+        for r in sorted(enabled_rules, key=lambda r: r.get("slug", ""))
+    ]
+    blob = json.dumps(
+        canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return "sha256:" + hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/regis/schemas/playbook/result.schema.json
+++ b/regis/schemas/playbook/result.schema.json
@@ -15,6 +15,10 @@
       "type": ["string", "null"],
       "description": "SemVer of the playbook that produced this report."
     },
+    "ruleset_hash": {
+      "type": "string",
+      "description": "Tamper-evident sha256 fingerprint of the resolved, enforced ruleset (sha256:<hex>)."
+    },
     "api_version": {
       "type": ["string", "null"],
       "description": "apiVersion of the playbook that produced this result (e.g. \"regis.io/v1alpha1\")."

--- a/tests/commands/test_playbook_migrate.py
+++ b/tests/commands/test_playbook_migrate.py
@@ -219,7 +219,12 @@ def test_migrate_playbook_data_renames_key_and_refs() -> None:
 
 
 def test_migration_preserves_evaluation(tmp_path: Path) -> None:
-    """Pre- and post-migration playbooks evaluate to an IDENTICAL report."""
+    """Pre- and post-migration playbooks evaluate to identical verdicts.
+
+    The ``ruleset_hash`` fingerprint differs by design: migration rewrites
+    ``rule.``->``criterion.`` inside conditions, changing the resolved ruleset's
+    representation, not its enforcement.
+    """
     pb = _write(tmp_path, _LEGACY_PLAYBOOK)
 
     before = yaml.safe_load(pb.read_text(encoding="utf-8"))
@@ -231,6 +236,10 @@ def test_migration_preserves_evaluation(tmp_path: Path) -> None:
     after = yaml.safe_load(pb.read_text(encoding="utf-8"))
     res_after = evaluate_rules(_SAMPLE_REPORT, {"rules": after["spec"]["rules"]})
 
+    # ruleset_hash pins the resolved condition representation, which migration
+    # rewrites (`rule.`->`criterion.`); verdicts are what must be preserved.
+    res_after.pop("ruleset_hash", None)
+    res_before.pop("ruleset_hash", None)
     assert res_after == res_before
 
 
@@ -240,7 +249,8 @@ def test_migration_silences_deprecation_warning(tmp_path: Path) -> None:
     BEFORE migration the legacy ``rule:`` template-reference key makes the
     engine emit a ``DeprecationWarning`` on every evaluation; AFTER running
     ``migrate`` the migrated playbook evaluates with ZERO deprecation warnings,
-    while producing a byte-identical report.
+    while producing identical verdicts (the ``ruleset_hash`` fingerprint differs
+    by design — migration rewrites conditions).
     """
     pb = _write(tmp_path, _LEGACY_PLAYBOOK)
     before = yaml.safe_load(pb.read_text(encoding="utf-8"))
@@ -259,7 +269,10 @@ def test_migration_silences_deprecation_warning(tmp_path: Path) -> None:
         warnings.simplefilter("error", DeprecationWarning)
         res_after = evaluate_rules(_SAMPLE_REPORT, {"rules": after["spec"]["rules"]})
 
-    # The whole point of the dual-bind migration: identical report.
+    # The whole point of the dual-bind migration: identical verdicts. The
+    # ruleset_hash fingerprint legitimately differs (conditions were rewritten).
+    res_after.pop("ruleset_hash", None)
+    res_before.pop("ruleset_hash", None)
     assert res_after == res_before
 
 

--- a/tests/report/test_sarif.py
+++ b/tests/report/test_sarif.py
@@ -227,3 +227,18 @@ def test_clean_run_emits_pass_receipt_keyed_to_digest():
     # self-consistent: the receipt's ruleIndex resolves to its descriptor
     rules = s["runs"][0]["tool"]["driver"]["rules"]
     assert rules[receipt["ruleIndex"]]["id"] == receipt["ruleId"]
+
+
+def test_clean_receipt_carries_ruleset_hash_when_present():
+    rpt = _report([_rule("a", "warning", "passed")])
+    rpt["playbook"] = {"ruleset_hash": "sha256:abc123"}
+    s = json.loads(render_sarif(rpt))
+    receipt = s["runs"][0]["results"][0]
+    assert receipt["properties"]["ruleset_hash"] == "sha256:abc123"
+
+
+def test_clean_receipt_omits_ruleset_hash_when_absent():
+    # No playbook block -> no ruleset_hash property (backward compatible).
+    s = json.loads(render_sarif(_report([_rule("a", "warning", "passed")])))
+    receipt = s["runs"][0]["results"][0]
+    assert "ruleset_hash" not in receipt["properties"]

--- a/tests/test_playbook_evaluator.py
+++ b/tests/test_playbook_evaluator.py
@@ -206,3 +206,21 @@ def test_evaluate_source_name_set():
     """source_name parameter populates _meta in the result (line 300)."""
     out = evaluate({"name": "x"}, {}, source_name="my-playbook.yaml")
     assert out["_meta"] == {"source_name": "my-playbook.yaml"}
+
+
+def test_evaluate_result_carries_ruleset_hash():
+    report = {
+        "request": {"analyzers": ["freshness"]},
+        "results": {"freshness": {"age_days": 10}},
+    }
+    playbook = {
+        "name": "p",
+        "rules": [
+            {
+                "slug": "freshness.age",
+                "condition": {"<": [{"var": "results.freshness.age_days"}, 30]},
+            }
+        ],
+    }
+    result = evaluate(playbook, report)
+    assert result["ruleset_hash"].startswith("sha256:")

--- a/tests/test_rules_evaluator.py
+++ b/tests/test_rules_evaluator.py
@@ -670,3 +670,20 @@ def test_evaluate_rules_condition_exception_marks_failed():
     bad = next(r for r in res["rules"] if r["slug"] == "bad-op")
     assert bad["passed"] is False
     assert bad["status"] == "failed"
+
+
+def test_evaluate_rules_returns_ruleset_hash():
+    report = {
+        "request": {"analyzers": ["freshness"]},
+        "results": {"freshness": {"age_days": 10}},
+    }
+    rules_def = {
+        "rules": [
+            {
+                "slug": "freshness.age",
+                "condition": {"<": [{"var": "results.freshness.age_days"}, 30]},
+            }
+        ]
+    }
+    res = evaluate_rules(report, rules_def)
+    assert res["ruleset_hash"].startswith("sha256:")

--- a/tests/test_ruleset_fingerprint.py
+++ b/tests/test_ruleset_fingerprint.py
@@ -1,0 +1,49 @@
+"""Unit tests for the resolved-ruleset fingerprint."""
+
+from regis.core.domain.rules.fingerprint import ruleset_fingerprint
+
+
+def _rule(slug, level="critical", condition=None, **extra):
+    return {
+        "slug": slug,
+        "level": level,
+        "condition": condition if condition is not None else {">": [{"var": "x"}, 0]},
+        **extra,
+    }
+
+
+def test_deterministic():
+    rules = [_rule("a"), _rule("b")]
+    assert ruleset_fingerprint(rules) == ruleset_fingerprint(rules)
+
+
+def test_order_independent():
+    a, b = _rule("a"), _rule("b")
+    assert ruleset_fingerprint([a, b]) == ruleset_fingerprint([b, a])
+
+
+def test_threshold_change_changes_hash():
+    # The core guarantee: loosening a threshold inside the condition changes the hash.
+    loose = ruleset_fingerprint([_rule("cve", condition={"<=": [{"var": "n"}, 9999]})])
+    strict = ruleset_fingerprint([_rule("cve", condition={"<=": [{"var": "n"}, 0]})])
+    assert loose != strict
+
+
+def test_severity_change_changes_hash():
+    crit = ruleset_fingerprint([_rule("a", level="critical")])
+    info = ruleset_fingerprint([_rule("a", level="info")])
+    assert crit != info
+
+
+def test_cosmetic_change_is_stable():
+    bare = ruleset_fingerprint([_rule("a")])
+    decorated = ruleset_fingerprint(
+        [_rule("a", description="x", message="y", tags=["t"])]
+    )
+    assert bare == decorated
+
+
+def test_format_is_prefixed_sha256():
+    h = ruleset_fingerprint([_rule("a")])
+    assert h.startswith("sha256:")
+    assert len(h) == len("sha256:") + 64


### PR DESCRIPTION
## Summary

The SARIF `kind:"pass"` receipt (from #797) now carries a **`ruleset_hash`** — a tamper-evident `sha256` fingerprint of the resolved, enforced ruleset, keyed alongside the image digest. A clean receipt no longer just proves *governance happened*; it proves *which ruleset* governed. A consumer can pin the expected hash and reject a receipt produced against a **trivial, loosened, or swapped** playbook — "governed on paper" becomes detectable.

The fingerprint hashes each enabled rule's `{slug, level, condition}`. Because the resolved JSON Logic `condition` carries thresholds baked in, **loosening a threshold** (e.g. `cve-count.max` 0 → 9999) changes the hash even when the rule slug and severity are unchanged. Cosmetic fields (description, message, tags) are excluded, so they don't perturb it.

## Why

#797 closed the *absence* gap (clean vs never-scanned). This closes the *substance* gap: identity alone (`slug`+`version`) is gameable — a trivial playbook can call itself `prod-security-v2`. A content fingerprint of what actually bit is the only thing that defeats it.

## Design notes

- **Computed in the core** (`core.domain.rules`), a pure function; the SARIF adapter only renders it. The "what was enforced" fingerprint is a domain fact.
- **No schema version bump.** `ruleset_hash` lands on the playbook `result`, the *open* section of the contract (`result.schema.json` has no top-level `additionalProperties:false`), so it validates additively. The schema property-add is documentary.
- **One hash per playbook**; the receipt surfaces the primary (`playbooks[0]`). Backward compatible — the property is omitted when the report has no playbook.
- **Known property:** a `regis playbook migrate` (or any condition rewrite) changes the hash even when verdicts are preserved — the hash pins the resolved *representation*, not semantic equivalence. The two `test_playbook_migrate` tests were updated to assert verdict preservation (hash excluded); this is the intended behavior, not a regression.

## Deferred (per spec §6)

Pinning on failing runs, multi-playbook hash-merge, and consumer-side allowlist distribution.

## Tests

New `tests/test_ruleset_fingerprint.py` (determinism · order-independence · **threshold → hash changes** · cosmetic-stable · format) plus wiring/surface tests. Full suite **908 passed, 1 skipped**, coverage 96.64% (per-file gate green), ruff clean.

Builds on #797 (merged). Design spec: `docs/superpowers/specs/2026-06-24-playbook-ruleset-hash-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)