### PR TITLE
fix(registry): handle digest-pinned image references

### DIFF
--- a/regis/adapters/driven/registry/parser.py
+++ b/regis/adapters/driven/registry/parser.py
@@ -128,7 +128,15 @@ def _parse_bare_reference(ref: str) -> RegistryRef:
 
 
 def _split_tag(ref: str) -> tuple[str, str]:
-    """Split ``repo:tag`` into a ``(repo, tag)`` tuple."""
+    """Split ``repo:tag`` or ``repo@digest`` into a ``(repo, reference)`` tuple.
+
+    A digest (``repo@sha256:hex``) is returned intact — prefix included — so
+    downstream reference builders use the ``@`` separator. Splitting on ``:``
+    here would corrupt the digest's internal ``sha256:`` colon.
+    """
+    if "@" in ref:
+        repo, digest = ref.split("@", 1)
+        return repo, digest
     if ":" in ref:
         repo, tag = ref.rsplit(":", 1)
         return repo, tag

--- a/regis/adapters/driven/tools/subprocess_tool_runner.py
+++ b/regis/adapters/driven/tools/subprocess_tool_runner.py
@@ -33,7 +33,9 @@ class SubprocessToolRunner(ToolRunner):
 
     @staticmethod
     def _full_ref(image: ImageReference) -> str:
-        return f"{image.registry}/{image.repository}:{image.tag}"
+        # Digests join with ``@``, tags with ``:`` (mirrors regctl.image_ref).
+        separator = "@" if image.tag.startswith("sha256:") else ":"
+        return f"{image.registry}/{image.repository}{separator}{image.tag}"
 
     def scan_vulnerabilities(self, image: ImageReference) -> dict[str, Any]:
         return run_grype(

--- a/tests/adapters/test_subprocess_tool_runner.py
+++ b/tests/adapters/test_subprocess_tool_runner.py
@@ -19,6 +19,24 @@ def test_is_a_tool_runner() -> None:
     assert isinstance(SubprocessToolRunner(), ToolRunner)
 
 
+def test_full_ref_uses_at_separator_for_digest(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_grype(image, username, password, platform):
+        captured["image"] = image
+        return {"matches": []}
+
+    monkeypatch.setattr(mod, "run_grype", fake_run_grype)
+    digest_image = ImageReference(
+        registry="docker.io",
+        repository="library/nginx",
+        tag="sha256:" + "a" * 64,
+        platform="linux/amd64",
+    )
+    SubprocessToolRunner().scan_vulnerabilities(digest_image)
+    assert captured["image"] == f"docker.io/library/nginx@sha256:{'a' * 64}"
+
+
 def test_scan_vulnerabilities_delegates_to_grype(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,6 +51,20 @@ class TestParseBareReferences:
         assert ref == RegistryRef("myregistry.example.com", "org/image", "v1.0")
 
 
+class TestParseDigestReferences:
+    """Digest-pinned references keep the ``sha256:`` prefix intact as the tag."""
+
+    DIGEST = "sha256:" + "a" * 64
+
+    def test_bare_digest_reference(self):
+        ref = parse_image_url(f"ghcr.io/trivoallan/regis@{self.DIGEST}")
+        assert ref == RegistryRef("ghcr.io", "trivoallan/regis", self.DIGEST)
+
+    def test_dockerhub_digest_reference(self):
+        ref = parse_image_url(f"nginx@{self.DIGEST}")
+        assert ref == RegistryRef("registry-1.docker.io", "library/nginx", self.DIGEST)
+
+
 class TestRegistryRef:
     """Test RegistryRef properties."""
 


### PR DESCRIPTION
## Summary

Digest-pinned image references (`repo@sha256:hex`) were misparsed at the registry boundary, causing internal analyzer failures that only partly surfaced — enough analyzers still passed to emit verdicts, masking the breakage.

`_split_tag` did a naive `rsplit(":", 1)`, which cut the digest's internal `sha256:` colon:

| Input | `repository` (corrupted) | `tag` (corrupted) |
|---|---|---|
| `ghcr.io/org/img@sha256:DIGEST` | `org/img@sha256` | `DIGEST` (bare hex, prefix lost) |

Every reference rebuilt from that corrupted identity was malformed:

- **versioning** ran `tag ls …/img@sha256` on an invalid repository → failure.
- **hadolint** (multi-arch images) fed a resolved platform digest `sha256:NEW` back through `image_ref` over a repo already ending in `@sha256` → `…@sha256@sha256:NEW`, the reported double digest.
- **scanners passed by accident**: `_full_ref` hardcoded `:`, recombining `…@sha256` + `:hex` into a valid-looking digest ref — which is why verdicts were still emitted.

## Fix

Two layers that had drifted from the correct `image_ref` separator pattern (`@` for digests, `:` for tags):

1. **Root cause** — `_split_tag` (`registry/parser.py`) now recognizes the `@digest` suffix and keeps the `sha256:` prefix intact as the tag, so reference builders use `@`.
2. **Unmasked second layer** — `SubprocessToolRunner._full_ref` is now digest-aware, mirroring `image_ref` instead of hardcoding `:`.

## Notes for reviewers

- Scope kept minimal: not deduplicated against `regis.utils.regctl.image_ref` because that helper also normalizes `registry-1.docker.io → docker.io`, so reusing it would bundle a scanner-behavior change into a bugfix.
- Out of scope (rare, not reported): the combined `repo:tag@digest` form and registry-with-port-without-tag (a pre-existing latent split issue).

## Testing

- New failing-first tests: `TestParseDigestReferences` (bare + Docker Hub digest refs) and `_full_ref` digest separator.
- Full suite: 901 passed, 1 skipped, coverage 96.63% (double gate green), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)