### PR TITLE
test(cli): drop dead leftover comment in coverage_cli test

### DIFF
--- a/tests/test_coverage_cli.py
+++ b/tests/test_coverage_cli.py
@@ -85,9 +85,6 @@ def test_analyze_schema_validation_error(mock_discover, mock_client):
                     "Report schema validation failed: Failing validation"
                     in result.output
                 )
-                # 原则上，代码本身不应该被修改。
-                #    in result.output
-                # )
 
 
 @patch("regis.adapters.driving.cli.commands.analyze.RegistryClient")


### PR DESCRIPTION
## Summary

Removes a stray untranslated comment and two commented-out dead assertion lines in `tests/test_coverage_cli.py` left over from an earlier edit. The live assertion directly above is complete; these three lines are pure cruft.

Surfaced by a whole-project `/plan-eng-review` (test-hygiene finding). Trivial, zero behaviour change — the larger `test_coverage_*` line-chasing cleanup is tracked separately as a TODO/issue.