### PR TITLE
docs: install the CLI via uv, fix a missed image ref (completes #808)

### DIFF
--- a/docs/website/docs/usage/getting-started.md
+++ b/docs/website/docs/usage/getting-started.md
@@ -31,8 +31,10 @@ The requirements depend on whether you use the Docker image or install the tool 
   - **Hadolint**: Required for Dockerfile linting.
   - **Dockle**: Required for container image security linting.
 
+Install the `regis` CLI from source with **[uv](https://docs.astral.sh/uv/)**:
+
 ```bash
-pip install regis
+uv tool install git+https://github.com/trivoallan/regis.git
 ```
 
 :::tip

--- a/docs/website/docs/usage/troubleshooting.md
+++ b/docs/website/docs/usage/troubleshooting.md
@@ -188,7 +188,7 @@ Yes. Regis is designed for CI/CD. Use Docker for simplicity:
 ```bash
 docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  trivoallan/regis analyze myimage:latest --html
+  ghcr.io/trivoallan/regis analyze myimage:latest --html
 ```
 
 Then collect the generated `report.html` (and `report.json`) as a CI artifact. See the [GitHub](./integrations/github.md) and [GitLab](./integrations/gitlab.md) integration guides for more details.


### PR DESCRIPTION
## Summary

Completes the install-docs fix from #808, which merged with only its first commit — the `pip install regis` → uv replacement was lost when the branch was rebased before merge, so main still shipped the dangerous line.

## Changes

- `docs/usage/getting-started.md` — `pip install regis` → `uv tool install git+https://github.com/trivoallan/regis.git`. `pip install regis` installs an **unrelated** PyPI package (`regis 0.1.92`, "Rex Engine") due to a name collision; this project is not on PyPI under that name. uv-from-source matches the `uv sync` contributor path already documented.
- `docs/usage/troubleshooting.md` — the CI/CD `docker run -v … trivoallan/regis` example still used the Docker Hub ref (404); → `ghcr.io/trivoallan/regis`. (A multi-line invocation my earlier single-line grep missed.)

After this, no current doc references `pip install regis` or a bare-Docker-Hub `trivoallan/regis` run/pull.

Closes #809.