### PR TITLE
feat(ci): publish multi-arch container images including linux/arm64

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -89,6 +92,7 @@ jobs:
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-tools-fetch-smoke.yml
+++ b/.github/workflows/ci-tools-fetch-smoke.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build slim image
@@ -36,6 +39,17 @@ jobs:
             VARIANT=slim
           cache-from: type=gha,scope=slim-smoke
           cache-to: type=gha,mode=max,scope=slim-smoke
+
+      - name: Build slim image for arm64 (guard, build-only)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          build-args: |
+            VARIANT=slim
+          cache-from: type=gha,scope=slim-arm64
+          cache-to: type=gha,mode=max,scope=slim-arm64
 
       - name: Cache empty -> check
         run: |


### PR DESCRIPTION
## Summary

- `ghcr.io/trivoallan/regis` now publishes a multi-arch manifest list — `linux/arm64` alongside `linux/amd64` — so Apple Silicon developers and arm64 CI runners (e.g. AWS Graviton) pull a native image instead of running the amd64 build under emulation.
- The Dockerfile was already architecture-aware (every fetched tool — grype, syft, trufflehog, hadolint, dockle, regctl — branches on `TARGETARCH`, and the Python runtime resolves to `musllinux` aarch64 wheels with no compilation). This change just sets `platforms:` on the publish step.
- Adds a CI guard that builds the arm64 image on every PR (`ci-tools-fetch-smoke.yml`), so the arm64 path can no longer regress silently and only surface at publish time.

## Test Plan

- [x] Local two-platform build passes for both variants: `docker buildx build --platform linux/amd64,linux/arm64 --build-arg VARIANT={slim,full} --output type=cacheonly .`
- [x] Both workflow files parse as valid YAML; Trunk/actionlint pre-commit hook clean.
- [ ] After merge/publish: `docker buildx imagetools inspect ghcr.io/trivoallan/regis:latest` lists both `linux/amd64` and `linux/arm64`.
- [ ] `docker run --rm --platform linux/arm64 ghcr.io/trivoallan/regis:latest --help` runs the native arm64 image.

### Known follow-ups (non-blocking)

- Published SBOMs describe `linux/amd64` only (anchore/sbom-action scans the index's default platform).
- The image-size badge stays amd64-based (measured on the runner's host arch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)