### PR TITLE
docs: fix broken container image reference in getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Regis provides unified container analysis, custom playbooks, and highly customiz
 ## Key Features
 
 - **Unified Registry Inspection** — Fast, multi-arch metadata extraction from any OCI-compliant registry using `regctl`.
-- **Pluggable Analyzer Ecosystem** — Orchestrates industry-standard tools like `Trivy`, `regctl`, `Hadolint`, and `Dockle` to gather comprehensive security insights.
+- **Pluggable Analyzer Ecosystem** — Orchestrates industry-standard tools like `grype`, `regctl`, `Hadolint`, and `Dockle` to gather comprehensive security insights.
 - **Policy-as-Code Playbooks** — Define compliance and security rules (e.g., "no critical vulnerabilities", "maximum image age") using flexible `jsonLogic` evaluations.
 - **Hybrid Reporting** — Simultaneously generates machine-readable JSON for automation and rich, interactive HTML dashboards for human review.
 - **CI/CD Native** — Designed to integrate seamlessly into GitHub Actions or GitLab CI pipelines with first-class support for MR/PR reporting.

--- a/docs/website/docs/usage/getting-started.md
+++ b/docs/website/docs/usage/getting-started.md
@@ -13,7 +13,7 @@ sidebar_position: 1
 The easiest way to use `regis` without managing local dependencies is to use the official Docker image. It comes pre-packaged with regctl, grype, syft, trufflehog, Hadolint, and Dockle.
 
 ```bash
-docker run --rm trivoallan/regis --help
+docker run --rm ghcr.io/trivoallan/regis --help
 ```
 
 ### Local Installation

--- a/docs/website/docs/usage/troubleshooting.md
+++ b/docs/website/docs/usage/troubleshooting.md
@@ -31,7 +31,7 @@ When you run `regis`, it requires certain external binaries depending on which a
 
 3. **Using Docker** is the easiest path—the official image comes pre-packaged with all dependencies:
    ```bash
-   docker run --rm trivoallan/regis analyze nginx:latest
+   docker run --rm ghcr.io/trivoallan/regis analyze nginx:latest
    ```
 
 ## Registry Authentication Errors


### PR DESCRIPTION
## Summary

The documented first-run command was broken. A `/devex-review` dogfooding the install path found that `docker run --rm trivoallan/regis` (in getting-started and troubleshooting) hits **Docker Hub 404** — Regis publishes to **ghcr.io** (`ghcr.io/trivoallan/regis`, per `cd-docker.yml` `REGISTRY: ghcr.io`). The recommended hello-world failed image-not-found on first contact.

## Changes

- `docs/usage/getting-started.md` — `docker run --rm trivoallan/regis` → `ghcr.io/trivoallan/regis`
- `docs/usage/troubleshooting.md` — same fix
- `README.md` — feature list named `Trivy`; Regis migrated to grype → `grype`

`tools-management.md` already used the correct `ghcr.io/...` ref; `versioned_docs/*` are frozen snapshots, intentionally untouched.

## Out of scope (tracked separately)

- The other broken install path — `pip install regis` installs an unrelated PyPI package (`regis 0.1.92`, a name collision) — needs a real uv-based replacement → separate issue.
- Missing `SECURITY.md` / `CONTRIBUTING.md` / issue templates → separate issue.

## Verify

```
curl -so /dev/null -w '%{http_code}' https://hub.docker.com/v2/repositories/trivoallan/regis/   # 404 (the old ref)
```
ghcr image resolves; `docker run --rm ghcr.io/trivoallan/regis --help` is the working command.

Closes #809.