### PR TITLE
fix(cli): make --fail-level behave identically across analyze and evaluate

### DIFF
--- a/regis/adapters/driving/cli/commands/analyze.py
+++ b/regis/adapters/driving/cli/commands/analyze.py
@@ -22,6 +22,7 @@ from regis.adapters.driven.report.presentation_renderer import (
 from regis.adapters.driving.cli.composition import build_analyze_image, build_evaluate
 from regis.core.application.analyze_image import AnalyzerOutcome
 from regis.core.domain.analyzers.base import BaseAnalyzer
+from regis.core.domain.rules.breach import breached_slugs
 from regis.core.model.image_reference import ImageReference
 from regis.core.model.report import Report
 from regis.utils.report import (
@@ -475,18 +476,7 @@ def analyze(
         )
         _render_verdict_block(final_report, quiet=quiet)
         if evaluate and fail:
-            level_order = {"critical": 1, "warning": 2, "info": 3}
-            threshold = level_order.get(fail_level.lower())
-            breached = (
-                [
-                    r.get("slug", "unknown")
-                    for r in final_report.get("rules", [])
-                    if not r.get("passed", False)
-                    and level_order.get(r.get("level", "info").lower(), 3) <= threshold
-                ]
-                if threshold is not None
-                else []
-            )
+            breached = breached_slugs(final_report.get("rules", []), fail_level)
             if breached:
                 click.echo(
                     f"\nError: Analysis failed due to {len(breached)} rule breaches "

--- a/regis/adapters/driving/cli/commands/rules.py
+++ b/regis/adapters/driving/cli/commands/rules.py
@@ -10,6 +10,7 @@ from typing import Any
 import click
 
 from regis.core.domain.analyzers.discovery import discover_analyzers
+from regis.core.domain.rules.breach import breached_slugs
 
 
 def _render_rule_markdown(rule: dict[str, Any]) -> str:
@@ -390,16 +391,7 @@ def eval_rules(
             click.echo(f"{icon} [{r['slug']}] {r['message']}")
 
     if fail:
-        level_order = {"critical": 1, "warning": 2, "info": 3, "none": 4}
-        threshold = level_order.get(fail_level.lower(), 1)
-
-        breaches = []
-        for r in result["rules"]:
-            if not r["passed"]:
-                rule_level = r.get("level", "info").lower()
-                if level_order.get(rule_level, 3) <= threshold:
-                    breaches.append(r["slug"])
-
+        breaches = breached_slugs(result["rules"], fail_level)
         if breaches:
             click.echo(
                 f"\nError: Evaluation failed due to {len(breaches)} rule breaches at level '{fail_level}' or above.",

--- a/regis/core/application/analyze_image.py
+++ b/regis/core/application/analyze_image.py
@@ -22,6 +22,7 @@ from typing import Any
 from regis.core.application.playbook_runner import run_playbooks, validate_report
 from regis.core.domain.context import AnalysisContext
 from regis.core.domain.errors import AnalyzerError, RegistryError, ToolError
+from regis.core.domain.rules.breach import breached_slugs
 from regis.core.model.image_reference import ImageReference
 from regis.core.model.report import REPORT_SCHEMA_VERSION, Report
 from regis.core.ports.image_inspector import ImageInspector
@@ -267,16 +268,5 @@ class AnalyzeImage:
         self._sink.emit(Report(final_report), formats=formats)
         self._presentation.render(Report(final_report))
 
-        level_order = {"critical": 1, "warning": 2, "info": 3}
-        threshold = level_order.get(fail_level.lower(), None)
-        if threshold is None:
-            # "none" or unknown level — nothing breaches.
-            breached: list[str] = []
-        else:
-            breached = [
-                r.get("slug", "unknown")
-                for r in final_report.get("rules", [])
-                if not r.get("passed", False)
-                and level_order.get(r.get("level", "info").lower(), 3) <= threshold
-            ]
+        breached = breached_slugs(final_report.get("rules", []), fail_level)
         return AnalysisResult(final_report, bool(breached), len(breached), breached)

--- a/regis/core/domain/rules/breach.py
+++ b/regis/core/domain/rules/breach.py
@@ -1,0 +1,47 @@
+"""Shared ``--fail`` breach detection.
+
+Which non-passing rules meet the requested fail threshold. Extracted so the
+``analyze`` use-case and the ``analyze`` / ``rules evaluate`` CLI commands share
+one definition. They had drifted into three copies of a ``level_order`` map that
+disagreed on the ``none``/unknown fail level (one treated it as "never fail",
+another as "fail on everything", a third as "fail as if critical"), so the same
+``--fail-level`` could behave differently per command. This is the single source
+of truth.
+
+Severity rank: lower = more severe. A non-passing rule breaches when its own
+level is at or above the requested fail level (``rank <= threshold``). An unknown
+or ``"none"`` fail level yields no threshold, so nothing breaches.
+
+    fail_level   threshold   non-passing rule breaches when its level is...
+    ----------   ---------   ----------------------------------------------
+    critical         1       critical
+    warning          2       critical, warning
+    info             3       critical, warning, info (any breach)
+    none / other    --       never (no breach)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_LEVEL_RANK: dict[str, int] = {"critical": 1, "warning": 2, "info": 3}
+# An unlabelled rule level is treated as the least severe known level (info).
+_RULE_LEVEL_DEFAULT = _LEVEL_RANK["info"]
+
+
+def breached_slugs(rules: list[dict[str, Any]], fail_level: str) -> list[str]:
+    """Return the slugs of non-passing rules at or above ``fail_level``.
+
+    Empty when ``fail_level`` is ``"none"`` or any value outside
+    ``critical``/``warning``/``info`` -- i.e. "do not fail on anything".
+    """
+    threshold = _LEVEL_RANK.get((fail_level or "").lower())
+    if threshold is None:
+        return []
+    return [
+        rule.get("slug", "unknown")
+        for rule in rules
+        if not rule.get("passed", False)
+        and _LEVEL_RANK.get(str(rule.get("level", "info")).lower(), _RULE_LEVEL_DEFAULT)
+        <= threshold
+    ]

--- a/tests/core/test_breach.py
+++ b/tests/core/test_breach.py
@@ -1,0 +1,51 @@
+"""Unit tests for the shared ``--fail`` breach helper.
+
+Pins the unified semantics that the analyze use-case and the analyze / rules
+evaluate CLI commands now share (they had drifted on ``none``/unknown).
+"""
+
+import pytest
+
+from regis.core.domain.rules.breach import breached_slugs
+
+_RULES = [
+    {"slug": "crit", "level": "critical", "passed": False},
+    {"slug": "warn", "level": "warning", "passed": False},
+    {"slug": "info", "level": "info", "passed": False},
+    {"slug": "ok", "level": "critical", "passed": True},  # passing -> never a breach
+]
+
+
+@pytest.mark.parametrize(
+    "fail_level, expected",
+    [
+        ("critical", ["crit"]),
+        ("warning", ["crit", "warn"]),
+        ("info", ["crit", "warn", "info"]),
+        ("CRITICAL", ["crit"]),  # case-insensitive
+        ("none", []),  # "never fail"
+        ("", []),  # unknown -> never fail
+        ("bogus", []),  # unknown -> never fail (NOT "fail as critical")
+    ],
+)
+def test_threshold_is_at_or_above_and_excludes_passing(fail_level, expected):
+    assert breached_slugs(_RULES, fail_level) == expected
+
+
+def test_unlabelled_rule_level_is_treated_as_info():
+    # An unlabelled non-passing rule is least-severe (info): it breaches only at
+    # fail_level=info, never at warning/critical.
+    rules = [{"slug": "bare", "passed": False}]
+    assert breached_slugs(rules, "info") == ["bare"]
+    assert breached_slugs(rules, "warning") == []
+    assert breached_slugs(rules, "critical") == []
+
+
+def test_missing_slug_falls_back_to_unknown():
+    assert breached_slugs([{"level": "critical", "passed": False}], "critical") == [
+        "unknown"
+    ]
+
+
+def test_empty_rules_never_breaches():
+    assert breached_slugs([], "info") == []


### PR DESCRIPTION
## Summary

The `--fail` breach threshold was implemented **three times by hand** and the copies had drifted, so the same `--fail-level` could fail one command and pass another on identical input. This extracts a single source of truth and routes all three sites through it.

## The bug

Three independent `level_order` maps decided which non-passing rules breach the requested `--fail-level`:

| Site | `none` / unknown fail-level behaviour |
|------|----------------------------------------|
| `core/application/analyze_image.py` (use-case) | unknown → `None` threshold → **never breaches** (pinned by `tests/core/test_analyze_image.py`) |
| `cli/commands/analyze.py` (cache-hit branch) | unknown → `None` → never breaches |
| `cli/commands/rules.py` (`evaluate`) | map had `none: 4`, default `1` → unknown **fails as critical**, `none` **fails on everything** |

The three agreed on `critical`/`warning`/`info` (the only CLI `Choice` values), so the divergence is latent through the CLI today — but `analyze_image` is a public use-case called directly with `fail_level="none"`, and the copies were a regression waiting to surface the moment a fourth caller or a new level appeared.

## The fix

- New single source of truth: `regis/core/domain/rules/breach.py::breached_slugs(rules, fail_level)`.
- All three sites route through it (`analyze_image.py`, `analyze.py` cache-hit, `rules.py` evaluate).
- Unified semantics match the already-tested use-case contract: `critical`/`warning`/`info` gate at-or-above; `none` or any unknown value **never breaches** ("don't fail on anything" — the intuitive reading).
- The display-only `level_order` in `core/domain/rules/evaluator.py` (a sort key, `none: 4`, default `99`) is a different concern and left untouched.
- `tests/core/test_breach.py` pins the unified behaviour (thresholds, case-insensitivity, `none`/unknown → `[]`, unlabelled rule → info, passing rules excluded).

Net: ~30 lines of divergent duplication → one 18-line helper.

## Reviewer notes

Surfaced by a whole-project `/plan-eng-review`. This is the one finding that was an actual behavioural bug (the rest were debt → tracked separately). Independent of #802.

## Test

```
uv run pytest tests/core/test_breach.py tests/core/test_analyze_image.py tests/test_rules_command.py tests/test_cli.py tests/commands/ --no-cov -q
161 passed
```
ruff: clean. import-linter: Hexagonal layering KEPT.