### PR TITLE
docs(roadmap): write the roadmap in English

### DIFF
--- a/docs/memory-bank/roadmap.md
+++ b/docs/memory-bank/roadmap.md
@@ -22,15 +22,15 @@ Format: **Now / Next / Later** — no hard dates (avoids false precision).
 
 ## Recently shipped
 
-| Item                                                                            | Status |
-| ------------------------------------------------------------------------------- | ------ |
-| Hexagonal migration (ports & adapters, enforced by import-linter)               | Done   |
-| SARIF output of playbook verdicts (`result.kind` policy/vuln) + `ruleset_hash`  | Done   |
-| Multi-arch container images (linux/amd64 + arm64)                               | Done   |
-| Dependency automation → Renovate                                                | Done   |
-| GitLab CI-native integration extracted to a dedicated template                  | Done   |
-| Playbook format → Kubernetes-style envelope (`apiVersion` / `kind`)             | Done   |
-| Container image size reduction (slim/full variants, lazy tool fetch)            | Done   |
+| Item                                                                           | Status |
+| ------------------------------------------------------------------------------ | ------ |
+| Hexagonal migration (ports & adapters, enforced by import-linter)              | Done   |
+| SARIF output of playbook verdicts (`result.kind` policy/vuln) + `ruleset_hash` | Done   |
+| Multi-arch container images (linux/amd64 + arm64)                              | Done   |
+| Dependency automation → Renovate                                               | Done   |
+| GitLab CI-native integration extracted to a dedicated template                 | Done   |
+| Playbook format → Kubernetes-style envelope (`apiVersion` / `kind`)            | Done   |
+| Container image size reduction (slim/full variants, lazy tool fetch)           | Done   |
 
 ---
 
@@ -49,26 +49,26 @@ Format: **Now / Next / Later** — no hard dates (avoids false precision).
 
 ## Next — planned (~1-3 months)
 
-| Item                                                                                                                                             | Note                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| **Provenance integration**: Regis verdicts → signed attestations at a registry's front door (houba)                                              | SARIF contract already conforms; depends on houba maturity |
-| **Native Harbor** support (`RegistryProvider` abstraction)                                                                                       | generic product feature                                    |
-| Reusable playbook archetypes: image-admission gate · continuous catalog compliance · tiered progression (bronze → silver → gold)                 | built on the bundle format                                 |
-| Distribution: `uv tool install` + a non-colliding PyPI distribution name                                                                         | follows from the install fix (#809)                        |
-| Documentation i18n pipeline (automated translation)                                                                                              | generic                                                    |
+| Item                                                                                                                             | Note                                                       |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Provenance integration**: Regis verdicts → signed attestations at a registry's front door (houba)                              | SARIF contract already conforms; depends on houba maturity |
+| **Native Harbor** support (`RegistryProvider` abstraction)                                                                       | generic product feature                                    |
+| Reusable playbook archetypes: image-admission gate · continuous catalog compliance · tiered progression (bronze → silver → gold) | built on the bundle format                                 |
+| Distribution: `uv tool install` + a non-colliding PyPI distribution name                                                         | follows from the install fix (#809)                        |
+| Documentation i18n pipeline (automated translation)                                                                              | generic                                                    |
 
 ---
 
 ## Later — directional (~3-6+ months)
 
-| Item                                                       | Note                  |
-| ---------------------------------------------------------- | --------------------- |
-| Multi-image / fleet posture comparison (`regis diff`)      | directional           |
-| Playbook/policy versioning with compatibility ranges       | design spike required |
-| Org-level score aggregation + reporting                    | directional           |
-| Developer guide: writing custom analyzers                  | directional           |
-| Self-scan in CI (Regis analyzes its own image each release)| maturity signal       |
-| Import / merge an existing image catalog                   | design spike required |
+| Item                                                        | Note                  |
+| ----------------------------------------------------------- | --------------------- |
+| Multi-image / fleet posture comparison (`regis diff`)       | directional           |
+| Playbook/policy versioning with compatibility ranges        | design spike required |
+| Org-level score aggregation + reporting                     | directional           |
+| Developer guide: writing custom analyzers                   | directional           |
+| Self-scan in CI (Regis analyzes its own image each release) | maturity signal       |
+| Import / merge an existing image catalog                    | design spike required |
 
 ---
 

--- a/docs/memory-bank/roadmap.md
+++ b/docs/memory-bank/roadmap.md
@@ -4,76 +4,76 @@
 
 > Last updated: 2026-06-25 · Current version: v0.37.x · Stage: pre-v1
 
-## Positionnement
+## Positioning
 
-Sécurité conteneur & policy-as-code, avec un pivot vers la **provenance
-supply-chain** : les verdicts Regis (SARIF, `result.kind` discriminant
-policy/vuln) sont consommables comme attestations signées à la porte d'entrée
-d'un registre.
+Container security & policy-as-code, with a pivot toward **supply-chain
+provenance**: Regis verdicts (SARIF, with `result.kind` discriminating policy
+from vulnerability) are consumable as signed attestations at a registry's front
+door.
 
-Format : **Now / Next / Later** — pas de dates dures (évite la fausse précision).
+Format: **Now / Next / Later** — no hard dates (avoids false precision).
 
 ## Memory Bank Alignment
 
-- Garder les items synchronisés avec `docs/memory-bank/projectbrief.md` et `progress.md`.
-- Traiter `decisionLog.md` et `roadmap.md` comme historique de planification supplémentaire, pas comme contexte opérationnel primaire.
+- Keep items synchronized with `docs/memory-bank/projectbrief.md` and `progress.md`.
+- Treat `decisionLog.md` and `roadmap.md` as supplemental planning history, not the primary operational context.
 
 ---
 
-## Récemment livré
+## Recently shipped
 
-| Item                                                                            | Statut |
+| Item                                                                            | Status |
 | ------------------------------------------------------------------------------- | ------ |
-| Migration hexagonale (ports & adapters, imposée par import-linter)              | Done   |
-| Sortie SARIF des verdicts playbook (`result.kind` policy/vuln) + `ruleset_hash` | Done   |
-| Images conteneur multi-arch (linux/amd64 + arm64)                               | Done   |
-| Automatisation des dépendances → Renovate                                       | Done   |
-| Intégration GitLab CI-native extraite vers un template dédié                    | Done   |
-| Format playbook → enveloppe Kubernetes (`apiVersion` / `kind`)                  | Done   |
-| Réduction taille image (variantes slim/full, fetch outils paresseux)            | Done   |
+| Hexagonal migration (ports & adapters, enforced by import-linter)               | Done   |
+| SARIF output of playbook verdicts (`result.kind` policy/vuln) + `ruleset_hash`  | Done   |
+| Multi-arch container images (linux/amd64 + arm64)                               | Done   |
+| Dependency automation → Renovate                                                | Done   |
+| GitLab CI-native integration extracted to a dedicated template                  | Done   |
+| Playbook format → Kubernetes-style envelope (`apiVersion` / `kind`)             | Done   |
+| Container image size reduction (slim/full variants, lazy tool fetch)            | Done   |
 
 ---
 
-## Now — engagé / en cours
+## Now — committed / in progress
 
-| Item                                                                                                 | Statut   | Réf        |
+| Item                                                                                                 | Status   | Ref        |
 | ---------------------------------------------------------------------------------------------------- | -------- | ---------- |
-| Réparer l'install getting-started (Docker → `ghcr.io`, `pip` → `uv`)                                 | On Track | PR #808    |
-| Cache registry par-run + handoff SBOM syft → grype (performance de scan)                             | Planned  | issue #806 |
-| Refacto de la commande `analyze.py` + resserrer le layering `utils/`                                 | Planned  | issue #807 |
-| Santé projet : `SECURITY.md`, `CONTRIBUTING.md`, templates d'issues                                  | Planned  | issue #810 |
-| **Format bundle playbook** (`playbook.yaml` + `README.md` + `inputs.schema.json` + `InputsAnalyzer`) | Planned  | sprint     |
-| Finitions site de doc (branding, navigation, SEO) + arrêt des snapshots versionnés                   | Planned  | sprint     |
+| Fix the getting-started install (Docker → `ghcr.io`, `pip` → `uv`)                                   | On Track | PR #812    |
+| Per-run registry cache + syft → grype SBOM handoff (scan performance)                                | Planned  | issue #806 |
+| Refactor the `analyze.py` command + tighten `utils/` layering                                        | Planned  | issue #807 |
+| Project health: `SECURITY.md`, `CONTRIBUTING.md`, issue templates                                    | Planned  | issue #810 |
+| **Playbook bundle format** (`playbook.yaml` + `README.md` + `inputs.schema.json` + `InputsAnalyzer`) | Planned  | sprint     |
+| Docs site finishing (branding, navigation, SEO) + stop versioned snapshots                           | Planned  | sprint     |
 
 ---
 
-## Next — planifié (≈ 1-3 mois)
+## Next — planned (~1-3 months)
 
-| Item                                                                                                                                           | Note                                                      |
-| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| **Intégration provenance** : verdicts Regis → attestations signées à la porte d'un registre (houba)                                            | contrat SARIF déjà conforme ; dépend de la maturité houba |
-| Support **Harbor natif** (abstraction `RegistryProvider`)                                                                                      | feature produit générique                                 |
-| Archétypes de playbook réutilisables : gate d'admission d'image · conformité catalogue continue · progression par tiers (bronze → argent → or) | bâtis sur le format bundle                                |
-| Distribution : `uv tool install` + nom de distribution PyPI non-collisionnant                                                                  | issu du fix d'install (#809)                              |
-| Pipeline i18n de la documentation (traduction automatisée)                                                                                     | générique                                                 |
-
----
-
-## Later — directionnel (≈ 3-6+ mois)
-
-| Item                                                       | Note                |
-| ---------------------------------------------------------- | ------------------- |
-| Comparaison de posture multi-image / flotte (`regis diff`) | directionnel        |
-| Versioning playbook/policy avec ranges de compatibilité    | design spike requis |
-| Agrégation de score org-level + reporting                  | directionnel        |
-| Guide développeur : création d'analyzers custom            | directionnel        |
-| Self-scan CI (Regis s'analyse lui-même à chaque release)   | signal de maturité  |
-| Import / fusion d'un catalogue d'images existant           | design spike requis |
+| Item                                                                                                                                             | Note                                                       |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| **Provenance integration**: Regis verdicts → signed attestations at a registry's front door (houba)                                              | SARIF contract already conforms; depends on houba maturity |
+| **Native Harbor** support (`RegistryProvider` abstraction)                                                                                       | generic product feature                                    |
+| Reusable playbook archetypes: image-admission gate · continuous catalog compliance · tiered progression (bronze → silver → gold)                 | built on the bundle format                                 |
+| Distribution: `uv tool install` + a non-colliding PyPI distribution name                                                                         | follows from the install fix (#809)                        |
+| Documentation i18n pipeline (automated translation)                                                                                              | generic                                                    |
 
 ---
 
-## Risques & dépendances
+## Later — directional (~3-6+ months)
 
-- **Maturité houba (pré-prod)** cadence le calendrier de l'intégration provenance. Mitigation : le contrat SARIF est **gelé**, donc Regis intègre contre une interface stable pendant que houba durcit.
-- **Capacité** : Now porte déjà 6 items ; Next / Later sont directionnels, pas engagés. Tout ajout en Now implique qu'un item en sorte (zéro-somme contre la capacité).
-- **Dépendances bloquées** : migration dashboard Tailwind v4 — **coupée** (la dashboard standalone est abandonnée ; la visibilité passe par `report.json` + l'outillage de provenance).
+| Item                                                       | Note                  |
+| ---------------------------------------------------------- | --------------------- |
+| Multi-image / fleet posture comparison (`regis diff`)      | directional           |
+| Playbook/policy versioning with compatibility ranges       | design spike required |
+| Org-level score aggregation + reporting                    | directional           |
+| Developer guide: writing custom analyzers                  | directional           |
+| Self-scan in CI (Regis analyzes its own image each release)| maturity signal       |
+| Import / merge an existing image catalog                   | design spike required |
+
+---
+
+## Risks & dependencies
+
+- **houba maturity (pre-prod)** paces the provenance-integration timeline. Mitigation: the SARIF contract is **frozen**, so Regis can integrate against a stable interface while houba hardens.
+- **Capacity**: Now already carries 6 items; Next / Later are directional, not committed. Anything added to Now means something else comes off (zero-sum against capacity).
+- **Blocked dependencies**: the dashboard Tailwind v4 migration is **cut** (the standalone dashboard was abandoned; visibility now rides `report.json` + provenance tooling).


### PR DESCRIPTION
## Summary

The roadmap is a user-facing, externally-readable artifact (like the README and the docs site), so it should be in English. The previous refresh (#811) landed it in French; this translates it. Content unchanged.

(The install-fix row now references the open PR that actually carries the fix.)