### PR TITLE
test(report): pin houba SARIF ingestion-profile contract

### DIFF
--- a/tests/report/test_sarif.py
+++ b/tests/report/test_sarif.py
@@ -242,3 +242,55 @@ def test_clean_receipt_omits_ruleset_hash_when_absent():
     s = json.loads(render_sarif(_report([_rule("a", "warning", "passed")])))
     receipt = s["runs"][0]["results"][0]
     assert "ruleset_hash" not in receipt["properties"]
+
+
+# --- houba SARIF ingestion-profile contract (cross-repo drift insurance) ---
+# regis emits; the sibling repo houba (trivoallan/houba) ingests per its
+# docs/reference/sarif-ingestion-profile.md (houba ADR 0039). houba keys on the
+# STANDARD SARIF result.kind, never on tool name: kind absent -> vuln.*, kind
+# present -> policy.* (pass -> policy.passed, else policy.<severity> bucketed by
+# security-severity). The two repos version separately, so this pins the
+# invariants houba depends on -- a regis emitter change that breaks policy
+# bucketing fails here instead of silently inflating houba's vuln.* counts.
+
+
+def _houba_bucket(security_severity: str) -> str:
+    """houba's documented CVSS bands: >=9.0 critical, >=7.0 high, >=4.0 medium, else low."""
+    score = float(security_severity)
+    if score >= 9.0:
+        return "critical"
+    if score >= 7.0:
+        return "high"
+    if score >= 4.0:
+        return "medium"
+    return "low"
+
+
+def test_houba_ingestion_profile_contract():
+    # (1) Every emitted result -- breach run and clean run alike -- carries a kind
+    #     houba understands, so a regis verdict NEVER lands in houba's vuln.* space.
+    breaches = json.loads(
+        render_sarif(
+            _report(
+                [
+                    _rule("crit", "critical", "failed"),
+                    _rule("warn", "warning", "failed"),
+                    _rule("note", "info", "failed"),
+                    _rule("ok", "warning", "passed"),
+                ]
+            )
+        )
+    )["runs"][0]["results"]
+    clean = json.loads(render_sarif(_report([_rule("ok", "warning", "passed")])))[
+        "runs"
+    ][0]["results"]
+    assert breaches and clean
+    assert all(r.get("kind") in {"pass", "fail"} for r in breaches + clean)
+    assert [r["kind"] for r in clean] == ["pass"]  # clean -> single policy.passed
+
+    # (2) Every breach carries a security-severity that lands in houba's documented
+    #     bucket -- pins regis' numbers to houba's CVSS thresholds on both sides.
+    by_id = {r["ruleId"]: r for r in breaches}
+    assert _houba_bucket(by_id["crit"]["properties"]["security-severity"]) == "critical"
+    assert _houba_bucket(by_id["warn"]["properties"]["security-severity"]) == "high"
+    assert _houba_bucket(by_id["note"]["properties"]["security-severity"]) == "low"


### PR DESCRIPTION
## Summary

Adds a cross-repo contract test locking the SARIF invariants the sibling repo [`houba`](https://github.com/trivoallan/houba) depends on when it ingests Regis verdicts. **No source change** — Regis's SARIF emitter already conforms (#789/#791/#798); this is drift insurance.

## Why

Regis emits playbook verdicts as SARIF; houba ingests them per its frozen [SARIF ingestion profile](https://github.com/trivoallan/houba/blob/main/docs/reference/sarif-ingestion-profile.md) (houba ADR 0039). houba keys on the **standard** `result.kind`, never on the tool name:

- `kind` present → governance verdict → `policy.*` (`pass` → `policy.passed`, else `policy.<severity>`)
- `kind` absent → vulnerability finding → `vuln.*`

The two repos version independently, so a future change to Regis's emitter (e.g. the `level → security-severity` mapping, or dropping `kind`) could **silently** break policy bucketing on the houba side — a regression no existing test catches holistically.

## What changed

`tests/report/test_sarif.py` gains `test_houba_ingestion_profile_contract`, encoding the cross-repo invariants as a named contract:

1. **Every emitted result carries a `kind` houba understands** — across a breach run *and* a clean run — so a Regis verdict never lands in houba's `vuln.*` space.
2. **Each breach's `security-severity` lands in houba's documented CVSS bucket** (≥9.0 critical, ≥7.0 high, <4.0 low) — pinning Regis's numbers to houba's thresholds on both sides.

Reuses the file's existing `_rule`/`_report` helpers; no new fixtures, no source change.

## Reviewer notes

- Surfaced by a `/plan-ceo-review` (HOLD) of the e.SNCF observe-first rollout: the rollout collapsed onto houba's front door, and the only Regis-side work left was this drift insurance. The contract itself is frozen on the houba side (ADR 0039), so this test pins the producing end.
- `tests/` is excluded from coverage measurement; the emitter (`regis/adapters/driven/report/sarif.py`) is already covered.

## Test

```
uv run pytest tests/report/test_sarif.py --no-cov -q
14 passed in 0.03s
```
ruff format + check: clean.